### PR TITLE
Runtime Zod validation + wire format types

### DIFF
--- a/renderer/src/actions.ts
+++ b/renderer/src/actions.ts
@@ -28,6 +28,7 @@ import type { App } from "@modelcontextprotocol/ext-apps";
 import { toast } from "sonner";
 import type { StateStore } from "./state";
 import { interpolateProps } from "./interpolation";
+import { validateAction } from "./validation";
 
 /** Action spec as received from the JSON component tree. */
 export interface ActionSpec {
@@ -112,6 +113,12 @@ export async function executeAction(
     action as Record<string, unknown>,
     ctx,
   ) as ActionSpec;
+
+  // Validate resolved action against its Zod schema
+  const validationError = validateAction(resolved);
+  if (validationError) {
+    return false;
+  }
 
   let success = true;
   let errorMessage: string | undefined;

--- a/renderer/src/components/validation-error.tsx
+++ b/renderer/src/components/validation-error.tsx
@@ -1,0 +1,51 @@
+/**
+ * Inline error component for invalid component nodes.
+ *
+ * Replaces a broken node in the rendered tree with a clear error message
+ * and collapsible detail section showing the Zod validation issues.
+ */
+
+import { useState } from "react";
+import type { ValidationResult } from "../validation";
+
+interface ValidationErrorProps {
+  error: ValidationResult;
+  node: Record<string, unknown>;
+}
+
+export function ValidationError({ error, node }: ValidationErrorProps) {
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <div
+      role="alert"
+      className="rounded-md border border-destructive/50 bg-destructive/10 p-3 text-sm"
+    >
+      <div className="flex items-start justify-between gap-2">
+        <p className="font-medium text-destructive">{error.message}</p>
+        <button
+          type="button"
+          onClick={() => setExpanded(!expanded)}
+          className="shrink-0 text-xs text-muted-foreground hover:text-foreground"
+        >
+          {expanded ? "Hide" : "Details"}
+        </button>
+      </div>
+
+      {expanded && (
+        <div className="mt-2 space-y-2">
+          {error.issues.length > 0 && (
+            <ul className="list-inside list-disc space-y-0.5 text-xs text-muted-foreground">
+              {error.issues.map((issue, i) => (
+                <li key={i}>{issue}</li>
+              ))}
+            </ul>
+          )}
+          <pre className="max-h-40 overflow-auto rounded bg-muted p-2 text-xs">
+            {JSON.stringify(node, null, 2)}
+          </pre>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/renderer/src/renderer.tsx
+++ b/renderer/src/renderer.tsx
@@ -16,6 +16,8 @@ import { interpolateProps, interpolateString } from "./interpolation";
 import { executeActions, type ActionSpec } from "./actions";
 import type { StateStore } from "./state";
 import { evaluateCondition } from "./conditions";
+import { validateNode } from "./validation";
+import { ValidationError } from "./components/validation-error";
 
 /** Shape of a node in the JSON component tree. */
 export interface ComponentNode {
@@ -248,6 +250,12 @@ function filterInternalProps(
  */
 export function RenderNode({ node, scope, state, app }: RenderNodeProps) {
   const { type, children, visibleWhen, ...rawProps } = node;
+
+  // Validate node against its Zod schema before any processing
+  const validationError = validateNode(node);
+  if (validationError) {
+    return <ValidationError error={validationError} node={node} />;
+  }
 
   // Conditional rendering via expression evaluator
   if (visibleWhen) {

--- a/renderer/src/schemas/accordion.ts
+++ b/renderer/src/schemas/accordion.ts
@@ -13,3 +13,6 @@ export const accordionSchema = containerBase.extend({
   collapsible: z.boolean().optional(),
   defaultValue: z.union([z.string(), z.array(z.string())]).optional(),
 });
+
+export type AccordionWire = z.infer<typeof accordionSchema>;
+export type AccordionItemWire = z.infer<typeof accordionItemSchema>;

--- a/renderer/src/schemas/actions.ts
+++ b/renderer/src/schemas/actions.ts
@@ -112,3 +112,13 @@ export const ACTION_SCHEMA_REGISTRY: Record<string, z.ZodType> = {
   toggleState: toggleStateSchema,
   showToast: showToastSchema,
 };
+
+export type ToolCallWire = z.infer<typeof toolCallSchema>;
+export type SendMessageWire = z.infer<typeof sendMessageSchema>;
+export type UpdateContextWire = z.infer<typeof updateContextSchema>;
+export type OpenLinkWire = z.infer<typeof openLinkSchema>;
+export type SetStateWire = z.infer<typeof setStateSchema>;
+export type ToggleStateWire = z.infer<typeof toggleStateSchema>;
+export type ShowToastWire = z.infer<typeof showToastSchema>;
+export type ActionWire = z.infer<typeof actionSchema>;
+export type ActionOrListWire = z.infer<typeof actionOrList>;

--- a/renderer/src/schemas/alert.ts
+++ b/renderer/src/schemas/alert.ts
@@ -21,3 +21,7 @@ export const alertDescriptionSchema = componentBase.extend({
   type: z.literal("AlertDescription"),
   content: z.string(),
 });
+
+export type AlertWire = z.infer<typeof alertSchema>;
+export type AlertTitleWire = z.infer<typeof alertTitleSchema>;
+export type AlertDescriptionWire = z.infer<typeof alertDescriptionSchema>;

--- a/renderer/src/schemas/badge.ts
+++ b/renderer/src/schemas/badge.ts
@@ -17,3 +17,5 @@ export const badgeSchema = componentBase.extend({
     ])
     .optional(),
 });
+
+export type BadgeWire = z.infer<typeof badgeSchema>;

--- a/renderer/src/schemas/base.ts
+++ b/renderer/src/schemas/base.ts
@@ -34,3 +34,6 @@ export const gapSchema = z.union([
   z.number().int(),
   z.tuple([z.number().int().nullable(), z.number().int().nullable()]),
 ]);
+
+export type ComponentBaseWire = z.infer<typeof componentBase>;
+export type ContainerBaseWire = z.infer<typeof containerBase>;

--- a/renderer/src/schemas/button.ts
+++ b/renderer/src/schemas/button.ts
@@ -33,3 +33,5 @@ export const buttonSchema = componentBase.extend({
   disabled: z.boolean().optional(),
   onClick: actionOrList.optional(),
 });
+
+export type ButtonWire = z.infer<typeof buttonSchema>;

--- a/renderer/src/schemas/button_group.ts
+++ b/renderer/src/schemas/button_group.ts
@@ -5,3 +5,5 @@ export const buttonGroupSchema = containerBase.extend({
   type: z.literal("ButtonGroup"),
   orientation: z.enum(["horizontal", "vertical"]).optional(),
 });
+
+export type ButtonGroupWire = z.infer<typeof buttonGroupSchema>;

--- a/renderer/src/schemas/calendar.ts
+++ b/renderer/src/schemas/calendar.ts
@@ -8,3 +8,5 @@ export const calendarSchema = componentBase.extend({
   name: z.string().optional(),
   onChange: actionOrList.optional(),
 });
+
+export type CalendarWire = z.infer<typeof calendarSchema>;

--- a/renderer/src/schemas/card.ts
+++ b/renderer/src/schemas/card.ts
@@ -31,3 +31,10 @@ export const cardContentSchema = containerBase.extend({
 export const cardFooterSchema = containerBase.extend({
   type: z.literal("CardFooter"),
 });
+
+export type CardWire = z.infer<typeof cardSchema>;
+export type CardHeaderWire = z.infer<typeof cardHeaderSchema>;
+export type CardTitleWire = z.infer<typeof cardTitleSchema>;
+export type CardDescriptionWire = z.infer<typeof cardDescriptionSchema>;
+export type CardContentWire = z.infer<typeof cardContentSchema>;
+export type CardFooterWire = z.infer<typeof cardFooterSchema>;

--- a/renderer/src/schemas/checkbox.ts
+++ b/renderer/src/schemas/checkbox.ts
@@ -12,3 +12,5 @@ export const checkboxSchema = componentBase.extend({
   required: z.boolean().optional(),
   onChange: actionOrList.optional(),
 });
+
+export type CheckboxWire = z.infer<typeof checkboxSchema>;

--- a/renderer/src/schemas/code.ts
+++ b/renderer/src/schemas/code.ts
@@ -6,3 +6,5 @@ export const codeSchema = componentBase.extend({
   content: z.string(),
   language: z.string().optional(),
 });
+
+export type CodeWire = z.infer<typeof codeSchema>;

--- a/renderer/src/schemas/column.ts
+++ b/renderer/src/schemas/column.ts
@@ -5,3 +5,5 @@ export const columnSchema = containerBase.extend({
   type: z.literal("Column"),
   gap: gapSchema.optional(),
 });
+
+export type ColumnWire = z.infer<typeof columnSchema>;

--- a/renderer/src/schemas/data_table.ts
+++ b/renderer/src/schemas/data_table.ts
@@ -18,3 +18,5 @@ export const dataTableSchema = componentBase.extend({
   pageSize: z.number().int().optional(),
   caption: z.string().optional(),
 });
+
+export type DataTableWire = z.infer<typeof dataTableSchema>;

--- a/renderer/src/schemas/date_picker.ts
+++ b/renderer/src/schemas/date_picker.ts
@@ -8,3 +8,5 @@ export const datePickerSchema = componentBase.extend({
   name: z.string().optional(),
   onChange: actionOrList.optional(),
 });
+
+export type DatePickerWire = z.infer<typeof datePickerSchema>;

--- a/renderer/src/schemas/dialog.ts
+++ b/renderer/src/schemas/dialog.ts
@@ -6,3 +6,5 @@ export const dialogSchema = containerBase.extend({
   title: z.string().optional(),
   description: z.string().optional(),
 });
+
+export type DialogWire = z.infer<typeof dialogSchema>;

--- a/renderer/src/schemas/div.ts
+++ b/renderer/src/schemas/div.ts
@@ -9,3 +9,6 @@ export const spanSchema = componentBase.extend({
   type: z.literal("Span"),
   content: z.string(),
 });
+
+export type DivWire = z.infer<typeof divSchema>;
+export type SpanWire = z.infer<typeof spanSchema>;

--- a/renderer/src/schemas/foreach.ts
+++ b/renderer/src/schemas/foreach.ts
@@ -5,3 +5,5 @@ export const forEachSchema = containerBase.extend({
   type: z.literal("ForEach"),
   key: z.string(),
 });
+
+export type ForEachWire = z.infer<typeof forEachSchema>;

--- a/renderer/src/schemas/form.ts
+++ b/renderer/src/schemas/form.ts
@@ -7,3 +7,5 @@ export const formSchema = containerBase.extend({
   gap: z.number().int().optional(),
   onSubmit: actionOrList.optional(),
 });
+
+export type FormWire = z.infer<typeof formSchema>;

--- a/renderer/src/schemas/grid.ts
+++ b/renderer/src/schemas/grid.ts
@@ -6,3 +6,5 @@ export const gridSchema = containerBase.extend({
   columns: z.number().int().optional(),
   gap: gapSchema.optional(),
 });
+
+export type GridWire = z.infer<typeof gridSchema>;

--- a/renderer/src/schemas/heading.ts
+++ b/renderer/src/schemas/heading.ts
@@ -10,3 +10,5 @@ export const headingSchema = componentBase.extend({
   bold: z.boolean().optional(),
   italic: z.boolean().optional(),
 });
+
+export type HeadingWire = z.infer<typeof headingSchema>;

--- a/renderer/src/schemas/image.ts
+++ b/renderer/src/schemas/image.ts
@@ -8,3 +8,5 @@ export const imageSchema = componentBase.extend({
   width: z.string().optional(),
   height: z.string().optional(),
 });
+
+export type ImageWire = z.infer<typeof imageSchema>;

--- a/renderer/src/schemas/index.ts
+++ b/renderer/src/schemas/index.ts
@@ -8,13 +8,25 @@
 
 import type { z } from "zod";
 
-// Re-export for convenient access
+// Re-export schemas and types for convenient access
 export {
   HANDLED_ACTIONS,
   ACTION_SCHEMA_REGISTRY,
   actionOrList,
 } from "./actions.ts";
+export type {
+  ToolCallWire,
+  SendMessageWire,
+  UpdateContextWire,
+  OpenLinkWire,
+  SetStateWire,
+  ToggleStateWire,
+  ShowToastWire,
+  ActionWire,
+  ActionOrListWire,
+} from "./actions.ts";
 export { componentBase, containerBase, gapSchema } from "./base.ts";
+export type { ComponentBaseWire, ContainerBaseWire } from "./base.ts";
 
 // One import per Python module — mirrors src/prefab_ui/components/*.py
 import { accordionSchema, accordionItemSchema } from "./accordion.ts";

--- a/renderer/src/schemas/input.ts
+++ b/renderer/src/schemas/input.ts
@@ -32,3 +32,5 @@ export const inputSchema = componentBase.extend({
   pattern: z.string().optional(),
   onChange: actionOrList.optional(),
 });
+
+export type InputWire = z.infer<typeof inputSchema>;

--- a/renderer/src/schemas/label.ts
+++ b/renderer/src/schemas/label.ts
@@ -6,3 +6,5 @@ export const labelSchema = containerBase.extend({
   text: z.string().optional(),
   forId: z.string().optional(),
 });
+
+export type LabelWire = z.infer<typeof labelSchema>;

--- a/renderer/src/schemas/markdown.ts
+++ b/renderer/src/schemas/markdown.ts
@@ -5,3 +5,5 @@ export const markdownSchema = componentBase.extend({
   type: z.literal("Markdown"),
   content: z.string(),
 });
+
+export type MarkdownWire = z.infer<typeof markdownSchema>;

--- a/renderer/src/schemas/pages.ts
+++ b/renderer/src/schemas/pages.ts
@@ -12,3 +12,6 @@ export const pagesSchema = containerBase.extend({
   defaultValue: z.string().optional(),
   name: z.string().optional(),
 });
+
+export type PageWire = z.infer<typeof pageSchema>;
+export type PagesWire = z.infer<typeof pagesSchema>;

--- a/renderer/src/schemas/popover.ts
+++ b/renderer/src/schemas/popover.ts
@@ -7,3 +7,5 @@ export const popoverSchema = containerBase.extend({
   description: z.string().optional(),
   side: z.enum(["top", "right", "bottom", "left"]).optional(),
 });
+
+export type PopoverWire = z.infer<typeof popoverSchema>;

--- a/renderer/src/schemas/progress.ts
+++ b/renderer/src/schemas/progress.ts
@@ -7,3 +7,5 @@ export const progressSchema = componentBase.extend({
   max: z.number().optional(),
   indicatorClass: z.string().optional(),
 });
+
+export type ProgressWire = z.infer<typeof progressSchema>;

--- a/renderer/src/schemas/radio.ts
+++ b/renderer/src/schemas/radio.ts
@@ -17,3 +17,6 @@ export const radioSchema = componentBase.extend({
   disabled: z.boolean().optional(),
   required: z.boolean().optional(),
 });
+
+export type RadioGroupWire = z.infer<typeof radioGroupSchema>;
+export type RadioWire = z.infer<typeof radioSchema>;

--- a/renderer/src/schemas/row.ts
+++ b/renderer/src/schemas/row.ts
@@ -5,3 +5,5 @@ export const rowSchema = containerBase.extend({
   type: z.literal("Row"),
   gap: gapSchema.optional(),
 });
+
+export type RowWire = z.infer<typeof rowSchema>;

--- a/renderer/src/schemas/select.ts
+++ b/renderer/src/schemas/select.ts
@@ -19,3 +19,6 @@ export const selectOptionSchema = componentBase.extend({
   selected: z.boolean().optional(),
   disabled: z.boolean().optional(),
 });
+
+export type SelectWire = z.infer<typeof selectSchema>;
+export type SelectOptionWire = z.infer<typeof selectOptionSchema>;

--- a/renderer/src/schemas/separator.ts
+++ b/renderer/src/schemas/separator.ts
@@ -5,3 +5,5 @@ export const separatorSchema = componentBase.extend({
   type: z.literal("Separator"),
   orientation: z.enum(["horizontal", "vertical"]).optional(),
 });
+
+export type SeparatorWire = z.infer<typeof separatorSchema>;

--- a/renderer/src/schemas/slider.ts
+++ b/renderer/src/schemas/slider.ts
@@ -12,3 +12,5 @@ export const sliderSchema = componentBase.extend({
   disabled: z.boolean().optional(),
   onChange: actionOrList.optional(),
 });
+
+export type SliderWire = z.infer<typeof sliderSchema>;

--- a/renderer/src/schemas/switch.ts
+++ b/renderer/src/schemas/switch.ts
@@ -12,3 +12,5 @@ export const switchSchema = componentBase.extend({
   required: z.boolean().optional(),
   onChange: actionOrList.optional(),
 });
+
+export type SwitchWire = z.infer<typeof switchSchema>;

--- a/renderer/src/schemas/table.ts
+++ b/renderer/src/schemas/table.ts
@@ -58,3 +58,12 @@ export const dataTableSchema = componentBase.extend({
   pageSize: z.number().int().optional(),
   caption: z.string().optional(),
 });
+
+export type TableWire = z.infer<typeof tableSchema>;
+export type TableHeaderWire = z.infer<typeof tableHeaderSchema>;
+export type TableBodyWire = z.infer<typeof tableBodySchema>;
+export type TableFooterWire = z.infer<typeof tableFooterSchema>;
+export type TableRowWire = z.infer<typeof tableRowSchema>;
+export type TableHeadWire = z.infer<typeof tableHeadSchema>;
+export type TableCellWire = z.infer<typeof tableCellSchema>;
+export type TableCaptionWire = z.infer<typeof tableCaptionSchema>;

--- a/renderer/src/schemas/tabs.ts
+++ b/renderer/src/schemas/tabs.ts
@@ -15,3 +15,6 @@ export const tabsSchema = containerBase.extend({
   name: z.string().optional(),
   onChange: actionOrList.optional(),
 });
+
+export type TabsWire = z.infer<typeof tabsSchema>;
+export type TabWire = z.infer<typeof tabSchema>;

--- a/renderer/src/schemas/text.ts
+++ b/renderer/src/schemas/text.ts
@@ -7,3 +7,5 @@ export const textSchema = componentBase.extend({
   bold: z.boolean().optional(),
   italic: z.boolean().optional(),
 });
+
+export type TextWire = z.infer<typeof textSchema>;

--- a/renderer/src/schemas/textarea.ts
+++ b/renderer/src/schemas/textarea.ts
@@ -14,3 +14,5 @@ export const textareaSchema = componentBase.extend({
   maxLength: z.number().int().optional(),
   onChange: actionOrList.optional(),
 });
+
+export type TextareaWire = z.infer<typeof textareaSchema>;

--- a/renderer/src/schemas/tooltip.ts
+++ b/renderer/src/schemas/tooltip.ts
@@ -6,3 +6,5 @@ export const tooltipSchema = containerBase.extend({
   content: z.string(),
   side: z.enum(["top", "right", "bottom", "left"]).optional(),
 });
+
+export type TooltipWire = z.infer<typeof tooltipSchema>;

--- a/renderer/src/schemas/typography.ts
+++ b/renderer/src/schemas/typography.ts
@@ -39,3 +39,15 @@ export const blockQuoteSchema = typographyBase.extend({
 export const inlineCodeSchema = typographyBase.extend({
   type: z.literal("InlineCode"),
 });
+
+export type H1Wire = z.infer<typeof h1Schema>;
+export type H2Wire = z.infer<typeof h2Schema>;
+export type H3Wire = z.infer<typeof h3Schema>;
+export type H4Wire = z.infer<typeof h4Schema>;
+export type PWire = z.infer<typeof pSchema>;
+export type LeadWire = z.infer<typeof leadSchema>;
+export type LargeWire = z.infer<typeof largeSchema>;
+export type SmallWire = z.infer<typeof smallSchema>;
+export type MutedWire = z.infer<typeof mutedSchema>;
+export type BlockQuoteWire = z.infer<typeof blockQuoteSchema>;
+export type InlineCodeWire = z.infer<typeof inlineCodeSchema>;

--- a/renderer/src/validation.test.ts
+++ b/renderer/src/validation.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Tests for runtime validation of component nodes and actions.
+ */
+
+import { describe, test, expect, vi, beforeEach } from "vitest";
+import { validateNode, validateAction } from "./validation.ts";
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  vi.spyOn(console, "warn").mockImplementation(() => {});
+});
+
+describe("validateNode", () => {
+  test("valid node returns null", () => {
+    const node = { type: "Button", label: "Click me" };
+    expect(validateNode(node)).toBeNull();
+  });
+
+  test("valid container node returns null", () => {
+    const node = {
+      type: "Column",
+      gap: 4,
+      children: [{ type: "Text", content: "Hello" }],
+    };
+    expect(validateNode(node)).toBeNull();
+  });
+
+  test("optional fields can be omitted", () => {
+    const node = { type: "Button", label: "Click" };
+    expect(validateNode(node)).toBeNull();
+  });
+
+  test("unknown type returns unknown_type error", () => {
+    const node = { type: "Buttton", label: "Typo" }; // codespell:ignore buttton
+    const result = validateNode(node);
+    expect(result).not.toBeNull();
+    expect(result!.kind).toBe("unknown_type");
+    expect(result!.message).toContain("Buttton"); // codespell:ignore buttton
+  });
+
+  test("missing required field returns schema_error", () => {
+    const node = { type: "Button" };
+    const result = validateNode(node);
+    expect(result).not.toBeNull();
+    expect(result!.kind).toBe("schema_error");
+    expect(result!.message).toContain("Button");
+    expect(result!.issues.length).toBeGreaterThan(0);
+  });
+
+  test("wrong field type returns schema_error", () => {
+    const node = { type: "Button", label: 42 };
+    const result = validateNode(node);
+    expect(result).not.toBeNull();
+    expect(result!.kind).toBe("schema_error");
+  });
+
+  test("issues contain descriptive path info", () => {
+    const node = { type: "Input", inputType: 123 };
+    const result = validateNode(node);
+    expect(result).not.toBeNull();
+    expect(result!.issues.some((i) => i.includes("inputType"))).toBe(true);
+  });
+
+  test("console.warn is called on failure", () => {
+    validateNode({ type: "Nonexistent" });
+    expect(console.warn).toHaveBeenCalledWith(
+      "[Prefab] Validation error:",
+      expect.stringContaining("Nonexistent"),
+      expect.any(Object),
+    );
+  });
+
+  test("console.warn is not called on success", () => {
+    validateNode({ type: "Text", content: "hello" });
+    expect(console.warn).not.toHaveBeenCalled();
+  });
+});
+
+describe("validateAction", () => {
+  test("valid action returns null", () => {
+    const action = { action: "setState", key: "count", value: 1 };
+    expect(validateAction(action)).toBeNull();
+  });
+
+  test("valid toolCall returns null", () => {
+    const action = {
+      action: "toolCall",
+      tool: "save",
+      arguments: { name: "test" },
+    };
+    expect(validateAction(action)).toBeNull();
+  });
+
+  test("unknown action type returns unknown_type error", () => {
+    const action = { action: "doMagic" };
+    const result = validateAction(action);
+    expect(result).not.toBeNull();
+    expect(result!.kind).toBe("unknown_type");
+    expect(result!.message).toContain("doMagic");
+  });
+
+  test("missing required field returns schema_error", () => {
+    const action = { action: "toolCall" };
+    const result = validateAction(action);
+    expect(result).not.toBeNull();
+    expect(result!.kind).toBe("schema_error");
+    expect(result!.issues.some((i) => i.includes("tool"))).toBe(true);
+  });
+
+  test("valid showToast returns null", () => {
+    const action = {
+      action: "showToast",
+      message: "Saved!",
+      variant: "success",
+    };
+    expect(validateAction(action)).toBeNull();
+  });
+
+  test("console.warn is called on failure", () => {
+    validateAction({ action: "unknownAction" });
+    expect(console.warn).toHaveBeenCalledWith(
+      "[Prefab] Action validation error:",
+      expect.stringContaining("unknownAction"),
+      expect.any(Object),
+    );
+  });
+});

--- a/renderer/src/validation.ts
+++ b/renderer/src/validation.ts
@@ -1,0 +1,95 @@
+/**
+ * Runtime validation for component nodes and actions.
+ *
+ * Uses the Zod schemas (originally built for contract testing) to validate
+ * incoming JSON at render time. Invalid nodes surface clear errors instead
+ * of producing cryptic React crashes.
+ */
+
+import { SCHEMA_REGISTRY, ACTION_SCHEMA_REGISTRY } from "./schemas";
+
+export interface ValidationResult {
+  kind: "unknown_type" | "schema_error";
+  message: string;
+  issues: string[];
+}
+
+/**
+ * Validate a component node against its Zod schema.
+ * Returns null if valid, or a ValidationResult describing the problem.
+ */
+export function validateNode(node: {
+  type: string;
+  [key: string]: unknown;
+}): ValidationResult | null {
+  const schema = SCHEMA_REGISTRY[node.type];
+  if (!schema) {
+    const result: ValidationResult = {
+      kind: "unknown_type",
+      message: `Unknown component: "${node.type}"`,
+      issues: [`"${node.type}" is not a registered component type`],
+    };
+    console.warn("[Prefab] Validation error:", result.message, { node });
+    return result;
+  }
+
+  const parsed = schema.safeParse(node);
+  if (!parsed.success) {
+    const issues = parsed.error.issues.map(
+      (issue) => `${issue.path.join(".")}: ${issue.message}`,
+    );
+    const result: ValidationResult = {
+      kind: "schema_error",
+      message: `Invalid <${node.type}> props`,
+      issues,
+    };
+    console.warn("[Prefab] Validation error:", result.message, {
+      issues,
+      node,
+    });
+    return result;
+  }
+
+  return null;
+}
+
+/**
+ * Validate a resolved action payload against its Zod schema.
+ * Returns null if valid, or a ValidationResult describing the problem.
+ */
+export function validateAction(action: {
+  action: string;
+  [key: string]: unknown;
+}): ValidationResult | null {
+  const schema = ACTION_SCHEMA_REGISTRY[action.action];
+  if (!schema) {
+    const result: ValidationResult = {
+      kind: "unknown_type",
+      message: `Unknown action: "${action.action}"`,
+      issues: [`"${action.action}" is not a registered action type`],
+    };
+    console.warn("[Prefab] Action validation error:", result.message, {
+      action,
+    });
+    return result;
+  }
+
+  const parsed = schema.safeParse(action);
+  if (!parsed.success) {
+    const issues = parsed.error.issues.map(
+      (issue) => `${issue.path.join(".")}: ${issue.message}`,
+    );
+    const result: ValidationResult = {
+      kind: "schema_error",
+      message: `Invalid "${action.action}" action`,
+      issues,
+    };
+    console.warn("[Prefab] Action validation error:", result.message, {
+      issues,
+      action,
+    });
+    return result;
+  }
+
+  return null;
+}


### PR DESCRIPTION
Malformed component JSON currently produces cryptic React crashes deep in the rendering pipeline. This PR catches those errors early — `validateNode()` runs at the top of `RenderNode` and replaces broken nodes with an inline `<ValidationError>` component showing what went wrong and the raw JSON. Actions validate after interpolation and short-circuit on failure (triggering `onError` callbacks as expected).

```tsx
// In RenderNode — 4 lines of wiring
const validationError = validateNode(node);
if (validationError) {
  return <ValidationError error={validationError} node={node} />;
}
```

The validation error component renders with `role="alert"`, a `destructive` border, and a collapsible detail section showing Zod issues + the raw node JSON — so typos like `"Buttton"` or missing required props surface clearly in the UI instead of silently failing.

As a side effect, every schema file now exports `z.infer` Wire types (e.g. `ButtonWire`, `ActionWire`), giving downstream code typed representations of the protocol format.