### PR TITLE
Add protocol version to wire format envelope

### DIFF
--- a/renderer/src/app.tsx
+++ b/renderer/src/app.tsx
@@ -32,6 +32,9 @@ import { useStateStore } from "./state";
 /** Reserved key prefix in structuredContent (renderer internals). */
 const RESERVED_PREFIX = "_prefab_";
 
+/** Protocol versions this renderer understands. */
+const SUPPORTED_VERSIONS = new Set(["0.1"]);
+
 /** Extract state from structuredContent (everything except reserved keys). */
 function extractState(
   structured: Record<string, unknown> | undefined,
@@ -68,6 +71,18 @@ export function App() {
     (result: { structuredContent?: Record<string, unknown> }) => {
       const structured = result.structuredContent;
       if (!structured) return;
+
+      // Check protocol version (warn but don't block rendering)
+      const version = structured._prefab_version as string | undefined;
+      if (!version) {
+        console.warn("[Prefab] Missing _prefab_version in structuredContent");
+      } else if (!SUPPORTED_VERSIONS.has(version)) {
+        console.warn(
+          `[Prefab] Unrecognized protocol version "${version}" (supported: ${[
+            ...SUPPORTED_VERSIONS,
+          ].join(", ")})`,
+        );
+      }
 
       // Extract component tree and state from structuredContent
       const view = structured._prefab_view as ComponentNode | undefined;

--- a/src/prefab_ui/response.py
+++ b/src/prefab_ui/response.py
@@ -14,6 +14,8 @@ from typing import Any
 import pydantic_core
 from pydantic import BaseModel, Field, model_validator
 
+PROTOCOL_VERSION = "0.1"
+
 
 class UIResponse(BaseModel):
     """Return type for server functions that render interactive UIs.
@@ -67,6 +69,8 @@ class UIResponse(BaseModel):
             state_json = pydantic_core.to_jsonable_python(self.state)
             if isinstance(state_json, dict):
                 result.update(state_json)
+
+        result["_prefab_version"] = PROTOCOL_VERSION
 
         if self.view is not None:
             result["_prefab_view"] = self.view.to_json()

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pytest
 
 from prefab_ui.components import Column, Heading, Text
-from prefab_ui.response import UIResponse
+from prefab_ui.response import PROTOCOL_VERSION, UIResponse
 
 
 class TestUIResponse:
@@ -25,7 +25,8 @@ class TestUIResponse:
     def test_state_only(self):
         resp = UIResponse(state={"x": 1})
         result = resp.to_json()
-        assert result == {"x": 1}
+        assert result["x"] == 1
+        assert result["_prefab_version"] == PROTOCOL_VERSION
 
     def test_view_only(self):
         resp = UIResponse(view=Text(content="hi"))
@@ -52,7 +53,7 @@ class TestUIResponse:
     def test_empty_response(self):
         resp = UIResponse()
         result = resp.to_json()
-        assert result == {}
+        assert result == {"_prefab_version": PROTOCOL_VERSION}
         assert resp.text_fallback() == "[No content]"
 
     def test_no_prefab_state_key(self):
@@ -68,6 +69,22 @@ class TestUIResponse:
     def test_reserved_key_validation_dollar(self):
         with pytest.raises(ValueError, match="reserved prefix '\\$'"):
             UIResponse(state={"$event": "bad"})
+
+
+class TestProtocolVersion:
+    def test_version_always_present(self):
+        resp = UIResponse(view=Text(content="hi"))
+        result = resp.to_json()
+        assert result["_prefab_version"] == PROTOCOL_VERSION
+
+    def test_version_with_state(self):
+        resp = UIResponse(state={"x": 1}, view=Text(content="hi"))
+        result = resp.to_json()
+        assert result["_prefab_version"] == PROTOCOL_VERSION
+        assert result["x"] == 1
+
+    def test_version_value(self):
+        assert PROTOCOL_VERSION == "0.1"
 
 
 class TestUIResponseState:


### PR DESCRIPTION
The wire format now carries `_prefab_version: "0.1"` in every envelope, giving both producer and renderer a way to detect incompatibility as the protocol evolves. The version is always present — even empty responses include it.

The renderer reads `_prefab_version` from `structuredContent` and `console.warn`s if it's missing or unrecognized, but never blocks rendering. This is intentionally soft enforcement: existing integrations keep working, and we have the hook to tighten it later when we're ready to make breaking changes.

The version value `"0.1"` is a placeholder — whether it eventually tracks the Python package version, stays independent, or becomes semver is a decision for when we approach 1.0.