### PR TITLE
Fix doc inconsistencies and centralize interpolation docs

### DIFF
--- a/docs/apps/components/accordion.mdx
+++ b/docs/apps/components/accordion.mdx
@@ -243,20 +243,6 @@ with Accordion(
 </CodeGroup>
 </ComponentPreview>
 
-## Data Interpolation
-
-Accordion item titles and content support `{{ field }}` placeholders for dynamic content:
-
-```python Interpolation Example
-from prefab_ui.components import Accordion, AccordionItem, Text
-
-with Accordion():
-    with AccordionItem("{{ user.status }}"):
-        Text("Last updated: {{ last_updated }}")
-    with AccordionItem("FAQ"):
-        Text("{{ faq_content }}")
-```
-
 ## API Reference
 
 <Card icon="code" title="Accordion Parameters">

--- a/docs/apps/components/alert.mdx
+++ b/docs/apps/components/alert.mdx
@@ -276,22 +276,6 @@ with Card():
 </CodeGroup>
 </ComponentPreview>
 
-## Data Interpolation
-
-Alert titles and descriptions support `{{ field }}` placeholders:
-
-```python Alert Interpolation
-from prefab_ui.components import (
-    Alert,
-    AlertTitle,
-    AlertDescription,
-)
-
-with Alert(variant="{{ severity }}"):
-    AlertTitle("{{ title }}")
-    AlertDescription("{{ message }}")
-```
-
 ## API Reference
 
 <Card icon="code" title="Alert Parameters">
@@ -306,7 +290,7 @@ with Alert(variant="{{ severity }}"):
 
 <Card icon="code" title="AlertTitle Parameters">
 <ParamField body="content" type="str" required>
-  Title text. Can be passed as a positional argument. Supports `{{ field }}` interpolation.
+  Title text. Can be passed as a positional argument.
 </ParamField>
 
 <ParamField body="css_class" type="str | None" default="None">
@@ -316,7 +300,7 @@ with Alert(variant="{{ severity }}"):
 
 <Card icon="code" title="AlertDescription Parameters">
 <ParamField body="content" type="str" required>
-  Description text. Can be passed as a positional argument. Supports `{{ field }}` interpolation.
+  Description text. Can be passed as a positional argument.
 </ParamField>
 
 <ParamField body="css_class" type="str | None" default="None">
@@ -352,5 +336,3 @@ with Alert(variant="{{ severity }}"):
   "cssClass?": "string",
   "visibleWhen?": "string"
 }
-
-</Card>

--- a/docs/apps/components/badge.mdx
+++ b/docs/apps/components/badge.mdx
@@ -111,22 +111,11 @@ with Column(gap=3):
 </CodeGroup>
 </ComponentPreview>
 
-## Data Interpolation
-
-Badge labels support `{{ field }}` placeholders:
-
-```python Badge Interpolation
-from prefab_ui.components import Badge
-
-Badge("{{ status }}")
-Badge("{{ count }} items", variant="secondary")
-```
-
 ## API Reference
 
 <Card icon="code" title="Badge Parameters">
 <ParamField body="label" type="str" required>
-  Badge text. Can be passed as a positional argument. Supports `{{ field }}` interpolation.
+  Badge text. Can be passed as a positional argument.
 </ParamField>
 
 <ParamField body="variant" type="str" default="default">

--- a/docs/apps/components/button.mdx
+++ b/docs/apps/components/button.mdx
@@ -309,21 +309,11 @@ with Column(gap=3, css_class="items-start w-full"):
 </CodeGroup>
 </ComponentPreview>
 
-## Data Interpolation
-
-Button labels support `{{ field }}` placeholders that are replaced with data at render time:
-
-```python Button Interpolation
-from prefab_ui.components import Button
-
-Button("View {{ name }}'s profile")
-```
-
 ## API Reference
 
 <Card icon="code" title="Button Parameters">
 <ParamField body="label" type="str" required>
-  Button text. Supports `{{ field }}` interpolation with data passed at render time.
+  Button text. Can be passed as a positional argument.
 </ParamField>
 
 <ParamField body="variant" type="str" default="default">

--- a/docs/apps/components/card.mdx
+++ b/docs/apps/components/card.mdx
@@ -292,24 +292,6 @@ with Grid(columns=3, gap=4):
 </CodeGroup>
 </ComponentPreview>
 
-## Data Interpolation
-
-Card sub-components that accept text (`CardTitle`, `CardDescription`) support `{{ field }}` placeholders:
-
-```python Card Interpolation
-from prefab_ui.components import (
-    Card,
-    CardHeader,
-    CardTitle,
-    CardDescription,
-)
-
-with Card():
-    with CardHeader():
-        CardTitle("{{ project_name }}")
-        CardDescription("Created by {{ author }}")
-```
-
 ## API Reference
 
 <Card icon="code" title="Card Parameters">
@@ -326,7 +308,7 @@ with Card():
 
 <Card icon="code" title="CardTitle Parameters">
 <ParamField body="content" type="str | None" default="None">
-  Title text. Can be passed as a positional argument. Supports `{{ field }}` interpolation. Alternatively, use child components instead of a string.
+  Title text. Can be passed as a positional argument. Alternatively, use child components instead of a string.
 </ParamField>
 
 <ParamField body="css_class" type="str | None" default="None">
@@ -336,7 +318,7 @@ with Card():
 
 <Card icon="code" title="CardDescription Parameters">
 <ParamField body="content" type="str | None" default="None">
-  Description text. Can be passed as a positional argument. Supports `{{ field }}` interpolation. Alternatively, use child components.
+  Description text. Can be passed as a positional argument. Alternatively, use child components.
 </ParamField>
 
 <ParamField body="css_class" type="str | None" default="None">

--- a/docs/apps/components/checkbox.mdx
+++ b/docs/apps/components/checkbox.mdx
@@ -152,32 +152,32 @@ with Column(gap=3, css_class="w-fit mx-auto"):
 
 <Card icon="code" title="Checkbox Parameters">
 
-<ParamField path="label" type="str | None">
-  Label text displayed next to the checkbox. Supports `{{ field }}` interpolation.
+<ParamField body="label" type="str | None" default="None">
+  Label text displayed next to the checkbox.
 </ParamField>
 
-<ParamField path="checked" type="bool" default="False">
-  Whether the checkbox is checked.
+<ParamField body="checked" type="bool" default="False">
+  Whether the checkbox is initially checked.
 </ParamField>
 
-<ParamField path="name" type="str | None">
+<ParamField body="name" type="str | None" default="None">
   Form field name for submission.
 </ParamField>
 
-<ParamField path="value" type="str | None">
-  Form value when checked. Supports `{{ field }}` interpolation.
+<ParamField body="value" type="str | None" default="None">
+  Form value when checked.
 </ParamField>
 
-<ParamField path="disabled" type="bool" default="False">
-  Whether the checkbox is disabled.
+<ParamField body="disabled" type="bool" default="False">
+  Whether the checkbox is non-interactive.
 </ParamField>
 
-<ParamField path="required" type="bool" default="False">
-  Whether the checkbox is required.
+<ParamField body="required" type="bool" default="False">
+  Whether the checkbox is required for form submission.
 </ParamField>
 
-<ParamField path="css_class" type="str | None">
-  Additional CSS classes to apply.
+<ParamField body="css_class" type="str | None" default="None">
+  Additional Tailwind CSS classes appended to the component's built-in styles.
 </ParamField>
 </Card>
 

--- a/docs/apps/components/code.mdx
+++ b/docs/apps/components/code.mdx
@@ -73,21 +73,11 @@ with Column(gap=3):
 </CodeGroup>
 </ComponentPreview>
 
-## Data Interpolation
-
-Content supports `{{ field }}` interpolation, so you can inject dynamic code from server data:
-
-```python Dynamic Code
-from prefab_ui.components import Code
-
-Code("{{ source }}", language="{{ language }}")
-```
-
 ## API Reference
 
 <Card icon="code" title="Code Parameters">
 <ParamField body="content" type="str" required>
-  Code content. Supports `{{ field }}` interpolation.
+  Code content. Can be passed as a positional argument.
 </ParamField>
 
 <ParamField body="language" type="str | None" default="None">

--- a/docs/apps/components/data-table.mdx
+++ b/docs/apps/components/data-table.mdx
@@ -157,24 +157,6 @@ DataTable(
 </CodeGroup>
 </ComponentPreview>
 
-## Data Interpolation
-
-Pass `rows` as a `{{ field }}` reference to render server data dynamically:
-
-```python DataTable Interpolation
-from prefab_ui.components import DataTable, DataTableColumn
-
-DataTable(
-    columns=[
-        DataTableColumn(key="name", header="Name", sortable=True),
-        DataTableColumn(key="status", header="Status"),
-    ],
-    rows="{{ users }}",
-    searchable=True,
-    paginated=True,
-)
-```
-
 ## API Reference
 
 <Card icon="code" title="DataTable Parameters">

--- a/docs/apps/components/image.mdx
+++ b/docs/apps/components/image.mdx
@@ -56,11 +56,11 @@ with Card():
 
 <Card icon="code" title="Image Parameters">
 <ParamField body="src" type="str" required>
-  Image URL. Supports `{{ field }}` interpolation.
+  Image URL.
 </ParamField>
 
 <ParamField body="alt" type="str" default='""'>
-  Alt text. Supports `{{ field }}` interpolation.
+  Alt text for accessibility.
 </ParamField>
 
 <ParamField body="width" type="str | None" default="None">

--- a/docs/apps/components/input.mdx
+++ b/docs/apps/components/input.mdx
@@ -240,32 +240,32 @@ Input(placeholder="Disabled input", disabled=True)
 
 <Card icon="code" title="Input Parameters">
 
-<ParamField path="input_type" type="str" default="text">
-  Input type: text, email, password, number, tel, url, search, date, time, datetime-local, file.
+<ParamField body="input_type" type="str" default="text">
+  Input type: `"text"`, `"email"`, `"password"`, `"number"`, `"tel"`, `"url"`, `"search"`, `"date"`, `"time"`, `"datetime-local"`, `"file"`.
 </ParamField>
 
-<ParamField path="placeholder" type="str | None">
-  Placeholder text. Supports `{{ field }}` interpolation.
+<ParamField body="placeholder" type="str | None" default="None">
+  Placeholder text shown when the input is empty.
 </ParamField>
 
-<ParamField path="value" type="str | None">
-  Initial value. Supports `{{ field }}` interpolation.
+<ParamField body="value" type="str | None" default="None">
+  Initial value.
 </ParamField>
 
-<ParamField path="name" type="str | None">
+<ParamField body="name" type="str | None" default="None">
   Form field name for submission.
 </ParamField>
 
-<ParamField path="disabled" type="bool" default="False">
-  Whether the input is disabled.
+<ParamField body="disabled" type="bool" default="False">
+  Whether the input is non-interactive.
 </ParamField>
 
-<ParamField path="required" type="bool" default="False">
+<ParamField body="required" type="bool" default="False">
   Whether the input is required for form submission.
 </ParamField>
 
-<ParamField path="css_class" type="str | None">
-  Additional CSS classes to apply.
+<ParamField body="css_class" type="str | None" default="None">
+  Additional Tailwind CSS classes appended to the component's built-in styles.
 </ParamField>
 </Card>
 

--- a/docs/apps/components/label.mdx
+++ b/docs/apps/components/label.mdx
@@ -8,7 +8,9 @@ import { ComponentPreview } from "/snippets/component-preview.mdx";
 
 Labels provide accessible text descriptions for form fields.
 
-## Basic Usage They can contain text directly or wrap other components.
+## Basic Usage
+
+Labels can contain text directly or wrap other components.
 
 <ComponentPreview auto json={`{"type":"Label","text":"Email address"}`}>
 <CodeGroup>
@@ -71,16 +73,16 @@ with Column(gap=2):
 
 <Card icon="code" title="Label Parameters">
 
-<ParamField path="text" type="str | None">
-  Label text content. Supports `{{ field }}` interpolation.
+<ParamField body="text" type="str | None" default="None">
+  Label text content. Can be passed as a positional argument.
 </ParamField>
 
-<ParamField path="for_id" type="str | None">
+<ParamField body="for_id" type="str | None" default="None">
   ID of the associated form field element.
 </ParamField>
 
-<ParamField path="css_class" type="str | None">
-  Additional CSS classes to apply.
+<ParamField body="css_class" type="str | None" default="None">
+  Additional Tailwind CSS classes appended to the component's built-in styles.
 </ParamField>
 </Card>
 

--- a/docs/apps/components/layout.mdx
+++ b/docs/apps/components/layout.mdx
@@ -416,7 +416,7 @@ with Grid(2, gap=6):
 
 <Card icon="code" title="Span Parameters">
 <ParamField body="content" type="str" required>
-  Text content. Supports `{{ field }}` interpolation. Can be passed as a positional argument.
+  Text content. Can be passed as a positional argument.
 </ParamField>
 
 <ParamField body="css_class" type="str | None" default="None">

--- a/docs/apps/components/markdown.mdx
+++ b/docs/apps/components/markdown.mdx
@@ -45,27 +45,11 @@ Version **2.5.0** brings several improvements:
 </CodeGroup>
 </ComponentPreview>
 
-## Data Interpolation
-
-Use `{{ field }}` placeholders to inject server data into markdown content:
-
-```python Markdown Interpolation
-from prefab_ui.components import Markdown
-
-Markdown("""
-## {{ title }}
-
-{{ description }}
-
-**Status:** {{ status }}
-""")
-```
-
 ## API Reference
 
 <Card icon="code" title="Markdown Parameters">
 <ParamField body="content" type="str" required>
-  Markdown text. Can be passed as a positional argument. Supports `{{ field }}` interpolation.
+  Markdown text. Can be passed as a positional argument.
 </ParamField>
 
 <ParamField body="css_class" type="str | None" default="None">

--- a/docs/apps/components/progress.mdx
+++ b/docs/apps/components/progress.mdx
@@ -233,21 +233,11 @@ with Column(gap=3):
 </CodeGroup>
 </ComponentPreview>
 
-## Data Interpolation
-
-Progress values support `{{ field }}` interpolation, making them ideal for showing live server data:
-
-```python Progress Interpolation
-from prefab_ui.components import Progress
-
-Progress(value="{{ completion_pct }}")
-```
-
 ## API Reference
 
 <Card icon="code" title="Progress Parameters">
 <ParamField body="value" type="float" default="0">
-  Current progress value. Supports `{{ field }}` interpolation.
+  Current progress value.
 </ParamField>
 
 <ParamField body="max" type="float" default="100">

--- a/docs/apps/components/radio.mdx
+++ b/docs/apps/components/radio.mdx
@@ -155,43 +155,43 @@ with RadioGroup(name="plan"):
 
 ## API Reference
 
-<Card icon="code" title="Radio Parameters">
-
-<ParamField path="name" type="str | None">
+<Card icon="code" title="RadioGroup Parameters">
+<ParamField body="name" type="str | None" default="None">
   Form field name shared by all radio buttons in the group.
 </ParamField>
 
-<ParamField path="css_class" type="str | None">
-  Additional CSS classes to apply.
+<ParamField body="css_class" type="str | None" default="None">
+  Additional Tailwind CSS classes appended to the component's built-in styles.
+</ParamField>
+</Card>
+
+<Card icon="code" title="Radio Parameters">
+<ParamField body="value" type="str" required>
+  Form value for this option.
 </ParamField>
 
-
-<ParamField path="value" type="str">
-  Form value for this option. Supports `{{ field }}` interpolation.
+<ParamField body="label" type="str | None" default="None">
+  Label text displayed next to the radio button.
 </ParamField>
 
-<ParamField path="label" type="str | None">
-  Label text displayed next to the radio button. Supports `{{ field }}` interpolation.
+<ParamField body="checked" type="bool" default="False">
+  Whether this radio button is initially selected.
 </ParamField>
 
-<ParamField path="checked" type="bool" default="False">
-  Whether this radio button is selected.
+<ParamField body="name" type="str | None" default="None">
+  Form field name. Usually inherited from RadioGroup.
 </ParamField>
 
-<ParamField path="name" type="str | None">
-  Form field name (usually inherited from RadioGroup).
+<ParamField body="disabled" type="bool" default="False">
+  Whether the radio button is non-interactive.
 </ParamField>
 
-<ParamField path="disabled" type="bool" default="False">
-  Whether the radio button is disabled.
+<ParamField body="required" type="bool" default="False">
+  Whether a selection is required for form submission.
 </ParamField>
 
-<ParamField path="required" type="bool" default="False">
-  Whether a selection is required.
-</ParamField>
-
-<ParamField path="css_class" type="str | None">
-  Additional CSS classes to apply.
+<ParamField body="css_class" type="str | None" default="None">
+  Additional Tailwind CSS classes.
 </ParamField>
 </Card>
 

--- a/docs/apps/components/select.mdx
+++ b/docs/apps/components/select.mdx
@@ -252,50 +252,50 @@ with Column(gap=2):
 ## API Reference
 
 <Card icon="code" title="Select Parameters">
-
-<ParamField path="placeholder" type="str | None">
-  Placeholder text when no option is selected. Supports `{{ field }}` interpolation.
+<ParamField body="placeholder" type="str | None" default="None">
+  Placeholder text shown when no option is selected.
 </ParamField>
 
-<ParamField path="name" type="str | None">
+<ParamField body="name" type="str | None" default="None">
   Form field name for submission.
 </ParamField>
 
-<ParamField path="size" type="'sm' | 'default'" default="'default'">
-  Select size.
+<ParamField body="size" type="str" default="default">
+  Select size: `"default"`, `"sm"`.
 </ParamField>
 
-<ParamField path="disabled" type="bool" default="False">
-  Whether the select is disabled.
+<ParamField body="disabled" type="bool" default="False">
+  Whether the select is non-interactive.
 </ParamField>
 
-<ParamField path="required" type="bool" default="False">
-  Whether a selection is required.
+<ParamField body="required" type="bool" default="False">
+  Whether a selection is required for form submission.
 </ParamField>
 
-<ParamField path="css_class" type="str | None">
-  Additional CSS classes to apply.
+<ParamField body="css_class" type="str | None" default="None">
+  Additional Tailwind CSS classes appended to the component's built-in styles.
+</ParamField>
+</Card>
+
+<Card icon="code" title="SelectOption Parameters">
+<ParamField body="value" type="str" required>
+  Option value for form submission.
 </ParamField>
 
-
-<ParamField path="value" type="str">
-  Option value for form submission. Supports `{{ field }}` interpolation.
+<ParamField body="label" type="str" required>
+  Display text shown to the user.
 </ParamField>
 
-<ParamField path="label" type="str">
-  Display text for the option. Supports `{{ field }}` interpolation.
-</ParamField>
-
-<ParamField path="selected" type="bool" default="False">
+<ParamField body="selected" type="bool" default="False">
   Whether this option is initially selected.
 </ParamField>
 
-<ParamField path="disabled" type="bool" default="False">
-  Whether this option is disabled.
+<ParamField body="disabled" type="bool" default="False">
+  Whether this option is non-interactive.
 </ParamField>
 
-<ParamField path="css_class" type="str | None">
-  Additional CSS classes to apply.
+<ParamField body="css_class" type="str | None" default="None">
+  Additional Tailwind CSS classes.
 </ParamField>
 </Card>
 

--- a/docs/apps/components/separator.mdx
+++ b/docs/apps/components/separator.mdx
@@ -160,12 +160,12 @@ with Card():
 
 <Card icon="code" title="Separator Parameters">
 
-<ParamField path="orientation" type="'horizontal' | 'vertical'" default="'horizontal'">
-  Separator direction.
+<ParamField body="orientation" type="str" default="horizontal">
+  Separator direction: `"horizontal"`, `"vertical"`.
 </ParamField>
 
-<ParamField path="css_class" type="str | None">
-  Additional CSS classes to apply. Useful for controlling height/width and spacing.
+<ParamField body="css_class" type="str | None" default="None">
+  Additional Tailwind CSS classes. Useful for controlling height/width and spacing.
 </ParamField>
 </Card>
 

--- a/docs/apps/components/slider.mdx
+++ b/docs/apps/components/slider.mdx
@@ -219,32 +219,32 @@ Slider(min=0, max=100, value=30, disabled=True)
 
 <Card icon="code" title="Slider Parameters">
 
-<ParamField path="min" type="float" default="0">
+<ParamField body="min" type="float" default="0">
   Minimum value of the range.
 </ParamField>
 
-<ParamField path="max" type="float" default="100">
+<ParamField body="max" type="float" default="100">
   Maximum value of the range.
 </ParamField>
 
-<ParamField path="value" type="float | None">
-  Initial value. Supports `{{ field }}` interpolation.
+<ParamField body="value" type="float | None" default="None">
+  Initial value.
 </ParamField>
 
-<ParamField path="step" type="float | None">
+<ParamField body="step" type="float | None" default="None">
   Step increment for the slider. If not provided, slider moves continuously.
 </ParamField>
 
-<ParamField path="name" type="str | None">
+<ParamField body="name" type="str | None" default="None">
   Form field name for submission.
 </ParamField>
 
-<ParamField path="disabled" type="bool" default="False">
-  Whether the slider is disabled.
+<ParamField body="disabled" type="bool" default="False">
+  Whether the slider is non-interactive.
 </ParamField>
 
-<ParamField path="css_class" type="str | None">
-  Additional CSS classes to apply.
+<ParamField body="css_class" type="str | None" default="None">
+  Additional Tailwind CSS classes appended to the component's built-in styles.
 </ParamField>
 </Card>
 

--- a/docs/apps/components/state.mdx
+++ b/docs/apps/components/state.mdx
@@ -4,19 +4,62 @@ description: Provide scoped interpolation values to children.
 icon: database
 ---
 
-`State` is a control-flow component that provides local `{{ }}` interpolation values to its children. Children resolve template expressions against the State's values first, falling through to parent scopes and then global state.
+import { ComponentPreview } from '/snippets/component-preview.mdx'
+
+`State` provides local [interpolation](/apps/patterns/interpolation) values to its children. Children resolve `{{ }}` template expressions against the State's values first, falling through to parent scopes and then global state.
 
 This is useful when you want to inject data into a subtree without polluting global state or duplicating values across multiple props.
 
-```python Basic Usage
-from prefab_ui.components import State, Card, CardHeader, CardTitle, CardDescription
+## Basic Usage
 
-with State(name="Alice", role="Engineer"):
+<ComponentPreview auto json={`{"type":"State","state":{"name":"Arthur Dent","role":"Reluctant Adventurer"},"children":[{"type":"Card","children":[{"type":"CardHeader","children":[{"type":"CardTitle","content":"{{ name }}"},{"type":"CardDescription","content":"{{ role }}"}]}]}]}`}>
+<CodeGroup>
+```python Python
+from prefab_ui.components import (
+    Card,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+    State,
+)
+
+with State(name="Arthur Dent", role="Reluctant Adventurer"):
     with Card():
         with CardHeader():
             CardTitle("{{ name }}")
             CardDescription("{{ role }}")
 ```
+```json Protocol
+{
+  "type": "State",
+  "state": {
+    "name": "Arthur Dent",
+    "role": "Reluctant Adventurer"
+  },
+  "children": [
+    {
+      "type": "Card",
+      "children": [
+        {
+          "type": "CardHeader",
+          "children": [
+            {
+              "type": "CardTitle",
+              "content": "{{ name }}"
+            },
+            {
+              "type": "CardDescription",
+              "content": "{{ role }}"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+</CodeGroup>
+</ComponentPreview>
 
 ## How It Works
 
@@ -26,54 +69,125 @@ Any kwargs that aren't base component fields (`css_class`, `visible_when`, etc.)
 from prefab_ui.components import State, Text
 
 # Kwargs style
-with State(name="Alice", role="Engineer"):
+with State(name="Ford", role="Researcher"):
     Text("{{ name }} is a {{ role }}")
 
 # Dict style
-with State({"name": "Alice", "role": "Engineer"}):
+with State({"name": "Ford", "role": "Researcher"}):
     Text("{{ name }} is a {{ role }}")
 ```
 
-State values are resolved against the current interpolation context, so you can compose values from outer scopes:
-
-```python Composing Values
-from prefab_ui.components import State, Text, Column
-
-set_data(first="Alice", last="Smith")
-
-with Column():
-    with State(full_name="{{ first }} {{ last }}"):
-        Text("Hello, {{ full_name }}!")
-```
+Both forms produce the same wire format — a `State` node with a `state` object.
 
 ## Nested State
 
 State components can nest. Inner values shadow outer ones for the same key, and children see the merged context:
 
-```python Nested State
-from prefab_ui.components import State, Text, Column
+<ComponentPreview auto json={`{"type":"Column","gap":2,"children":[{"type":"State","state":{"greeting":"Don't Panic","name":"Arthur"},"children":[{"type":"Text","content":"{{ greeting }}, {{ name }}"},{"type":"State","state":{"name":"Ford"},"children":[{"type":"Text","content":"{{ greeting }}, {{ name }}"}]}]}]}`}>
+<CodeGroup>
+```python Python
+from prefab_ui.components import Column, State, Text
 
-with Column():
-    with State(greeting="Hello", name="Alice"):
-        Text("{{ greeting }}, {{ name }}")  # Hello, Alice
-        with State(name="Bob"):
-            Text("{{ greeting }}, {{ name }}")  # Hello, Bob
+with Column(gap=2):
+    with State(greeting="Don't Panic", name="Arthur"):
+        Text("{{ greeting }}, {{ name }}")
+        with State(name="Ford"):
+            Text("{{ greeting }}, {{ name }}")
 ```
+```json Protocol
+{
+  "type": "Column",
+  "gap": 2,
+  "children": [
+    {
+      "type": "State",
+      "state": {
+        "greeting": "Don't Panic",
+        "name": "Arthur"
+      },
+      "children": [
+        {
+          "type": "Text",
+          "content": "{{ greeting }}, {{ name }}"
+        },
+        {
+          "type": "State",
+          "state": {
+            "name": "Ford"
+          },
+          "children": [
+            {
+              "type": "Text",
+              "content": "{{ greeting }}, {{ name }}"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+</CodeGroup>
+</ComponentPreview>
+
+The first `Text` renders "Don't Panic, Arthur". The second renders "Don't Panic, Ford" — the inner `State` shadows `name` but inherits `greeting`.
 
 ## With ForEach
 
-State works well alongside `ForEach` for providing extra context to iterated templates:
+State works well alongside [ForEach](/apps/components/foreach) for providing extra context to iterated templates:
 
-```python State with ForEach
-from prefab_ui.components import State, ForEach, Badge, Row
+<ComponentPreview auto json={`{"_tree":{"type":"State","state":{"prefix":"Speaks"},"children":[{"cssClass":"items-center","type":"Row","gap":2,"children":[{"type":"ForEach","key":"languages","children":[{"type":"Badge","label":"{{ prefix }}: {{ _item }}","variant":"secondary"}]}]}]},"languages":["Python","TypeScript","Rust"]}`}>
+<CodeGroup>
+```python Python
+from prefab_ui.components import Badge, ForEach, Row, State
 
 set_data(languages=["Python", "TypeScript", "Rust"])
 
-with State(variant="secondary"):
-    with Row(gap=2):
+with State(prefix="Speaks"):
+    with Row(gap=2, css_class="items-center"):
         with ForEach("languages"):
-            Badge("{{ _item }}", variant="{{ variant }}")
+            Badge(
+                "{{ prefix }}: {{ _item }}",
+                variant="secondary",
+            )
 ```
+```json Protocol
+{
+  "_tree": {
+    "type": "State",
+    "state": {
+      "prefix": "Speaks"
+    },
+    "children": [
+      {
+        "cssClass": "items-center",
+        "type": "Row",
+        "gap": 2,
+        "children": [
+          {
+            "type": "ForEach",
+            "key": "languages",
+            "children": [
+              {
+                "type": "Badge",
+                "label": "{{ prefix }}: {{ _item }}",
+                "variant": "secondary"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "languages": [
+    "Python",
+    "TypeScript",
+    "Rust"
+  ]
+}
+```
+</CodeGroup>
+</ComponentPreview>
 
 ## API Reference
 

--- a/docs/apps/components/switch.mdx
+++ b/docs/apps/components/switch.mdx
@@ -149,32 +149,32 @@ with Column(gap=3):
 
 <Card icon="code" title="Switch Parameters">
 
-<ParamField path="label" type="str | None">
-  Label text displayed next to the switch. Supports `{{ field }}` interpolation.
+<ParamField body="label" type="str | None" default="None">
+  Label text displayed next to the switch.
 </ParamField>
 
-<ParamField path="checked" type="bool" default="False">
+<ParamField body="checked" type="bool" default="False">
   Whether the switch is on.
 </ParamField>
 
-<ParamField path="size" type="'sm' | 'default'" default="'default'">
-  Switch size.
+<ParamField body="size" type="str" default="default">
+  Switch size: `"default"`, `"sm"`.
 </ParamField>
 
-<ParamField path="name" type="str | None">
+<ParamField body="name" type="str | None" default="None">
   Form field name for submission.
 </ParamField>
 
-<ParamField path="disabled" type="bool" default="False">
-  Whether the switch is disabled.
+<ParamField body="disabled" type="bool" default="False">
+  Whether the switch is non-interactive.
 </ParamField>
 
-<ParamField path="required" type="bool" default="False">
-  Whether the switch is required.
+<ParamField body="required" type="bool" default="False">
+  Whether a selection is required for form submission.
 </ParamField>
 
-<ParamField path="css_class" type="str | None">
-  Additional CSS classes to apply.
+<ParamField body="css_class" type="str | None" default="None">
+  Additional Tailwind CSS classes appended to the component's built-in styles.
 </ParamField>
 </Card>
 

--- a/docs/apps/components/table.mdx
+++ b/docs/apps/components/table.mdx
@@ -281,29 +281,6 @@ with Table():
 </CodeGroup>
 </ComponentPreview>
 
-## Data Interpolation
-
-Cell content supports `{{ field }}` placeholders for rendering server data:
-
-```python Table Interpolation
-from prefab_ui.components import (
-    Table,
-    TableBody,
-    TableRow,
-    TableCell,
-)
-
-with Table():
-    with TableBody():
-        with TableRow():
-            TableCell("{{ name }}")
-            TableCell("{{ email }}")
-```
-
-<Tip>
-For large datasets with sorting, filtering, and pagination, use [DataTable](/apps/components/data-table) instead.
-</Tip>
-
 ## API Reference
 
 <Card icon="code" title="Table Parameters">
@@ -314,7 +291,7 @@ For large datasets with sorting, filtering, and pagination, use [DataTable](/app
 
 <Card icon="code" title="TableHead / TableCell Parameters">
 <ParamField body="content" type="str | None">
-  Text content. Can be passed as a positional argument. Supports `{{ field }}` interpolation. Alternatively, use child components for rich content.
+  Text content. Can be passed as a positional argument. Alternatively, use child components for rich content.
 </ParamField>
 
 <ParamField body="css_class" type="str | None" default="None">

--- a/docs/apps/components/textarea.mdx
+++ b/docs/apps/components/textarea.mdx
@@ -116,32 +116,32 @@ Textarea(placeholder="This textarea is disabled", disabled=True)
 
 <Card icon="code" title="Textarea Parameters">
 
-<ParamField path="placeholder" type="str | None">
-  Placeholder text. Supports `{{ field }}` interpolation.
+<ParamField body="placeholder" type="str | None" default="None">
+  Placeholder text shown when the textarea is empty.
 </ParamField>
 
-<ParamField path="value" type="str | None">
-  Initial value. Supports `{{ field }}` interpolation.
+<ParamField body="value" type="str | None" default="None">
+  Initial value.
 </ParamField>
 
-<ParamField path="name" type="str | None">
+<ParamField body="name" type="str | None" default="None">
   Form field name for submission.
 </ParamField>
 
-<ParamField path="rows" type="int | None">
+<ParamField body="rows" type="int | None" default="None">
   Number of visible text rows.
 </ParamField>
 
-<ParamField path="disabled" type="bool" default="False">
-  Whether the textarea is disabled.
+<ParamField body="disabled" type="bool" default="False">
+  Whether the textarea is non-interactive.
 </ParamField>
 
-<ParamField path="required" type="bool" default="False">
+<ParamField body="required" type="bool" default="False">
   Whether the textarea is required for form submission.
 </ParamField>
 
-<ParamField path="css_class" type="str | None">
-  Additional CSS classes to apply.
+<ParamField body="css_class" type="str | None" default="None">
+  Additional Tailwind CSS classes appended to the component's built-in styles.
 </ParamField>
 </Card>
 

--- a/docs/apps/components/typography.mdx
+++ b/docs/apps/components/typography.mdx
@@ -309,57 +309,6 @@ with Column(gap=2):
 </CodeGroup>
 </ComponentPreview>
 
-## Data Interpolation
-
-All typography components support `{{ field }}` placeholders that are replaced with data at render time:
-
-```python Typography Interpolation
-from prefab_ui.components import (
-    H1,
-    P,
-    Muted,
-)
-
-H1("Welcome, {{ name }}")
-P("You have {{ count }} new notifications.")
-Muted("Member since {{ joined }}")
-```
-
-## Format Specifiers
-
-Add a pipe (`|`) after a field name to format its value. This is useful for displaying numbers as percentages, formatting dates, or applying locale-specific number formatting.
-
-```python Format Examples
-from prefab_ui.components import P, Column
-
-with Column(gap=2):
-    P("Completion: {{ progress | percent }}")       # 0.75 → "75%"
-    P("Completion: {{ progress | percent:1 }}")     # 0.756 → "75.6%"
-    P("Revenue: {{ amount | currency }}")           # 9999.5 → "$9,999.50"
-    P("Users: {{ count | number }}")                # 1234 → "1,234"
-    P("Created: {{ date | date }}")                 # "2025-01-15" → "Jan 15, 2025"
-    P("Created: {{ date | date:long }}")            # → "January 15, 2025"
-    P("Updated: {{ timestamp | datetime }}")        # ISO → "Jan 15, 2025, 2:30 PM"
-```
-
-Available formats:
-
-| Format | Example | Description |
-|--------|---------|-------------|
-| `percent` | `0.75` → `"75%"` | Multiply by 100, add % |
-| `percent:N` | `0.756` → `"75.6%"` | Percent with N decimals |
-| `number` | `1234` → `"1,234"` | Locale-formatted number |
-| `number:N` | `1234` → `"1,234.00"` | Number with N decimals |
-| `currency` | `99.5` → `"$99.50"` | USD currency format |
-| `currency:EUR` | `99.5` → `"€99.50"` | Specified currency |
-| `date` | ISO → `"Jan 15, 2025"` | Medium date |
-| `date:short` | ISO → `"1/15/2025"` | Short date |
-| `date:long` | ISO → `"January 15, 2025"` | Long date |
-| `time` | ISO → `"2:30 PM"` | Time only |
-| `datetime` | ISO → `"Jan 15, 2025, 2:30 PM"` | Date + time |
-| `upper` | `"hello"` → `"HELLO"` | Uppercase |
-| `lower` | `"HELLO"` → `"hello"` | Lowercase |
-
 ## API Reference
 
 <Card icon="code" title="Styled Text Components">
@@ -367,7 +316,7 @@ Available formats:
 `H1`, `H2`, `H3`, `H4`, `P`, `Lead`, `Large`, `Small`, `Muted`, `BlockQuote`, `InlineCode` all share this interface:
 
 <ParamField body="content" type="str" required>
-  Text content. Supports `{{ field }}` and `{{ field | format }}` interpolation. Can be passed as a positional argument.
+  Text content. Can be passed as a positional argument.
 </ParamField>
 
 <ParamField body="bold" type="bool | None" default="None">

--- a/docs/apps/patterns/interpolation.mdx
+++ b/docs/apps/patterns/interpolation.mdx
@@ -1,0 +1,102 @@
+---
+title: Interpolation
+description: Dynamic values in component props using {{ }} templates.
+icon: wand-magic-sparkles
+---
+
+Every string prop on every component supports `{{ }}` template interpolation. When the renderer encounters `{{ key }}` in a string value, it replaces it with the current value of `key` from [state](/apps/components/state). No opt-in required — it works everywhere.
+
+```python
+from prefab_ui.components import Text
+
+Text("Hello, {{ name }}!")
+```
+
+If `name` is `"Trillian"` in state, this renders as "Hello, Trillian!".
+
+## Where Values Come From
+
+Interpolation resolves values from three sources, in priority order:
+
+1. **Local scope** — values provided by [State](/apps/components/state) or [ForEach](/apps/components/foreach) components
+2. **Global state** — values from `AppResult(state={...})`, named form controls, or [SetState](/apps/actions/set-state) actions
+3. **Action context** — `$event` (the triggering value) and `$error` (error messages), available only inside action specs
+
+Named form controls sync to global state automatically. When a user types into `Input(name="city")`, the key `city` updates on every keystroke and any `{{ city }}` reference re-renders instantly.
+
+## Dot Paths
+
+Use dot notation to reach into nested objects:
+
+```python
+from prefab_ui.components import Text
+
+# If state contains { "user": { "address": { "city": "Betelgeuse" } } }
+Text("Located in {{ user.address.city }}")
+```
+
+## Format Specifiers
+
+Add a pipe after the key to format the resolved value:
+
+```python
+from prefab_ui.components import Column, Text
+
+with Column(gap=2):
+    Text("{{ score | percent }}")       # 0.75 → "75%"
+    Text("{{ score | percent:1 }}")     # 0.756 → "75.6%"
+    Text("{{ price | number:2 }}")      # 1234 → "1,234.00"
+    Text("{{ price | currency }}")      # 1234 → "$1,234.00"
+    Text("{{ price | currency:EUR }}")  # 1234 → "€1,234.00"
+    Text("{{ date | date }}")           # ISO string → "Jan 15, 2025"
+    Text("{{ date | date:short }}")     # → "1/15/2025"
+    Text("{{ date | date:long }}")      # → "January 15, 2025"
+    Text("{{ date | time }}")           # → "2:30 PM"
+    Text("{{ date | datetime }}")       # → "Jan 15, 2025, 2:30 PM"
+    Text("{{ name | upper }}")          # "arthur" → "ARTHUR"
+    Text("{{ name | lower }}")          # "ARTHUR" → "arthur"
+```
+
+## Type Preservation
+
+When a template is the *entire* string value, the resolved type is preserved. This matters for props that expect numbers or booleans:
+
+```python
+from prefab_ui.components import Progress
+
+# "{{ volume }}" resolves to the number 75, not the string "75"
+Progress(value="{{ volume }}", max=100)
+```
+
+Mixed templates always produce strings: `"Volume: {{ volume }}%"` → `"Volume: 75%"`.
+
+## Universal Coverage
+
+Interpolation applies to any string in the component tree — labels, placeholders, values, CSS classes, URLs, titles, descriptions, action arguments. A few examples across different components:
+
+```python
+from prefab_ui.components import Button, Badge, Input, Image
+
+Button("View {{ name }}'s profile")
+Badge("{{ status }}", variant="{{ badge_variant }}")
+Input(placeholder="Search {{ category }}...")
+Image(src="{{ avatar_url }}", alt="{{ name }}")
+```
+
+## Scoping with State
+
+The [State](/apps/components/state) component provides local interpolation values to a subtree. Inner values shadow outer ones, and children see the merged context:
+
+```python
+from prefab_ui.components import State, Text, Column
+
+with Column():
+    with State(greeting="Don't Panic", name="Arthur"):
+        Text("{{ greeting }}, {{ name }}")
+        with State(name="Ford"):
+            Text("{{ greeting }}, {{ name }}")
+```
+
+The first `Text` renders "Don't Panic, Arthur". The second renders "Don't Panic, Ford" — the inner `State` shadows `name` but inherits `greeting`.
+
+See the [State](/apps/components/state) and [ForEach](/apps/components/foreach) docs for more on scoping and iteration.

--- a/docs/development/writing-component-docs.mdx
+++ b/docs/development/writing-component-docs.mdx
@@ -84,6 +84,13 @@ Conventions:
 - Use `[ChildType]` to reference other component schemas
 - Required props get `(required)` after the type
 
+## Interpolation
+
+Do **not** add per-field "Supports interpolation" callouts or per-component
+"Data Interpolation" sections. Interpolation is universal — every string
+prop on every component is interpolated automatically. This is documented
+centrally on the [Interpolation](/apps/patterns/interpolation) page.
+
 ## Example Content
 
 Use Hitchhiker's Guide to the Galaxy references for placeholder content

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -26,6 +26,9 @@
       "title": "Not found."
     }
   },
+  "head": [
+    "<script src=\"/renderer-config.js\"></script>"
+  ],
   "footer": {
     "socials": {
       "github": "https://github.com/PrefectHQ/prefab",
@@ -62,7 +65,8 @@
               "apps/patterns/forms",
               "apps/patterns/data-display",
               "apps/patterns/confirmation",
-              "apps/patterns/reusable-components"
+              "apps/patterns/reusable-components",
+              "apps/patterns/interpolation"
             ]
           },
           {


### PR DESCRIPTION
Component docs had accumulated inconsistencies: 9 files used `path` instead of `body` in ParamField, Select and Radio mixed parent/child params into a single Card, Alert had a stray `</Card>` tag, and Label had a heading/prose merge on one line. This fixes all of them and normalizes descriptions across every component API Reference (consistent wording for `disabled`, `css_class`, enum formatting, default values).

The bigger change is interpolation. The renderer interpolates every string prop on every component automatically, but the docs told a different story — `Supports {{ field }} interpolation` callouts appeared on ~15 specific fields across 13 files, implying other fields *don't* support it. This replaces all of that with a single [Interpolation](/apps/patterns/interpolation) page covering value sources, dot paths, format specifiers, type preservation, and scoping with State. The dev guide (`writing-component-docs.mdx`) now documents the rule: no per-field callouts, no per-component Data Interpolation sections.

Also upgraded the State component doc from plain code blocks to full ComponentPreview blocks with Protocol tabs — it was the only component doc with no visible previews.

```python
from prefab_ui.components import Button, Badge, Input, Image

# Interpolation works on every string prop, everywhere
Button("View {{ name }}'s profile")
Badge("{{ status }}", variant="{{ badge_variant }}")
Input(placeholder="Search {{ category }}...")
Image(src="{{ avatar_url }}", alt="{{ name }}")
```