### PR TITLE
Doc consistency, interpolation docs, and dev server port handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ Thumbs.db
 plans/
 
 # Build artifacts
+docs/renderer-config.js
 docs/css/preview.css
 docs/playground.js
 docs/component-bundle.js

--- a/docs/apps/patterns/data-display.mdx
+++ b/docs/apps/patterns/data-display.mdx
@@ -223,7 +223,7 @@ with Tabs(default_value="active"):
 
 Accordions work well when you have many items that benefit from progressive disclosure. Each section collapses to a title, and users expand only the sections they care about.
 
-<ComponentPreview auto json={`{"type":"Accordion","accordionType":"single","collapsible":true,"children":[{"type":"AccordionItem","title":"Section 1","value":"s1","children":[{"type":"Text","content":"Content for section 1"}]},{"type":"AccordionItem","title":"Section 2","value":"s2","children":[{"type":"Text","content":"Content for section 2"}]}]}`}>
+<ComponentPreview auto json={`{"type":"Accordion","multiple":false,"collapsible":true,"children":[{"type":"AccordionItem","title":"Section 1","value":"s1","children":[{"type":"Text","content":"Content for section 1"}]},{"type":"AccordionItem","title":"Section 2","value":"s2","children":[{"type":"Text","content":"Content for section 2"}]}]}`}>
 <CodeGroup>
 ```python Python
 from prefab_ui.components import Accordion, AccordionItem, Text
@@ -237,7 +237,7 @@ with Accordion():
 ```json Protocol
 {
   "type": "Accordion",
-  "accordionType": "single",
+  "multiple": false,
   "collapsible": true,
   "children": [
     {

--- a/docs/apps/playground.mdx
+++ b/docs/apps/playground.mdx
@@ -9,7 +9,7 @@ mode: wide
 The playground is a split-pane editor where you write Python on the left and see the rendered result on the right. Python executes directly in your browser via [Pyodide](https://pyodide.org) — no backend required.
 
 <iframe
-  src="http://localhost:3333/playground.html"
+  src={"http://localhost:" + (typeof window !== "undefined" && window.__PREFAB_RENDERER_PORT__ || 3333) + "/playground.html"}
   style={{ width: "100%", height: "700px", border: "1px solid var(--border-color, #e5e7eb)", borderRadius: "8px" }}
   sandbox="allow-scripts allow-same-origin"
 />

--- a/docs/snippets/component-preview.mdx
+++ b/docs/snippets/component-preview.mdx
@@ -42,7 +42,7 @@ export const ComponentPreview = ({ json, height, children }) => {
       <iframe
         ref={iframeRef}
         data-docpreview
-        src={"http://localhost:3333/renderer.html#docpreview:" + encodeURIComponent(json)}
+        src={"http://localhost:" + (typeof window !== "undefined" && window.__PREFAB_RENDERER_PORT__ || 3333) + "/renderer.html#docpreview:" + encodeURIComponent(json)}
         style={{ width: "100%", height: frameHeight + "px", border: "none", display: "block" }}
       />
       <div style={{ marginBottom: "-2rem" }}>{children}</div>

--- a/docs/styles/style.css
+++ b/docs/styles/style.css
@@ -1,3 +1,18 @@
 #content-area {
   max-width: 48rem !important; /* max-w-3xl instead of max-w-lg */
 }
+
+/* Code highlighting -- target only inline code elements, not code blocks */
+p code:not(pre code),
+table code:not(pre code),
+.prose code:not(pre code),
+li code:not(pre code),
+h1 code:not(pre code),
+h2 code:not(pre code),
+h3 code:not(pre code),
+h4 code:not(pre code),
+h5 code:not(pre code),
+h6 code:not(pre code) {
+  color: #f72585 !important;
+  background-color: rgba(247, 37, 133, 0.09);
+}

--- a/justfile
+++ b/justfile
@@ -27,16 +27,8 @@ renderer:
     cd renderer && npm run dev
 
 # Serve documentation locally (starts renderer dev server automatically)
-docs:
-    #!/usr/bin/env bash
-    set -e
-    cleanup() { kill 0 2>/dev/null; }
-    trap cleanup EXIT INT TERM
-    echo "Starting renderer dev server (localhost:3333)..."
-    (cd renderer && npm run dev) &
-    sleep 2
-    echo "Starting Mintlify docs server..."
-    cd docs && npx --yes mint@latest dev
+docs renderer-port="3333" docs-port="3000":
+    uv run prefab dev docs --renderer-port {{renderer-port}} --docs-port {{docs-port}}
 
 # Regenerate playground bundle.json and examples.json
 playground:

--- a/renderer/vite.config.ts
+++ b/renderer/vite.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
     },
   },
   server: {
-    port: 3333,
+    port: parseInt(process.env.RENDERER_PORT || "3333", 10),
     strictPort: true,
     cors: true,
   },

--- a/src/prefab_ui/cli/cli.py
+++ b/src/prefab_ui/cli/cli.py
@@ -2,8 +2,14 @@
 
 from __future__ import annotations
 
+import errno
 import functools
+import os
+import shutil
+import socket
+import subprocess
 import threading
+import time
 import webbrowser
 from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
@@ -25,10 +31,29 @@ app = cyclopts.App(
 )
 
 
+def _find_repo_root() -> Path:
+    """Locate the repo root relative to this file."""
+    return Path(__file__).parent.parent.parent.parent
+
+
 def _find_dist_dir() -> Path:
     """Locate the renderer dist directory relative to the repo root."""
-    repo_root = Path(__file__).parent.parent.parent.parent
-    return repo_root / "renderer" / "dist"
+    return _find_repo_root() / "renderer" / "dist"
+
+
+def _find_free_port(start: int) -> int:
+    """Return the first available port starting from *start*."""
+    port = start
+    while True:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            try:
+                s.bind(("127.0.0.1", port))
+                return port
+            except OSError as exc:
+                if exc.errno in (errno.EADDRINUSE, errno.EACCES):
+                    port += 1
+                else:
+                    raise
 
 
 @app.command
@@ -100,6 +125,127 @@ def playground(
     except KeyboardInterrupt:
         console.print("\n[yellow]Playground stopped[/yellow]")
         server.shutdown()
+
+
+dev_app = cyclopts.App(
+    name="dev",
+    help="Internal development tools (not user-facing).",
+)
+app.command(dev_app)
+
+
+@dev_app.command
+def docs(
+    *,
+    renderer_port: Annotated[
+        int,
+        cyclopts.Parameter(
+            name="--renderer-port",
+            help="Port for the renderer dev server",
+        ),
+    ] = 3333,
+    docs_port: Annotated[
+        int,
+        cyclopts.Parameter(
+            name="--docs-port",
+            help="Port for the Mintlify docs server",
+        ),
+    ] = 3000,
+) -> None:
+    """Serve documentation locally with live component previews.
+
+    Starts the Vite renderer dev server and the Mintlify docs server.
+    Automatically finds free ports if the requested ones are in use.
+
+    Example:
+        prefab dev docs
+        prefab dev docs --renderer-port 4000 --docs-port 3001
+    """
+    repo_root = _find_repo_root()
+    renderer_dir = repo_root / "renderer"
+    docs_dir = repo_root / "docs"
+
+    if not (renderer_dir / "package.json").is_file():
+        console.print(
+            "[bold red]Error:[/bold red] renderer/ directory not found.\n"
+            "  Run this command from the repo root."
+        )
+        raise SystemExit(1)
+
+    for cmd in ("npm", "npx"):
+        if not shutil.which(cmd):
+            console.print(
+                f"[bold red]Error:[/bold red] [cyan]{cmd}[/cyan] not found. "
+                "Install Node.js to use this command."
+            )
+            raise SystemExit(1)
+
+    actual_renderer_port = _find_free_port(renderer_port)
+    if actual_renderer_port != renderer_port:
+        console.print(
+            f"[yellow]Renderer port {renderer_port} in use, "
+            f"using {actual_renderer_port}[/yellow]"
+        )
+
+    actual_docs_port = _find_free_port(docs_port)
+    if actual_docs_port != docs_port:
+        console.print(
+            f"[yellow]Docs port {docs_port} in use, using {actual_docs_port}[/yellow]"
+        )
+
+    config_path = docs_dir / "renderer-config.js"
+    procs: list[subprocess.Popen[bytes]] = []
+
+    try:
+        config_path.write_text(
+            f"window.__PREFAB_RENDERER_PORT__ = {actual_renderer_port};\n"
+        )
+
+        console.print(
+            f"Starting renderer dev server "
+            f"([cyan]localhost:{actual_renderer_port}[/cyan])..."
+        )
+        renderer_env = {
+            **os.environ,
+            "RENDERER_PORT": str(actual_renderer_port),
+        }
+        procs.append(
+            subprocess.Popen(
+                ["npm", "run", "dev"],
+                cwd=renderer_dir,
+                env=renderer_env,
+            )
+        )
+
+        time.sleep(2)
+
+        console.print(
+            f"Starting Mintlify docs server "
+            f"([cyan]localhost:{actual_docs_port}[/cyan])..."
+        )
+        docs_env = {**os.environ, "PORT": str(actual_docs_port)}
+        procs.append(
+            subprocess.Popen(
+                ["npx", "--yes", "mint@latest", "dev"],
+                cwd=docs_dir,
+                env=docs_env,
+            )
+        )
+
+        while all(p.poll() is None for p in procs):
+            time.sleep(0.5)
+
+    except KeyboardInterrupt:
+        console.print("\n[yellow]Docs servers stopped[/yellow]")
+    finally:
+        config_path.unlink(missing_ok=True)
+        for proc in procs:
+            proc.terminate()
+        for proc in procs:
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                proc.kill()
 
 
 class _SilentHandler(SimpleHTTPRequestHandler):


### PR DESCRIPTION
Component docs had inconsistent patterns for interpolation examples — some pages had their own "Dynamic Content" or "Interpolation" sections, others didn't mention it at all. This centralizes interpolation into a dedicated patterns page and removes the scattered per-component versions, keeping component docs focused on their own API surface.

Also adds `prefab dev docs` to the CLI, which orchestrates the Vite renderer and Mintlify docs servers with automatic free-port detection:

```bash
prefab dev docs
prefab dev docs --renderer-port 4000 --docs-port 3001
```

Previously `just docs` would crash if port 3333 was taken. Now both servers gracefully find free ports, and the renderer port is propagated to the doc previews via a generated `renderer-config.js`.

Other fixes: inline code highlighting in docs CSS, accordion `accordionType` → `multiple` in data-display pattern.