### PR TITLE
Upgrade thin component docs and remove per-field interpolation callouts

### DIFF
--- a/docs/apps/components/badge.mdx
+++ b/docs/apps/components/badge.mdx
@@ -10,17 +10,17 @@ Badges are small, pill-shaped labels for status indicators, counts, and categori
 
 ## Basic Usage
 
-<ComponentPreview auto json={`{"type":"Badge","label":"New Feature","variant":"default"}`}>
+<ComponentPreview auto json={`{"type":"Badge","label":"Mostly Harmless","variant":"default"}`}>
 <CodeGroup>
 ```python Python
 from prefab_ui.components import Badge
 
-Badge("New Feature")
+Badge("Mostly Harmless")
 ```
 ```json Protocol
 {
   "type": "Badge",
-  "label": "New Feature",
+  "label": "Mostly Harmless",
   "variant": "default"
 }
 ```
@@ -102,6 +102,108 @@ with Column(gap=3):
           "type": "Badge",
           "label": "Info",
           "variant": "info"
+        }
+      ]
+    }
+  ]
+}
+```
+</CodeGroup>
+</ComponentPreview>
+
+## In Context
+
+Badges pair well with cards and other layout components as inline status indicators:
+
+<ComponentPreview auto json={`{"type":"Column","gap":3,"children":[{"type":"Card","children":[{"type":"CardHeader","children":[{"cssClass":"items-center","type":"Row","gap":2,"children":[{"type":"CardTitle","content":"Heart of Gold"},{"type":"Badge","label":"Online","variant":"success"}]},{"type":"CardDescription","content":"Infinite Improbability Drive engaged"}]}]},{"type":"Card","children":[{"type":"CardHeader","children":[{"cssClass":"items-center","type":"Row","gap":2,"children":[{"type":"CardTitle","content":"Vogon Fleet"},{"type":"Badge","label":"Approaching","variant":"warning"}]},{"type":"CardDescription","content":"Demolition order filed with local planning authority"}]}]}]}`}>
+<CodeGroup>
+```python Python
+from prefab_ui.components import (
+    Badge,
+    Card,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+    Column,
+    Row,
+)
+
+with Column(gap=3):
+    with Card():
+        with CardHeader():
+            with Row(gap=2, css_class="items-center"):
+                CardTitle("Heart of Gold")
+                Badge("Online", variant="success")
+            CardDescription("Infinite Improbability Drive engaged")
+    with Card():
+        with CardHeader():
+            with Row(gap=2, css_class="items-center"):
+                CardTitle("Vogon Fleet")
+                Badge("Approaching", variant="warning")
+            CardDescription("Demolition order filed with local planning authority")
+```
+```json Protocol
+{
+  "type": "Column",
+  "gap": 3,
+  "children": [
+    {
+      "type": "Card",
+      "children": [
+        {
+          "type": "CardHeader",
+          "children": [
+            {
+              "cssClass": "items-center",
+              "type": "Row",
+              "gap": 2,
+              "children": [
+                {
+                  "type": "CardTitle",
+                  "content": "Heart of Gold"
+                },
+                {
+                  "type": "Badge",
+                  "label": "Online",
+                  "variant": "success"
+                }
+              ]
+            },
+            {
+              "type": "CardDescription",
+              "content": "Infinite Improbability Drive engaged"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "Card",
+      "children": [
+        {
+          "type": "CardHeader",
+          "children": [
+            {
+              "cssClass": "items-center",
+              "type": "Row",
+              "gap": 2,
+              "children": [
+                {
+                  "type": "CardTitle",
+                  "content": "Vogon Fleet"
+                },
+                {
+                  "type": "Badge",
+                  "label": "Approaching",
+                  "variant": "warning"
+                }
+              ]
+            },
+            {
+              "type": "CardDescription",
+              "content": "Demolition order filed with local planning authority"
+            }
+          ]
         }
       ]
     }

--- a/docs/apps/components/code.mdx
+++ b/docs/apps/components/code.mdx
@@ -10,25 +10,22 @@ Code blocks display source code or configuration with automatic syntax highlight
 
 ## Basic Usage
 
-<ComponentPreview auto json={`{"type":"Code","content":"def greet(name: str) -> str:\\n    \\"\\"\\"Return a greeting message.\\"\\"\\"\\n    return f\\"Hello, {name}!\\"\\n\\n# Call the function\\nmessage = greet(\\"World\\")\\nprint(message)","language":"python"}`}>
+<ComponentPreview auto json={`{"type":"Code","content":"def answer() -> int:\\n    \\"\\"\\"Return the Answer to the Ultimate Question\\n    of Life, the Universe, and Everything.\\"\\"\\"\\n    return 42","language":"python"}`}>
 <CodeGroup>
 ```python Python
 from prefab_ui.components import Code
 
 Code("""
-def greet(name: str) -> str:
-    \"\"\"Return a greeting message.\"\"\"
-    return f"Hello, {name}!"
-
-# Call the function
-message = greet("World")
-print(message)
+def answer() -> int:
+    \"\"\"Return the Answer to the Ultimate Question
+    of Life, the Universe, and Everything.\"\"\"
+    return 42
 """.strip(), language="python")
 ```
 ```json Protocol
 {
   "type": "Code",
-  "content": "def greet(name: str) -> str:\n    \"\"\"Return a greeting message.\"\"\"\n    return f\"Hello, {name}!\"\n\n# Call the function\nmessage = greet(\"World\")\nprint(message)",
+  "content": "def answer() -> int:\n    \"\"\"Return the Answer to the Ultimate Question\n    of Life, the Universe, and Everything.\"\"\"\n    return 42",
   "language": "python"
 }
 ```
@@ -37,15 +34,20 @@ print(message)
 
 ## Multiple Languages
 
-<ComponentPreview auto json={`{"type":"Column","gap":3,"children":[{"type":"Code","content":"pip install prefab-ui","language":"bash"},{"type":"Code","content":"SELECT * FROM users WHERE active = true;","language":"sql"},{"type":"Code","content":"{ \\"name\\": \\"prefab-ui\\", \\"version\\": \\"2.0\\" }","language":"json"}]}`}>
+<ComponentPreview auto json={`{"type":"Column","gap":3,"children":[{"type":"Code","content":"pip install prefab-ui","language":"bash"},{"type":"Code","content":"SELECT name, designation\\nFROM crew\\nWHERE ship = 'Heart of Gold';","language":"sql"},{"type":"Code","content":"{ \\"ship\\": \\"Heart of Gold\\", \\"drive\\": \\"Infinite Improbability\\" }","language":"json"}]}`}>
 <CodeGroup>
 ```python Python
 from prefab_ui.components import Code, Column
 
 with Column(gap=3):
     Code("pip install prefab-ui", language="bash")
-    Code("SELECT * FROM users WHERE active = true;", language="sql")
-    Code('{ "name": "prefab-ui", "version": "2.0" }', language="json")
+    Code(
+        "SELECT name, designation\n"
+        "FROM crew\n"
+        "WHERE ship = 'Heart of Gold';",
+        language="sql",
+    )
+    Code('{ "ship": "Heart of Gold", "drive": "Infinite Improbability" }', language="json")
 ```
 ```json Protocol
 {
@@ -59,12 +61,12 @@ with Column(gap=3):
     },
     {
       "type": "Code",
-      "content": "SELECT * FROM users WHERE active = true;",
+      "content": "SELECT name, designation\nFROM crew\nWHERE ship = 'Heart of Gold';",
       "language": "sql"
     },
     {
       "type": "Code",
-      "content": "{ \"name\": \"prefab-ui\", \"version\": \"2.0\" }",
+      "content": "{ \"ship\": \"Heart of Gold\", \"drive\": \"Infinite Improbability\" }",
       "language": "json"
     }
   ]
@@ -72,6 +74,16 @@ with Column(gap=3):
 ```
 </CodeGroup>
 </ComponentPreview>
+
+## Dynamic Content
+
+Code content supports [interpolation](/apps/patterns/interpolation), so you can display server-generated output:
+
+```python
+from prefab_ui.components import Code
+
+Code("{{ query_result }}", language="sql")
+```
 
 ## API Reference
 

--- a/docs/apps/components/dialog.mdx
+++ b/docs/apps/components/dialog.mdx
@@ -10,7 +10,7 @@ Dialogs display content in a modal overlay that focuses user attention. Like Pop
 
 ## Basic Usage
 
-<ComponentPreview auto json={`{"type":"Dialog","title":"Edit Profile","description":"Make changes to your profile here. Click save when you're done.","children":[{"type":"Button","label":"Edit Profile","variant":"outline","size":"default","disabled":false},{"type":"Column","gap":3,"children":[{"type":"Label","text":"Name"},{"type":"Input","inputType":"text","placeholder":"Your name","name":"dialogName","disabled":false,"required":false},{"type":"Label","text":"Username"},{"type":"Input","inputType":"text","placeholder":"@username","name":"dialogUsername","disabled":false,"required":false}]},{"cssClass":"justify-end","type":"Row","gap":2,"children":[{"type":"Button","label":"Save changes","variant":"default","size":"default","disabled":false}]}]}`}>
+<ComponentPreview auto height="400px" json={`{"type":"Dialog","title":"Crew Profile","description":"Update your details for the Heart of Gold crew manifest.","children":[{"type":"Button","label":"Edit Profile","variant":"outline","size":"default","disabled":false},{"type":"Column","gap":3,"children":[{"type":"Label","text":"Name"},{"type":"Input","inputType":"text","placeholder":"Arthur Dent","name":"crewName","disabled":false,"required":false},{"type":"Label","text":"Designation"},{"type":"Input","inputType":"text","placeholder":"Sandwich Maker","name":"crewDesignation","disabled":false,"required":false}]},{"cssClass":"justify-end","type":"Row","gap":2,"children":[{"type":"Button","label":"Save changes","variant":"default","size":"default","disabled":false}]}]}`}>
 <CodeGroup>
 ```python Python
 from prefab_ui.components import (
@@ -23,23 +23,23 @@ from prefab_ui.components import (
 )
 
 with Dialog(
-    title="Edit Profile",
-    description="Make changes to your profile here. Click save when you're done.",
+    title="Crew Profile",
+    description="Update your details for the Heart of Gold crew manifest.",
 ):
     Button("Edit Profile", variant="outline")
     with Column(gap=3):
         Label("Name")
-        Input(name="dialogName", placeholder="Your name")
-        Label("Username")
-        Input(name="dialogUsername", placeholder="@username")
+        Input(name="crewName", placeholder="Arthur Dent")
+        Label("Designation")
+        Input(name="crewDesignation", placeholder="Sandwich Maker")
     with Row(gap=2, css_class="justify-end"):
         Button("Save changes")
 ```
 ```json Protocol
 {
   "type": "Dialog",
-  "title": "Edit Profile",
-  "description": "Make changes to your profile here. Click save when you're done.",
+  "title": "Crew Profile",
+  "description": "Update your details for the Heart of Gold crew manifest.",
   "children": [
     {
       "type": "Button",
@@ -59,20 +59,20 @@ with Dialog(
         {
           "type": "Input",
           "inputType": "text",
-          "placeholder": "Your name",
-          "name": "dialogName",
+          "placeholder": "Arthur Dent",
+          "name": "crewName",
           "disabled": false,
           "required": false
         },
         {
           "type": "Label",
-          "text": "Username"
+          "text": "Designation"
         },
         {
           "type": "Input",
           "inputType": "text",
-          "placeholder": "@username",
-          "name": "dialogUsername",
+          "placeholder": "Sandwich Maker",
+          "name": "crewDesignation",
           "disabled": false,
           "required": false
         }
@@ -100,26 +100,69 @@ with Dialog(
 
 ## Confirmation Pattern
 
-Dialogs work well for destructive actions that need explicit confirmation.
+Dialogs work well for destructive actions that need explicit confirmation before proceeding.
 
-```python Dialog Confirmation
+<ComponentPreview auto height="360px" json={`{"type":"Dialog","title":"Activate Improbability Drive","description":"This action cannot be undone.","children":[{"type":"Button","label":"Engage Drive","variant":"destructive","size":"default","disabled":false},{"type":"Text","content":"Are you sure? The last time this was engaged, a sperm whale and a bowl of petunias materialized in mid-air."},{"cssClass":"justify-end","type":"Row","gap":2,"children":[{"type":"Button","label":"Cancel","variant":"outline","size":"default","disabled":false},{"type":"Button","label":"Engage","variant":"destructive","size":"default","disabled":false}]}]}`}>
+<CodeGroup>
+```python Python
 from prefab_ui.components import Button, Dialog, Row, Text
-from prefab_ui.actions import ToolCall
 
 with Dialog(
-    title="Delete Item",
+    title="Activate Improbability Drive",
     description="This action cannot be undone.",
 ):
-    Button("Delete", variant="destructive")
-    Text("Are you sure you want to permanently delete this item?")
+    Button("Engage Drive", variant="destructive")
+    Text(
+        "Are you sure? The last time this was engaged, "
+        "a sperm whale and a bowl of petunias materialized in mid-air."
+    )
     with Row(gap=2, css_class="justify-end"):
         Button("Cancel", variant="outline")
-        Button(
-            "Delete",
-            variant="destructive",
-            on_click=ToolCall("delete_item"),
-        )
+        Button("Engage", variant="destructive")
 ```
+```json Protocol
+{
+  "type": "Dialog",
+  "title": "Activate Improbability Drive",
+  "description": "This action cannot be undone.",
+  "children": [
+    {
+      "type": "Button",
+      "label": "Engage Drive",
+      "variant": "destructive",
+      "size": "default",
+      "disabled": false
+    },
+    {
+      "type": "Text",
+      "content": "Are you sure? The last time this was engaged, a sperm whale and a bowl of petunias materialized in mid-air."
+    },
+    {
+      "cssClass": "justify-end",
+      "type": "Row",
+      "gap": 2,
+      "children": [
+        {
+          "type": "Button",
+          "label": "Cancel",
+          "variant": "outline",
+          "size": "default",
+          "disabled": false
+        },
+        {
+          "type": "Button",
+          "label": "Engage",
+          "variant": "destructive",
+          "size": "default",
+          "disabled": false
+        }
+      ]
+    }
+  ]
+}
+```
+</CodeGroup>
+</ComponentPreview>
 
 ## API Reference
 

--- a/docs/apps/components/foreach.mdx
+++ b/docs/apps/components/foreach.mdx
@@ -10,7 +10,7 @@ import { ComponentPreview } from '/snippets/component-preview.mdx'
 
 ## Basic Usage
 
-<ComponentPreview auto json={`{"_tree":{"type":"ForEach","key":"users","children":[{"type":"Card","children":[{"type":"CardHeader","children":[{"cssClass":"items-center","type":"Row","gap":2,"children":[{"type":"CardTitle","content":"{{ name }}"},{"type":"Badge","label":"{{ role }}","variant":"secondary"}]},{"type":"CardDescription","content":"{{ email }}"}]}]}]},"users":[{"name":"Alice","role":"Admin","email":"alice@example.com"},{"name":"Bob","role":"Editor","email":"bob@example.com"},{"name":"Carol","role":"Viewer","email":"carol@example.com"}]}`}>
+<ComponentPreview auto json={`{"_tree":{"type":"ForEach","key":"crew","children":[{"type":"Card","children":[{"type":"CardHeader","children":[{"cssClass":"items-center","type":"Row","gap":2,"children":[{"type":"CardTitle","content":"{{ name }}"},{"type":"Badge","label":"{{ designation }}","variant":"secondary"}]},{"type":"CardDescription","content":"{{ email }}"}]}]}]},"crew":[{"name":"Arthur Dent","designation":"Sandwich Maker","email":"arthur@heart-of-gold.ship"},{"name":"Ford Prefect","designation":"Researcher","email":"ford@megadodo.pub"},{"name":"Trillian","designation":"Astrophysicist","email":"trillian@heart-of-gold.ship"}]}`}>
 <CodeGroup>
 ```python Python
 from prefab_ui.components import (
@@ -23,25 +23,25 @@ from prefab_ui.components import (
     Row,
 )
 
-set_data(users=[
-    {"name": "Alice", "role": "Admin", "email": "alice@example.com"},
-    {"name": "Bob", "role": "Editor", "email": "bob@example.com"},
-    {"name": "Carol", "role": "Viewer", "email": "carol@example.com"},
+set_data(crew=[
+    {"name": "Arthur Dent", "designation": "Sandwich Maker", "email": "arthur@heart-of-gold.ship"},
+    {"name": "Ford Prefect", "designation": "Researcher", "email": "ford@megadodo.pub"},
+    {"name": "Trillian", "designation": "Astrophysicist", "email": "trillian@heart-of-gold.ship"},
 ])
 
-with ForEach("users"):
+with ForEach("crew"):
     with Card():
         with CardHeader():
             with Row(gap=2, css_class="items-center"):
                 CardTitle("{{ name }}")
-                Badge("{{ role }}", variant="secondary")
+                Badge("{{ designation }}", variant="secondary")
             CardDescription("{{ email }}")
 ```
 ```json Protocol
 {
   "_tree": {
     "type": "ForEach",
-    "key": "users",
+    "key": "crew",
     "children": [
       {
         "type": "Card",
@@ -60,7 +60,7 @@ with ForEach("users"):
                   },
                   {
                     "type": "Badge",
-                    "label": "{{ role }}",
+                    "label": "{{ designation }}",
                     "variant": "secondary"
                   }
                 ]
@@ -75,21 +75,21 @@ with ForEach("users"):
       }
     ]
   },
-  "users": [
+  "crew": [
     {
-      "name": "Alice",
-      "role": "Admin",
-      "email": "alice@example.com"
+      "name": "Arthur Dent",
+      "designation": "Sandwich Maker",
+      "email": "arthur@heart-of-gold.ship"
     },
     {
-      "name": "Bob",
-      "role": "Editor",
-      "email": "bob@example.com"
+      "name": "Ford Prefect",
+      "designation": "Researcher",
+      "email": "ford@megadodo.pub"
     },
     {
-      "name": "Carol",
-      "role": "Viewer",
-      "email": "carol@example.com"
+      "name": "Trillian",
+      "designation": "Astrophysicist",
+      "email": "trillian@heart-of-gold.ship"
     }
   ]
 }
@@ -97,13 +97,13 @@ with ForEach("users"):
 </CodeGroup>
 </ComponentPreview>
 
-When rendered with data like `{"users": [{"name": "Alice", ...}, ...]}`, this produces one card per user.
+When rendered with the data above, this produces one card per crew member.
 
 ## How It Works
 
 The `key` argument (passed positionally or as a keyword) names the field in the data dict that contains the list. At render time, `ForEach` iterates that list. If each item is a dict, its keys become the interpolation context for that iteration. If an item is a scalar, it's available as `{{ _item }}`.
 
-<ComponentPreview auto json={`{"_tree":{"type":"Row","gap":2,"children":[{"type":"ForEach","key":"tags","children":[{"type":"Badge","label":"{{ _item }}","variant":"secondary"}]}]},"tags":["python","mcp","prefab-ui","async"]}`}>
+<ComponentPreview auto json={`{"_tree":{"type":"Row","gap":2,"children":[{"type":"ForEach","key":"tags","children":[{"type":"Badge","label":"{{ _item }}","variant":"secondary"}]}]},"tags":["earth","magrathea","vogon poetry","42"]}`}>
 <CodeGroup>
 ```python Python
 from prefab_ui.components import (
@@ -112,7 +112,7 @@ from prefab_ui.components import (
     Row,
 )
 
-set_data(tags=["python", "mcp", "prefab-ui", "async"])
+set_data(tags=["earth", "magrathea", "vogon poetry", "42"])
 
 with Row(gap=2):
     with ForEach("tags"):
@@ -138,17 +138,17 @@ with Row(gap=2):
     ]
   },
   "tags": [
-    "python",
-    "mcp",
-    "prefab-ui",
-    "async"
+    "earth",
+    "magrathea",
+    "vogon poetry",
+    "42"
   ]
 }
 ```
 </CodeGroup>
 </ComponentPreview>
 
-With `{"tags": ["python", "mcp", "prefab-ui", "async"]}`, this renders one badge per item.
+With `{"tags": ["earth", "magrathea", "vogon poetry", "42"]}`, this renders one badge per item.
 
 ## Nested Data
 

--- a/docs/apps/components/pages.mdx
+++ b/docs/apps/components/pages.mdx
@@ -10,37 +10,303 @@ Pages provide a multi-page layout where only the active page renders. Navigate b
 
 ## Basic Usage
 
-```python Pages Example
+<ComponentPreview auto json={`{"type":"Column","gap":4,"children":[{"type":"Row","gap":2,"children":[{"type":"Button","label":"Earth","variant":"default","size":"default","disabled":false,"onClick":{"action":"setState","key":"entry","value":"earth"}},{"type":"Button","label":"Magrathea","variant":"outline","size":"default","disabled":false,"onClick":{"action":"setState","key":"entry","value":"magrathea"}},{"type":"Button","label":"Milliways","variant":"outline","size":"default","disabled":false,"onClick":{"action":"setState","key":"entry","value":"milliways"}}]},{"type":"Pages","defaultValue":"earth","name":"entry","children":[{"type":"Page","title":"Earth","value":"earth","children":[{"type":"Card","children":[{"type":"CardHeader","children":[{"type":"CardTitle","content":"Earth"},{"type":"CardDescription","content":"Mostly harmless."}]}]}]},{"type":"Page","title":"Magrathea","value":"magrathea","children":[{"type":"Card","children":[{"type":"CardHeader","children":[{"type":"CardTitle","content":"Magrathea"},{"type":"CardDescription","content":"Ancient planet-building civilization. Custom-built luxury planets for the ultra-rich."}]}]}]},{"type":"Page","title":"Milliways","value":"milliways","children":[{"type":"Card","children":[{"type":"CardHeader","children":[{"type":"CardTitle","content":"Milliways"},{"type":"CardDescription","content":"The Restaurant at the End of the Universe. Reservations recommended."}]}]}]}]}]}`}>
+<CodeGroup>
+```python Python
 from prefab_ui.components import (
     Button,
+    Card,
+    CardDescription,
+    CardHeader,
+    CardTitle,
     Column,
-    H2,
     Page,
     Pages,
     Row,
-    Text,
 )
 from prefab_ui.actions import SetState
 
 with Column(gap=4):
     with Row(gap=2):
-        Button("Home", on_click=SetState("page", "home"))
-        Button("Settings", variant="outline", on_click=SetState("page", "settings"))
-        Button("Profile", variant="outline", on_click=SetState("page", "profile"))
+        Button("Earth", on_click=SetState("entry", "earth"))
+        Button("Magrathea", variant="outline", on_click=SetState("entry", "magrathea"))
+        Button("Milliways", variant="outline", on_click=SetState("entry", "milliways"))
 
-    with Pages(name="page", default_value="home"):
-        with Page("Home", value="home"):
-            H2("Welcome Home")
-            Text("This is the main content area.")
-        with Page("Settings", value="settings"):
-            H2("Settings")
-            Text("Configuration options go here.")
-        with Page("Profile", value="profile"):
-            H2("Your Profile")
-            Text("Profile details go here.")
+    with Pages(name="entry", default_value="earth"):
+        with Page("Earth", value="earth"):
+            with Card():
+                with CardHeader():
+                    CardTitle("Earth")
+                    CardDescription("Mostly harmless.")
+        with Page("Magrathea", value="magrathea"):
+            with Card():
+                with CardHeader():
+                    CardTitle("Magrathea")
+                    CardDescription(
+                        "Ancient planet-building civilization. "
+                        "Custom-built luxury planets for the ultra-rich."
+                    )
+        with Page("Milliways", value="milliways"):
+            with Card():
+                with CardHeader():
+                    CardTitle("Milliways")
+                    CardDescription(
+                        "The Restaurant at the End of the Universe. "
+                        "Reservations recommended."
+                    )
 ```
+```json Protocol
+{
+  "type": "Column",
+  "gap": 4,
+  "children": [
+    {
+      "type": "Row",
+      "gap": 2,
+      "children": [
+        {
+          "type": "Button",
+          "label": "Earth",
+          "variant": "default",
+          "size": "default",
+          "disabled": false,
+          "onClick": {
+            "action": "setState",
+            "key": "entry",
+            "value": "earth"
+          }
+        },
+        {
+          "type": "Button",
+          "label": "Magrathea",
+          "variant": "outline",
+          "size": "default",
+          "disabled": false,
+          "onClick": {
+            "action": "setState",
+            "key": "entry",
+            "value": "magrathea"
+          }
+        },
+        {
+          "type": "Button",
+          "label": "Milliways",
+          "variant": "outline",
+          "size": "default",
+          "disabled": false,
+          "onClick": {
+            "action": "setState",
+            "key": "entry",
+            "value": "milliways"
+          }
+        }
+      ]
+    },
+    {
+      "type": "Pages",
+      "defaultValue": "earth",
+      "name": "entry",
+      "children": [
+        {
+          "type": "Page",
+          "title": "Earth",
+          "value": "earth",
+          "children": [
+            {
+              "type": "Card",
+              "children": [
+                {
+                  "type": "CardHeader",
+                  "children": [
+                    {
+                      "type": "CardTitle",
+                      "content": "Earth"
+                    },
+                    {
+                      "type": "CardDescription",
+                      "content": "Mostly harmless."
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Page",
+          "title": "Magrathea",
+          "value": "magrathea",
+          "children": [
+            {
+              "type": "Card",
+              "children": [
+                {
+                  "type": "CardHeader",
+                  "children": [
+                    {
+                      "type": "CardTitle",
+                      "content": "Magrathea"
+                    },
+                    {
+                      "type": "CardDescription",
+                      "content": "Ancient planet-building civilization. Custom-built luxury planets for the ultra-rich."
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Page",
+          "title": "Milliways",
+          "value": "milliways",
+          "children": [
+            {
+              "type": "Card",
+              "children": [
+                {
+                  "type": "CardHeader",
+                  "children": [
+                    {
+                      "type": "CardTitle",
+                      "content": "Milliways"
+                    },
+                    {
+                      "type": "CardDescription",
+                      "content": "The Restaurant at the End of the Universe. Reservations recommended."
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+</CodeGroup>
+</ComponentPreview>
 
-The `name` prop connects the Pages component to client state. When `page` changes (via `SetState`), the corresponding page renders. This makes Pages ideal for wizard flows, multi-step forms, or any layout where you want to swap entire sections without a server round-trip.
+The `name` prop connects the Pages component to client state. When the `entry` key changes (via `SetState`), the corresponding page renders. This makes Pages ideal for wizard flows, multi-step forms, or any layout where you want to swap entire sections without a server round-trip.
+
+## Step-by-Step Navigation
+
+Pages pair naturally with `SetState` to build wizard flows. Each page's button advances to the next step:
+
+<ComponentPreview auto json={`{"type":"Column","gap":4,"children":[{"type":"Pages","defaultValue":"setup","name":"step","children":[{"type":"Page","title":"Setup","value":"setup","children":[{"type":"Text","content":"Configure your settings."},{"type":"Button","label":"Next","variant":"default","size":"default","disabled":false,"onClick":{"action":"setState","key":"step","value":"review"}}]},{"type":"Page","title":"Review","value":"review","children":[{"type":"Text","content":"Review your choices."},{"cssClass":"gap-2","type":"Row","children":[{"type":"Button","label":"Back","variant":"outline","size":"default","disabled":false,"onClick":{"action":"setState","key":"step","value":"setup"}},{"type":"Button","label":"Next","variant":"default","size":"default","disabled":false,"onClick":{"action":"setState","key":"step","value":"complete"}}]}]},{"type":"Page","title":"Complete","value":"complete","children":[{"type":"Text","content":"All done!"}]}]}]}`}>
+<CodeGroup>
+```python Python
+from prefab_ui.components import Button, Column, Page, Pages, Row, Text
+from prefab_ui.actions import SetState
+
+with Column(gap=4):
+    with Pages(name="step", default_value="setup"):
+        with Page("Setup", value="setup"):
+            Text("Configure your settings.")
+            Button("Next", on_click=SetState("step", "review"))
+        with Page("Review", value="review"):
+            Text("Review your choices.")
+            with Row(css_class="gap-2"):
+                Button("Back", variant="outline", on_click=SetState("step", "setup"))
+                Button("Next", on_click=SetState("step", "complete"))
+        with Page("Complete", value="complete"):
+            Text("All done!")
+```
+```json Protocol
+{
+  "type": "Column",
+  "gap": 4,
+  "children": [
+    {
+      "type": "Pages",
+      "defaultValue": "setup",
+      "name": "step",
+      "children": [
+        {
+          "type": "Page",
+          "title": "Setup",
+          "value": "setup",
+          "children": [
+            {
+              "type": "Text",
+              "content": "Configure your settings."
+            },
+            {
+              "type": "Button",
+              "label": "Next",
+              "variant": "default",
+              "size": "default",
+              "disabled": false,
+              "onClick": {
+                "action": "setState",
+                "key": "step",
+                "value": "review"
+              }
+            }
+          ]
+        },
+        {
+          "type": "Page",
+          "title": "Review",
+          "value": "review",
+          "children": [
+            {
+              "type": "Text",
+              "content": "Review your choices."
+            },
+            {
+              "cssClass": "gap-2",
+              "type": "Row",
+              "children": [
+                {
+                  "type": "Button",
+                  "label": "Back",
+                  "variant": "outline",
+                  "size": "default",
+                  "disabled": false,
+                  "onClick": {
+                    "action": "setState",
+                    "key": "step",
+                    "value": "setup"
+                  }
+                },
+                {
+                  "type": "Button",
+                  "label": "Next",
+                  "variant": "default",
+                  "size": "default",
+                  "disabled": false,
+                  "onClick": {
+                    "action": "setState",
+                    "key": "step",
+                    "value": "complete"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Page",
+          "title": "Complete",
+          "value": "complete",
+          "children": [
+            {
+              "type": "Text",
+              "content": "All done!"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+</CodeGroup>
+</ComponentPreview>
 
 ## API Reference
 
@@ -50,7 +316,7 @@ The `name` prop connects the Pages component to client state. When `page` change
 </ParamField>
 
 <ParamField body="name" type="str | None" default="None">
-  State key for tracking the active page. Other components can read `$state[name]` or write with `SetState`.
+  State key for tracking the active page. Other components can write to this key with `SetState`.
 </ParamField>
 
 <ParamField body="css_class" type="str | None" default="None">

--- a/docs/apps/components/popover.mdx
+++ b/docs/apps/components/popover.mdx
@@ -10,7 +10,7 @@ Popovers display rich content in a floating panel when users click a trigger ele
 
 ## Basic Usage
 
-<ComponentPreview auto height="340px" json={`{"type":"Popover","title":"Dimensions","description":"Set the dimensions for the layer.","children":[{"type":"Button","label":"Open popover","variant":"outline","size":"default","disabled":false},{"type":"Column","gap":3,"children":[{"type":"Label","text":"Width"},{"type":"Input","inputType":"text","placeholder":"100%","name":"width","disabled":false,"required":false},{"type":"Label","text":"Height"},{"type":"Input","inputType":"text","placeholder":"25px","name":"height","disabled":false,"required":false}]}]}`}>
+<ComponentPreview auto height="340px" json={`{"type":"Popover","title":"Babel Fish Settings","description":"Configure your universal translator.","children":[{"type":"Button","label":"Open popover","variant":"outline","size":"default","disabled":false},{"type":"Column","gap":3,"children":[{"type":"Label","text":"Source Language"},{"type":"Input","inputType":"text","placeholder":"Vogon","name":"sourceLang","disabled":false,"required":false},{"type":"Label","text":"Target Language"},{"type":"Input","inputType":"text","placeholder":"Galactic Standard","name":"targetLang","disabled":false,"required":false}]}]}`}>
 <CodeGroup>
 ```python Python
 from prefab_ui.components import (
@@ -21,19 +21,19 @@ from prefab_ui.components import (
     Popover,
 )
 
-with Popover(title="Dimensions", description="Set the dimensions for the layer."):
+with Popover(title="Babel Fish Settings", description="Configure your universal translator."):
     Button("Open popover", variant="outline")
     with Column(gap=3):
-        Label("Width")
-        Input(name="width", placeholder="100%")
-        Label("Height")
-        Input(name="height", placeholder="25px")
+        Label("Source Language")
+        Input(name="sourceLang", placeholder="Vogon")
+        Label("Target Language")
+        Input(name="targetLang", placeholder="Galactic Standard")
 ```
 ```json Protocol
 {
   "type": "Popover",
-  "title": "Dimensions",
-  "description": "Set the dimensions for the layer.",
+  "title": "Babel Fish Settings",
+  "description": "Configure your universal translator.",
   "children": [
     {
       "type": "Button",
@@ -48,25 +48,25 @@ with Popover(title="Dimensions", description="Set the dimensions for the layer."
       "children": [
         {
           "type": "Label",
-          "text": "Width"
+          "text": "Source Language"
         },
         {
           "type": "Input",
           "inputType": "text",
-          "placeholder": "100%",
-          "name": "width",
+          "placeholder": "Vogon",
+          "name": "sourceLang",
           "disabled": false,
           "required": false
         },
         {
           "type": "Label",
-          "text": "Height"
+          "text": "Target Language"
         },
         {
           "type": "Input",
           "inputType": "text",
-          "placeholder": "25px",
-          "name": "height",
+          "placeholder": "Galactic Standard",
+          "name": "targetLang",
           "disabled": false,
           "required": false
         }
@@ -82,7 +82,7 @@ with Popover(title="Dimensions", description="Set the dimensions for the layer."
 
 Skip the `title` and `description` to render content directly in the panel.
 
-<ComponentPreview auto height="260px" json={`{"type":"Popover","children":[{"type":"Button","label":"Settings","variant":"outline","size":"default","disabled":false},{"type":"Column","gap":3,"children":[{"type":"Label","text":"Volume"},{"type":"Slider","min":0.0,"max":100.0,"value":50.0,"name":"volume","disabled":false}]}]}`}>
+<ComponentPreview auto height="260px" json={`{"type":"Popover","children":[{"type":"Button","label":"Settings","variant":"outline","size":"default","disabled":false},{"type":"Column","gap":3,"children":[{"type":"Label","text":"Improbability Factor"},{"type":"Slider","min":0.0,"max":100.0,"value":42.0,"name":"improbability","disabled":false}]}]}`}>
 <CodeGroup>
 ```python Python
 from prefab_ui.components import (
@@ -96,8 +96,8 @@ from prefab_ui.components import (
 with Popover():
     Button("Settings", variant="outline")
     with Column(gap=3):
-        Label("Volume")
-        Slider(min=0, max=100, value=50, name="volume")
+        Label("Improbability Factor")
+        Slider(min=0, max=100, value=42, name="improbability")
 ```
 ```json Protocol
 {
@@ -116,14 +116,14 @@ with Popover():
       "children": [
         {
           "type": "Label",
-          "text": "Volume"
+          "text": "Improbability Factor"
         },
         {
           "type": "Slider",
           "min": 0.0,
           "max": 100.0,
-          "value": 50.0,
-          "name": "volume",
+          "value": 42.0,
+          "name": "improbability",
           "disabled": false
         }
       ]
@@ -133,6 +133,20 @@ with Popover():
 ```
 </CodeGroup>
 </ComponentPreview>
+
+## Positioning
+
+Control which side the panel appears on with the `side` prop:
+
+```python
+from prefab_ui.components import Button, Popover, Text
+
+with Popover(title="Guide Entry", side="right"):
+    Button("Hover for info", variant="outline")
+    Text("A towel is about the most massively useful thing an interstellar hitchhiker can have.")
+```
+
+The renderer auto-adjusts if the popover would overflow the viewport, so the `side` is a preference rather than a hard constraint.
 
 ## API Reference
 
@@ -146,7 +160,7 @@ with Popover():
 </ParamField>
 
 <ParamField body="side" type="str | None" default="None">
-  Which side to show the popover: `"top"`, `"right"`, `"bottom"`, `"left"`.
+  Preferred side to show the popover: `"top"`, `"right"`, `"bottom"`, `"left"`.
 </ParamField>
 
 <ParamField body="css_class" type="str | None" default="None">

--- a/src/prefab_ui/components/alert.py
+++ b/src/prefab_ui/components/alert.py
@@ -67,7 +67,7 @@ class AlertTitle(Component):
     """
 
     type: Literal["AlertTitle"] = "AlertTitle"
-    content: str = Field(description="Title text with {{ field }} interpolation")
+    content: str = Field(description="Title text")
 
     @overload
     def __init__(self, content: str, /, **kwargs: Any) -> None: ...
@@ -92,7 +92,7 @@ class AlertDescription(Component):
     """
 
     type: Literal["AlertDescription"] = "AlertDescription"
-    content: str = Field(description="Description text with {{ field }} interpolation")
+    content: str = Field(description="Description text")
 
     @overload
     def __init__(self, content: str, /, **kwargs: Any) -> None: ...

--- a/src/prefab_ui/components/badge.py
+++ b/src/prefab_ui/components/badge.py
@@ -37,7 +37,7 @@ class Badge(Component):
     """A badge component for displaying status or labels.
 
     Args:
-        label: Badge text (supports ``{{ field }}`` interpolation)
+        label: Badge text
         variant: Visual style - "default", "secondary", "destructive", "outline",
             "ghost", "success", "warning", "info"
         css_class: Additional CSS classes to apply
@@ -53,7 +53,7 @@ class Badge(Component):
     """
 
     type: Literal["Badge"] = "Badge"
-    label: str = Field(description="Badge text with {{ field }} interpolation")
+    label: str = Field(description="Badge text")
     variant: BadgeVariant = Field(
         default="default",
         description="Visual variant: default, secondary, destructive, outline, ghost, success, warning, or info",

--- a/src/prefab_ui/components/button.py
+++ b/src/prefab_ui/components/button.py
@@ -48,7 +48,7 @@ class Button(Component):
     """A button component with multiple variants and sizes.
 
     Args:
-        label: Button text (supports ``{{ field }}`` interpolation)
+        label: Button text
         variant: Visual style - "default", "destructive", "outline", "secondary", "ghost", "link"
         size: Button size - "default", "sm", "lg", "icon"
         disabled: Whether the button is disabled
@@ -62,7 +62,7 @@ class Button(Component):
     """
 
     type: Literal["Button"] = "Button"
-    label: str = Field(description="Button text with {{ field }} interpolation")
+    label: str = Field(description="Button text")
     variant: ButtonVariant = Field(
         default="default",
         description="Visual variant: default, destructive, outline, secondary, ghost, link",

--- a/src/prefab_ui/components/checkbox.py
+++ b/src/prefab_ui/components/checkbox.py
@@ -40,14 +40,10 @@ class Checkbox(Component):
     """
 
     type: Literal["Checkbox"] = "Checkbox"
-    label: str | None = Field(
-        default=None, description="Label text (supports {{ field }} interpolation)"
-    )
+    label: str | None = Field(default=None, description="Label text")
     checked: bool = Field(default=False, description="Whether checkbox is checked")
     name: str | None = Field(default=None, description="Form field name")
-    value: str | None = Field(
-        default=None, description="Form value (supports {{ field }} interpolation)"
-    )
+    value: str | None = Field(default=None, description="Form value")
     disabled: bool = Field(default=False, description="Whether checkbox is disabled")
     required: bool = Field(default=False, description="Whether checkbox is required")
     on_change: Action | list[Action] | None = Field(

--- a/src/prefab_ui/components/code.py
+++ b/src/prefab_ui/components/code.py
@@ -18,7 +18,7 @@ class Code(Component):
     """
 
     type: Literal["Code"] = "Code"
-    content: str = Field(description="Code content with {{ field }} interpolation")
+    content: str = Field(description="Code content")
     language: str | None = Field(
         default=None, description="Syntax highlighting language"
     )

--- a/src/prefab_ui/components/div.py
+++ b/src/prefab_ui/components/div.py
@@ -35,7 +35,7 @@ class Span(Component):
     """
 
     type: Literal["Span"] = "Span"
-    content: str = Field(description="Text content with {{ field }} interpolation")
+    content: str = Field(description="Text content")
 
     @overload
     def __init__(self, content: str, /, **kwargs: Any) -> None: ...

--- a/src/prefab_ui/components/heading.py
+++ b/src/prefab_ui/components/heading.py
@@ -10,7 +10,7 @@ from prefab_ui.components.base import Component
 
 
 class Heading(Component):
-    """Section heading (h1-h4) with ``{{ field }}`` interpolation.
+    """Section heading (h1-h4).
 
     Example::
 
@@ -18,7 +18,7 @@ class Heading(Component):
     """
 
     type: Literal["Heading"] = "Heading"
-    content: str = Field(description="Heading text with {{ field }} interpolation")
+    content: str = Field(description="Heading text")
     level: Literal[1, 2, 3, 4] = Field(
         default=1, description="Heading level (1=h1, 4=h4)"
     )

--- a/src/prefab_ui/components/image.py
+++ b/src/prefab_ui/components/image.py
@@ -10,7 +10,7 @@ from prefab_ui.components.base import Component
 
 
 class Image(Component):
-    """Image element with ``{{ field }}`` interpolation on src/alt.
+    """Image element.
 
     Example::
 
@@ -18,7 +18,7 @@ class Image(Component):
     """
 
     type: Literal["Image"] = "Image"
-    src: str = Field(description="Image URL with {{ field }} interpolation")
+    src: str = Field(description="Image URL")
     alt: str = Field(default="", description="Alt text")
     width: str | None = Field(default=None, description="CSS width")
     height: str | None = Field(default=None, description="CSS height")

--- a/src/prefab_ui/components/input.py
+++ b/src/prefab_ui/components/input.py
@@ -62,11 +62,9 @@ class Input(Component):
     )
     placeholder: str | None = Field(
         default=None,
-        description="Placeholder text (supports {{ field }} interpolation)",
+        description="Placeholder text",
     )
-    value: str | None = Field(
-        default=None, description="Input value (supports {{ field }} interpolation)"
-    )
+    value: str | None = Field(default=None, description="Input value")
     name: str | None = Field(default=None, description="Form field name")
     disabled: bool = Field(default=False, description="Whether input is disabled")
     required: bool = Field(default=False, description="Whether input is required")

--- a/src/prefab_ui/components/label.py
+++ b/src/prefab_ui/components/label.py
@@ -39,9 +39,7 @@ class Label(ContainerComponent):
     """
 
     type: Literal["Label"] = "Label"
-    text: str | None = Field(
-        default=None, description="Label text (supports {{ field }} interpolation)"
-    )
+    text: str | None = Field(default=None, description="Label text")
     for_id: str | None = Field(
         default=None,
         alias="forId",

--- a/src/prefab_ui/components/markdown.py
+++ b/src/prefab_ui/components/markdown.py
@@ -10,7 +10,7 @@ from prefab_ui.components.base import Component
 
 
 class Markdown(Component):
-    """Rendered markdown with ``{{ field }}`` interpolation.
+    """Rendered markdown component.
 
     Example::
 
@@ -18,7 +18,7 @@ class Markdown(Component):
     """
 
     type: Literal["Markdown"] = "Markdown"
-    content: str = Field(description="Markdown content with {{ field }} interpolation")
+    content: str = Field(description="Markdown content")
 
     @overload
     def __init__(self, content: str, /, **kwargs: Any) -> None: ...

--- a/src/prefab_ui/components/progress.py
+++ b/src/prefab_ui/components/progress.py
@@ -22,7 +22,7 @@ class Progress(Component):
     type: Literal["Progress"] = "Progress"
     value: float | str = Field(
         default=0,
-        description="Current progress value (supports {{ field }} interpolation)",
+        description="Current progress value",
     )
     max: float = Field(default=100, description="Maximum value (progress is value/max)")
     indicator_class: str | None = Field(

--- a/src/prefab_ui/components/radio.py
+++ b/src/prefab_ui/components/radio.py
@@ -64,10 +64,8 @@ class Radio(Component):
     """
 
     type: Literal["Radio"] = "Radio"
-    value: str = Field(description="Form value (supports {{ field }} interpolation)")
-    label: str | None = Field(
-        default=None, description="Label text (supports {{ field }} interpolation)"
-    )
+    value: str = Field(description="Form value")
+    label: str | None = Field(default=None, description="Label text")
     checked: bool = Field(default=False, description="Whether radio is selected")
     name: str | None = Field(default=None, description="Form field name")
     disabled: bool = Field(default=False, description="Whether radio is disabled")

--- a/src/prefab_ui/components/select.py
+++ b/src/prefab_ui/components/select.py
@@ -45,7 +45,7 @@ class Select(ContainerComponent):
     type: Literal["Select"] = "Select"
     placeholder: str | None = Field(
         default=None,
-        description="Placeholder text (supports {{ field }} interpolation)",
+        description="Placeholder text",
     )
     name: str | None = Field(default=None, description="Form field name")
     size: SelectSize = Field(default="default", description="Select size (sm, default)")
@@ -75,7 +75,7 @@ class SelectOption(Component):
     """
 
     type: Literal["SelectOption"] = "SelectOption"
-    value: str = Field(description="Option value (supports {{ field }} interpolation)")
-    label: str = Field(description="Display text (supports {{ field }} interpolation)")
+    value: str = Field(description="Option value")
+    label: str = Field(description="Display text")
     selected: bool = Field(default=False, description="Whether option is selected")
     disabled: bool = Field(default=False, description="Whether option is disabled")

--- a/src/prefab_ui/components/slider.py
+++ b/src/prefab_ui/components/slider.py
@@ -41,9 +41,7 @@ class Slider(Component):
     type: Literal["Slider"] = "Slider"
     min: float = Field(default=0, description="Minimum value")
     max: float = Field(default=100, description="Maximum value")
-    value: float | None = Field(
-        default=None, description="Initial value (supports {{ field }} interpolation)"
-    )
+    value: float | None = Field(default=None, description="Initial value")
     step: float | None = Field(default=None, description="Step increment")
     name: str | None = Field(default=None, description="Form field name")
     disabled: bool = Field(default=False, description="Whether slider is disabled")

--- a/src/prefab_ui/components/switch.py
+++ b/src/prefab_ui/components/switch.py
@@ -41,9 +41,7 @@ class Switch(Component):
     """
 
     type: Literal["Switch"] = "Switch"
-    label: str | None = Field(
-        default=None, description="Label text (supports {{ field }} interpolation)"
-    )
+    label: str | None = Field(default=None, description="Label text")
     checked: bool = Field(default=False, description="Whether switch is on")
     size: SwitchSize = Field(default="default", description="Switch size (sm, default)")
     name: str | None = Field(default=None, description="Form field name")

--- a/src/prefab_ui/components/text.py
+++ b/src/prefab_ui/components/text.py
@@ -10,7 +10,7 @@ from prefab_ui.components.base import Component
 
 
 class Text(Component):
-    """Body text with ``{{ field }}`` interpolation support.
+    """Body text component.
 
     Example::
 
@@ -18,7 +18,7 @@ class Text(Component):
     """
 
     type: Literal["Text"] = "Text"
-    content: str = Field(description="Text content with {{ field }} interpolation")
+    content: str = Field(description="Text content")
     bold: bool | None = Field(default=None, description="Render text in bold")
     italic: bool | None = Field(default=None, description="Render text in italic")
 

--- a/src/prefab_ui/components/textarea.py
+++ b/src/prefab_ui/components/textarea.py
@@ -41,11 +41,9 @@ class Textarea(Component):
     type: Literal["Textarea"] = "Textarea"
     placeholder: str | None = Field(
         default=None,
-        description="Placeholder text (supports {{ field }} interpolation)",
+        description="Placeholder text",
     )
-    value: str | None = Field(
-        default=None, description="Textarea value (supports {{ field }} interpolation)"
-    )
+    value: str | None = Field(default=None, description="Textarea value")
     name: str | None = Field(default=None, description="Form field name")
     rows: int | None = Field(default=None, description="Number of visible text rows")
     disabled: bool = Field(default=False, description="Whether textarea is disabled")

--- a/src/prefab_ui/components/typography.py
+++ b/src/prefab_ui/components/typography.py
@@ -1,8 +1,6 @@
 """Typography components following shadcn/ui conventions.
 
 These components provide semantic text styling with automatic dark mode support.
-All text content supports ``{{ field }}`` interpolation.
-
 Example::
 
     from prefab_ui.components import H1, H2, P, Muted, Lead
@@ -26,7 +24,7 @@ from prefab_ui.components.base import Component
 class _TextComponent(Component):
     """Base class for text components that accept positional content."""
 
-    content: str = Field(description="Text content with {{ field }} interpolation")
+    content: str = Field(description="Text content")
     bold: bool | None = Field(default=None, description="Render text in bold")
     italic: bool | None = Field(default=None, description="Render text in italic")
 


### PR DESCRIPTION
The first docs PR centralized interpolation into its own page and removed per-component Data Interpolation sections from the MDX docs. But the Python source still had `"supports {{ field }} interpolation"` scattered across every Pydantic Field description — implying that non-annotated fields *don't* support it. This cleans out all 26 instances across 19 component files.

On the docs side, the thinnest component pages get real content: Pages goes from zero ComponentPreviews to two (a Guide entry viewer and a wizard flow), Dialog gets a confirmation pattern preview with a height fix for the clipped modal overlay, Badge adds an "In Context" section, and Code/ForEach/Popover get richer examples. Sample content uses light Hitchhiker's Guide references — Arthur Dent crew profiles, Babel Fish settings, Improbability Drive confirmations.

```python
with Dialog(
    title="Activate Improbability Drive",
    description="This action cannot be undone.",
):
    Button("Engage Drive", variant="destructive")
    Text(
        "Are you sure? The last time this was engaged, "
        "a sperm whale and a bowl of petunias materialized in mid-air."
    )
    with Row(gap=2, css_class="justify-end"):
        Button("Cancel", variant="outline")
        Button("Engage", variant="destructive")
```