### PR TITLE
Replace iframe previews with shadow DOM

### DIFF
--- a/docs/snippets/component-preview.mdx
+++ b/docs/snippets/component-preview.mdx
@@ -1,50 +1,57 @@
 export const ComponentPreview = ({ json, height, children }) => {
-  var minH = height ? parseInt(height, 10) : 0;
-  const [frameHeight, setFrameHeight] = React.useState(minH);
-  const iframeRef = React.useRef(null);
+  const hostRef = React.useRef(null);
+  const handleRef = React.useRef(null);
 
   React.useEffect(() => {
-    const sendTheme = () => {
+    let cancelled = false;
+    const host = hostRef.current;
+    if (!host) return;
+
+    const port =
+      (typeof window !== "undefined" && window.__PREFAB_RENDERER_PORT__) ||
+      3333;
+
+    var loadModule = new Function("u", "return import(u)");
+    var preamble = window.__vite_plugin_react_preamble_installed__
+      ? Promise.resolve()
+      : loadModule("http://localhost:" + port + "/@react-refresh").then(
+          function (RefreshRuntime) {
+            RefreshRuntime.default.injectIntoGlobalHook(window);
+            window.$RefreshReg$ = function () {};
+            window.$RefreshSig$ = function () { return function (type) { return type; }; };
+            window.__vite_plugin_react_preamble_installed__ = true;
+          }
+        );
+    preamble.then(function () {
+      return loadModule("http://localhost:" + port + "/src/embed.tsx");
+    }).then(({ mountPreview }) => {
+      if (cancelled) return;
       var dark = document.documentElement.classList.contains("dark");
-      var iframe = iframeRef.current;
-      if (iframe && iframe.contentWindow) {
-        iframe.contentWindow.postMessage({ type: "prefab:theme", dark: dark }, "*");
-      }
-    };
+      handleRef.current = mountPreview(host, json, { dark: dark });
+    });
 
-    const handler = (e) => {
-      if (!e.data) return;
-      if (e.data.type === "prefab:resize") {
-        if (iframeRef.current && e.source === iframeRef.current.contentWindow) {
-          setFrameHeight(function (prev) {
-            return Math.max(e.data.height, minH);
-          });
-        }
-      }
-      if (e.data.type === "prefab:ready") {
-        sendTheme();
-      }
-    };
-
-    window.addEventListener("message", handler);
-
-    var observer = new MutationObserver(sendTheme);
-    observer.observe(document.documentElement, { attributes: true, attributeFilter: ["class"] });
+    var observer = new MutationObserver(() => {
+      var dark = document.documentElement.classList.contains("dark");
+      if (handleRef.current) handleRef.current.setDark(dark);
+    });
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["class"],
+    });
 
     return () => {
-      window.removeEventListener("message", handler);
+      cancelled = true;
       observer.disconnect();
+      if (handleRef.current) {
+        handleRef.current.unmount();
+        handleRef.current = null;
+      }
     };
   }, []);
 
   return (
     <Card>
-      <iframe
-        ref={iframeRef}
-        data-docpreview
-        src={"http://localhost:" + (typeof window !== "undefined" && window.__PREFAB_RENDERER_PORT__ || 3333) + "/renderer.html#docpreview:" + encodeURIComponent(json)}
-        style={{ width: "100%", height: frameHeight + "px", border: "none", display: "block" }}
-      />
+      <div ref={hostRef} />
       <div style={{ marginBottom: "-2rem" }}>{children}</div>
     </Card>
   );

--- a/renderer/src/embed.tsx
+++ b/renderer/src/embed.tsx
@@ -1,0 +1,195 @@
+/**
+ * Shadow DOM embed entry point for doc previews.
+ *
+ * Both the preview content and overlay portals render inside shadow roots,
+ * giving full CSS isolation from the host page. The portal shadow root lives
+ * on document.body so `position: fixed` overlays can use the full viewport.
+ */
+
+import { createRoot, type Root } from "react-dom/client";
+import { PortalContainerProvider } from "./portal-container";
+import { RenderTree, type ComponentNode } from "./renderer";
+import { useStateStore } from "./state";
+
+// Vite processes this through @tailwindcss/vite and returns the complete CSS
+// as a string instead of injecting it into the document.
+import rawCss from "./index.css?inline";
+
+// --- @property → :host fallback ---
+// `@property` declarations don't work inside shadow DOM <style> elements
+// (they're document-level constructs). Tailwind v4 relies on @property to set
+// initial values for internal variables like --tw-border-style. Extract them
+// and emit explicit :host assignments so they resolve inside the shadow root.
+function extractPropertyDefaults(css: string): string {
+  const defaults: string[] = [];
+  const re = /@property\s+(--[\w-]+)\s*\{[^}]*initial-value:\s*([^;\n}]+)/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(css)) !== null) {
+    const value = m[2].trim();
+    if (value) defaults.push(`  ${m[1]}: ${value};`);
+  }
+  return defaults.length ? `:host {\n${defaults.join("\n")}\n}\n` : "";
+}
+
+// --- Shared shadow CSS base ---
+// Both the preview and portal shadow roots reuse the same rewritten Tailwind
+// CSS. `:root` → `:host` for theme variables, `.dark` → `:host(.dark)` for
+// dark mode.
+const rewrittenCss =
+  extractPropertyDefaults(rawCss) +
+  rawCss
+    .replace(/:root/g, ":host")
+    .replace(/\.dark\s*\{/g, ":host(.dark) {")
+    .replace(/\.dark\s+\./g, ":host(.dark) .")
+    .replace(/\.dark\s+:/g, ":host(.dark) :");
+
+const fontStack = `ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+    "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif`;
+
+// Preview shadow root: positioned container with background
+const shadowCss =
+  rewrittenCss +
+  `
+[data-prefab-mount] {
+  position: relative;
+  background: var(--background);
+  color: var(--foreground);
+  font-family: ${fontStack};
+  margin: 0;
+  padding: 4rem 2rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-synthesis-weight: none;
+  text-rendering: optimizeLegibility;
+}
+`;
+
+// Portal shadow root: transparent container for overlays
+const portalShadowCss =
+  rewrittenCss +
+  `
+[data-prefab-portal] {
+  font-family: ${fontStack};
+  font-synthesis-weight: none;
+  text-rendering: optimizeLegibility;
+}
+`;
+
+interface MountHandle {
+  unmount(): void;
+  setDark(dark: boolean): void;
+}
+
+function EmbedPreview({
+  tree,
+  initialState,
+  container,
+}: {
+  tree: ComponentNode;
+  initialState: Record<string, unknown>;
+  container: HTMLElement;
+}) {
+  const state = useStateStore(initialState);
+  return (
+    <PortalContainerProvider container={container}>
+      <RenderTree tree={tree} state={state} app={null} />
+    </PortalContainerProvider>
+  );
+}
+
+/**
+ * Create a body-level portal host with its own shadow root for overlay content.
+ *
+ * The shadow root gives full CSS isolation from the host page — no style
+ * leakage in either direction. The host element sits directly on document.body
+ * so `position: fixed` overlays can use the full viewport.
+ */
+function getOrCreatePortalHost(id: string, dark: boolean): HTMLElement {
+  let host = document.getElementById(id);
+  let container: HTMLElement;
+
+  if (!host) {
+    host = document.createElement("div");
+    host.id = id;
+    document.body.appendChild(host);
+
+    const shadow = host.attachShadow({ mode: "open" });
+
+    const style = document.createElement("style");
+    style.textContent = portalShadowCss;
+    shadow.appendChild(style);
+
+    container = document.createElement("div");
+    container.setAttribute("data-prefab-portal", "");
+    shadow.appendChild(container);
+  } else {
+    container = host.shadowRoot!.querySelector("[data-prefab-portal]")!;
+  }
+
+  host.classList.toggle("dark", dark);
+  return container;
+}
+
+export function mountPreview(
+  host: HTMLElement,
+  json: string,
+  options?: { dark?: boolean },
+): MountHandle {
+  const shadow = host.attachShadow({ mode: "open" });
+
+  // Inject processed CSS
+  const style = document.createElement("style");
+  style.textContent = shadowCss;
+  shadow.appendChild(style);
+
+  // Create mount point inside shadow root
+  const mount = document.createElement("div");
+  mount.setAttribute("data-prefab-mount", "");
+  shadow.appendChild(mount);
+
+  const isDark = options?.dark ?? false;
+
+  // Apply initial dark mode
+  if (isDark) {
+    host.classList.add("dark");
+  }
+
+  // Body-level portal host with shadow DOM for overlays
+  const portalId = `prefab-portal-${
+    host.id || Math.random().toString(36).slice(2)
+  }`;
+  const portalContainer = getOrCreatePortalHost(portalId, isDark);
+
+  // Parse JSON
+  const parsed = JSON.parse(json);
+  const tree: ComponentNode = parsed._tree ?? parsed;
+  const userData: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(parsed)) {
+    if (k !== "_tree" && k !== "_state") userData[k] = v;
+  }
+  const initialState = { ...userData, ...(parsed._state ?? {}) };
+
+  // Mount React
+  let root: Root | null = createRoot(mount);
+  root.render(
+    <EmbedPreview
+      tree={tree}
+      initialState={initialState}
+      container={portalContainer}
+    />,
+  );
+
+  return {
+    unmount() {
+      root?.unmount();
+      root = null;
+      document.getElementById(portalId)?.remove();
+    },
+    setDark(dark: boolean) {
+      host.classList.toggle("dark", dark);
+      const portalHost = document.getElementById(portalId);
+      if (portalHost) portalHost.classList.toggle("dark", dark);
+    },
+  };
+}

--- a/renderer/src/portal-container.tsx
+++ b/renderer/src/portal-container.tsx
@@ -1,0 +1,23 @@
+import { createContext, useContext } from "react";
+
+const PortalContainerContext = createContext<HTMLElement | undefined>(
+  undefined,
+);
+
+export function PortalContainerProvider({
+  container,
+  children,
+}: {
+  container?: HTMLElement;
+  children: React.ReactNode;
+}) {
+  return (
+    <PortalContainerContext.Provider value={container}>
+      {children}
+    </PortalContainerContext.Provider>
+  );
+}
+
+export function usePortalContainer(): HTMLElement | undefined {
+  return useContext(PortalContainerContext);
+}

--- a/renderer/src/ui/dialog.tsx
+++ b/renderer/src/ui/dialog.tsx
@@ -3,6 +3,7 @@ import * as DialogPrimitive from "@radix-ui/react-dialog"
 import { X } from "lucide-react"
 
 import { cn } from "@/lib/utils"
+import { usePortalContainer } from "@/portal-container"
 
 const Dialog = DialogPrimitive.Root
 
@@ -30,8 +31,10 @@ DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
 const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
->(({ className, children, ...props }, ref) => (
-  <DialogPortal>
+>(({ className, children, ...props }, ref) => {
+  const container = usePortalContainer();
+  return (
+  <DialogPortal container={container}>
     <DialogOverlay />
     <DialogPrimitive.Content
       ref={ref}
@@ -48,7 +51,8 @@ const DialogContent = React.forwardRef<
       </DialogPrimitive.Close>
     </DialogPrimitive.Content>
   </DialogPortal>
-))
+  );
+})
 DialogContent.displayName = DialogPrimitive.Content.displayName
 
 const DialogHeader = ({

--- a/renderer/src/ui/popover.tsx
+++ b/renderer/src/ui/popover.tsx
@@ -4,6 +4,7 @@ import * as React from "react"
 import * as PopoverPrimitive from "@radix-ui/react-popover"
 
 import { cn } from "@/lib/utils"
+import { usePortalContainer } from "@/portal-container"
 
 const Popover = PopoverPrimitive.Root
 
@@ -12,8 +13,10 @@ const PopoverTrigger = PopoverPrimitive.Trigger
 const PopoverContent = React.forwardRef<
   React.ElementRef<typeof PopoverPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
->(({ className, align = "center", sideOffset = 4, ...props }, ref) => (
-  <PopoverPrimitive.Portal>
+>(({ className, align = "center", sideOffset = 4, ...props }, ref) => {
+  const container = usePortalContainer();
+  return (
+  <PopoverPrimitive.Portal container={container}>
     <PopoverPrimitive.Content
       ref={ref}
       align={align}
@@ -25,7 +28,8 @@ const PopoverContent = React.forwardRef<
       {...props}
     />
   </PopoverPrimitive.Portal>
-))
+  );
+})
 PopoverContent.displayName = PopoverPrimitive.Content.displayName
 
 export { Popover, PopoverTrigger, PopoverContent }

--- a/renderer/src/ui/select.tsx
+++ b/renderer/src/ui/select.tsx
@@ -3,6 +3,7 @@ import { Select as SelectPrimitive } from "radix-ui"
 import { Check, ChevronDown, ChevronUp } from "lucide-react"
 
 import { cn } from "@/lib/utils"
+import { usePortalContainer } from "@/portal-container"
 
 function Select({
   ...props
@@ -48,8 +49,9 @@ function SelectContent({
   position = "popper",
   ...props
 }: React.ComponentProps<typeof SelectPrimitive.Content>) {
+  const container = usePortalContainer();
   return (
-    <SelectPrimitive.Portal>
+    <SelectPrimitive.Portal container={container}>
       <SelectPrimitive.Content
         data-slot="select-content"
         className={cn(


### PR DESCRIPTION
The iframe-based `ComponentPreview` had two problems: overlay components (popovers, dialogs, selects) were trapped inside the iframe viewport, and cross-origin messaging for dark mode and height syncing was fragile.

This replaces iframes with shadow DOM mounting. The renderer's Vite dev server serves `embed.tsx` as a module, which `ComponentPreview` loads dynamically and calls `mountPreview(host, json)`. Both the preview content and overlay portals get their own shadow roots, giving full CSS isolation from Mintlify's styles in both directions.

The main challenge was Tailwind v4's `@property` declarations, which are document-level constructs that don't work inside shadow DOM `<style>` elements. `extractPropertyDefaults()` parses them out and emits the initial values as explicit `:host` variable assignments.

```tsx
// ComponentPreview now mounts directly into a div instead of an iframe
loadModule("http://localhost:" + port + "/src/embed.tsx")
  .then(({ mountPreview }) => {
    handle = mountPreview(host, json, { dark });
  });

// Dark mode is a direct call instead of postMessage
handle.setDark(dark);
```