### PR TITLE
Default renderer URL to CDN, add get_renderer_csp()

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Every frontend framework assumes a human wrote the code and a server is running.
 
 The renderer compiles that JSON to real React — not a toy dashboard, not a Streamlit approximation, but production UI components with state management, forms, data tables, and declarative interactivity. And it runs as a self-contained static bundle, no backend required at runtime.
 
-Prefab originated as [FastMCP](https://github.com/jlowin/fastmcp)'s Apps system and has been extracted as a standalone library so it can serve any backend. It ships as two packages: `prefab-ui` (Python, on PyPI) for building component trees, and `@prefect/prefab-ui` (TypeScript, on npm) for rendering them.
+Prefab originated as [FastMCP](https://github.com/jlowin/fastmcp)'s Apps system and has been extracted as a standalone library so it can serve any backend. It ships as two packages: `prefab-ui` (Python, on PyPI) for building component trees, and `@prefecthq/prefab-ui` (TypeScript, on npm) for rendering them.
 
 ## Installation
 

--- a/docs/welcome.mdx
+++ b/docs/welcome.mdx
@@ -60,7 +60,7 @@ The core idea is a pipeline: **JSON → React**. For Python authors, it's **Pyth
 
 1. A component tree is described — in Python via the DSL, or as raw JSON from any source
 2. The tree serializes to Prefab's JSON wire format
-3. A React renderer (shipped as `@prefect/prefab-ui` on npm) compiles the JSON into a live interface
+3. A React renderer (shipped as `@prefecthq/prefab-ui` on npm) compiles the JSON into a live interface
 
 State flows through templates. When you write `{{ query }}`, the renderer interpolates the current value of `query` from client-side state. Actions like `ToolCall` and `SetState` update that state, keeping the UI reactive.
 

--- a/renderer/package-lock.json
+++ b/renderer/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@prefect/prefab-ui",
+  "name": "@prefecthq/prefab-ui",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@prefect/prefab-ui",
+      "name": "@prefecthq/prefab-ui",
       "version": "0.0.0",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0",
@@ -3531,6 +3531,66 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.7.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.7.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.1.18",

--- a/renderer/package.json
+++ b/renderer/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@prefect/prefab-ui",
+  "name": "@prefecthq/prefab-ui",
   "private": true,
   "version": "0.0.0",
   "type": "module",

--- a/src/prefab_ui/renderer/__init__.py
+++ b/src/prefab_ui/renderer/__init__.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import os
 from importlib.metadata import version as _pkg_version
 
-_NPM_PACKAGE = "@prefect/prefab-ui"
+_NPM_PACKAGE = "@prefecthq/prefab-ui"
 _CDN_TEMPLATE = "https://cdn.jsdelivr.net/npm/{package}@{version}/dist"
 
 _RENDERER_STUB = """\

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -12,7 +12,7 @@ class TestGetRendererUrl:
         monkeypatch.delenv("PREFAB_RENDERER_URL", raising=False)
         url = get_renderer_url()
         assert "cdn.jsdelivr.net" in url
-        assert "@prefect/prefab-ui" in url
+        assert "@prefecthq/prefab-ui" in url
 
     def test_env_var_override(self, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.setenv("PREFAB_RENDERER_URL", "http://localhost:3333")
@@ -26,7 +26,7 @@ class TestGetRendererUrl:
         monkeypatch.delenv("PREFAB_RENDERER_URL", raising=False)
         url = get_renderer_url()
         # Version is dynamic, but should contain a @ after the package name
-        assert "@prefect/prefab-ui@" in url
+        assert "@prefecthq/prefab-ui@" in url
 
 
 class TestGetRendererHtml:


### PR DESCRIPTION
`get_renderer_html()` used to require `PREFAB_RENDERER_URL` and raise if it wasn't set. Now it defaults to loading the renderer from jsdelivr CDN, deriving the URL from the installed `prefab-ui` package version via `importlib.metadata`. The env var becomes a dev-only override for pointing at a local Vite server.

New `get_renderer_csp()` returns the CSP `resourceDomains` list that FastMCP needs when registering the `ui://` resource — so the host's sandbox allows loading the renderer assets.

```python
from prefab_ui.renderer import get_renderer_html, get_renderer_csp

html = get_renderer_html()  # just works — CDN by default
csp = get_renderer_csp()    # ["https://cdn.jsdelivr.net"]
```

This unblocks the FastMCP integration work (`fastmcp[apps]` calling into prefab for renderer HTML and CSP info).