### PR TITLE
Skip unchanged file writes in build-docs pipeline

### DIFF
--- a/docs/_preview-build/generate_protocol_pages.py
+++ b/docs/_preview-build/generate_protocol_pages.py
@@ -342,14 +342,17 @@ def main() -> None:
     PROTOCOL_DIR.mkdir(parents=True, exist_ok=True)
 
     generated = 0
+    written = 0
 
     # Generate component pages
     for wire_name, cls in sorted(COMPONENT_CLASSES.items()):
         filename = _class_to_filename(wire_name) + ".mdx"
         content = generate_component_page(wire_name, cls)
         path = PROTOCOL_DIR / filename
-        path.write_text(content)
-        print(f"  {path.relative_to(PROTOCOL_DIR.parents[2])}")
+        if not path.exists() or path.read_text() != content:
+            path.write_text(content)
+            print(f"  {path.relative_to(PROTOCOL_DIR.parents[2])}")
+            written += 1
         generated += 1
 
     # Generate action pages
@@ -357,13 +360,13 @@ def main() -> None:
         filename = _class_to_filename(name) + ".mdx"
         content = generate_component_page(name, cls)
         path = PROTOCOL_DIR / filename
-        path.write_text(content)
-        print(f"  {path.relative_to(PROTOCOL_DIR.parents[2])}")
+        if not path.exists() or path.read_text() != content:
+            path.write_text(content)
+            print(f"  {path.relative_to(PROTOCOL_DIR.parents[2])}")
+            written += 1
         generated += 1
 
-    print(
-        f"\nGenerated {generated} protocol reference pages in {PROTOCOL_DIR.relative_to(PROTOCOL_DIR.parents[2])}"
-    )
+    print(f"\nGenerated {generated} protocol reference pages, {written} updated")
 
 
 if __name__ == "__main__":

--- a/docs/_preview-build/scope_css.py
+++ b/docs/_preview-build/scope_css.py
@@ -81,5 +81,8 @@ final = f"{_THEME_CSS}\n{_INFRASTRUCTURE_CSS}\n/* ── Scoped Tailwind v4 util
 build_dir = Path(__file__).parent
 out = build_dir.parent / "css" / "preview.css"
 out.parent.mkdir(parents=True, exist_ok=True)
-out.write_text(final)
-print(f"Wrote {len(final)} bytes to {out}")
+if out.exists() and out.read_text() == final:
+    print(f"CSS unchanged ({len(final)} bytes)")
+else:
+    out.write_text(final)
+    print(f"Wrote {len(final)} bytes to {out}")


### PR DESCRIPTION
Running `build-docs` while Mintlify is serving caused ~60s first-load because every step unconditionally wrote files — 2.3MB embed.js, 88 protocol MDX pages, preview CSS — each triggering a Mintlify rebuild cascade.

Now unchanged outputs are skipped:

- **embed.js**: mtime check against `renderer/src/` (excluding generated `playground/` outputs). Saves the 3s Vite build and the 2.3MB file write when renderer source hasn't changed.
- **protocol pages**: content comparison before writing ~88 MDX files
- **preview CSS**: content comparison before writing

A no-change `build-docs` run now triggers zero file writes to `docs/`, so Mintlify sees nothing to rebuild.