### PR TITLE
Scope theme CSS tokens to .prefab-preview in docs

### DIFF
--- a/docs/_preview-build/scope_css.py
+++ b/docs/_preview-build/scope_css.py
@@ -14,7 +14,12 @@ from pathlib import Path
 
 # Read canonical design tokens from theme.css
 _theme_css_path = Path(__file__).resolve().parents[2] / "renderer" / "src" / "theme.css"
-_THEME_CSS = _theme_css_path.read_text()
+_THEME_CSS_RAW = _theme_css_path.read_text()
+# Scope theme tokens to .prefab-preview so they don't overwrite the host page's
+# own custom properties (e.g. Mintlify's --primary which uses space-separated RGB).
+_THEME_CSS = _THEME_CSS_RAW.replace(":root {", ".prefab-preview {").replace(
+    ".dark {", ".dark .prefab-preview {"
+)
 
 # Container styling applied to the .prefab-preview wrapper itself, plus
 # resets and Tailwind v4 property initializations that must be explicit


### PR DESCRIPTION
`scope_css.py` was prepending the raw `theme.css` (with `:root` selectors) unscoped into `docs/css/preview.css`. Since Mintlify auto-includes all CSS files from the docs directory, our `:root { --primary: oklch(...) }` overwrote Mintlify's own `--primary: 45 0 247` (space-separated RGB). Mintlify's sidebar icons use CSS mask images colored via `background-color: rgb(var(--primary)/1)` — the oklch value broke `rgb()` parsing, making the active page icon and dropdown icons invisible.

The fix rewrites `:root` → `.prefab-preview` and `.dark` → `.dark .prefab-preview` when emitting theme tokens, keeping them scoped to preview containers.