### PR TITLE
Add live preview to welcome page and fix build pipeline

### DIFF
--- a/.claude/skills/writing-component-docs/SKILL.md
+++ b/.claude/skills/writing-component-docs/SKILL.md
@@ -29,6 +29,11 @@ them by hand.
 
 After editing previews, run `prefab dev build-docs` to regenerate.
 
+**Code block titles:** Always give the Python block a title (e.g.,
+`` ```python Python ``). A block without a title produces a zero-width tab in
+the CodeGroup that users can't click. The title goes before other directives:
+`` ```python Python {5} ``.
+
 **Python code style inside previews:**
 - Target ~80 character line width
 - Use implicit string concatenation for long text

--- a/docs/components/area-chart.mdx
+++ b/docs/components/area-chart.mdx
@@ -15,15 +15,17 @@ AreaChart fills the region between a line and the axis, emphasizing the magnitud
 ```python Python
 from prefab_ui.components import AreaChart, ChartSeries
 
+data = [
+    {"month": "Jan", "desktop": 186, "mobile": 80},
+    {"month": "Feb", "desktop": 305, "mobile": 200},
+    {"month": "Mar", "desktop": 237, "mobile": 120},
+    {"month": "Apr", "desktop": 73, "mobile": 190},
+    {"month": "May", "desktop": 209, "mobile": 130},
+    {"month": "Jun", "desktop": 214, "mobile": 140},
+]
+
 AreaChart(
-    data=[
-        {"month": "Jan", "desktop": 186, "mobile": 80},
-        {"month": "Feb", "desktop": 305, "mobile": 200},
-        {"month": "Mar", "desktop": 237, "mobile": 120},
-        {"month": "Apr", "desktop": 73, "mobile": 190},
-        {"month": "May", "desktop": 209, "mobile": 130},
-        {"month": "Jun", "desktop": 214, "mobile": 140},
-    ],
+    data=data,
     series=[
         ChartSeries(data_key="desktop", label="Desktop"),
         ChartSeries(data_key="mobile", label="Mobile"),
@@ -94,7 +96,7 @@ AreaChart(
 
 Stacking shows how each series contributes to the total. The topmost line represents the combined value.
 
-<ComponentPreview auto json={`{"type":"AreaChart","data":[{"month":"Jan","desktop":186,"mobile":80},{"month":"Feb","desktop":305,"mobile":200},{"month":"Mar","desktop":237,"mobile":120},{"month":"Apr","desktop":73,"mobile":190},{"month":"May","desktop":209,"mobile":130},{"month":"Jun","desktop":214,"mobile":140}],"series":[{"dataKey":"desktop","label":"Desktop"},{"dataKey":"mobile","label":"Mobile"}],"xAxis":"month","height":300,"stacked":true,"showLegend":true}`}>
+<ComponentPreview auto json={`{"type":"AreaChart","data":[{"month":"Jan","desktop":186,"mobile":80},{"month":"Feb","desktop":305,"mobile":200},{"month":"Mar","desktop":237,"mobile":120},{"month":"Apr","desktop":73,"mobile":190},{"month":"May","desktop":209,"mobile":130},{"month":"Jun","desktop":214,"mobile":140}],"series":[{"dataKey":"desktop","label":"Desktop"},{"dataKey":"mobile","label":"Mobile"}],"xAxis":"month","height":300,"stacked":true,"curve":"linear","showDots":false,"showLegend":true,"showTooltip":true,"showGrid":true}`}>
 <CodeGroup>
 ```python Python {8}
 AreaChart(
@@ -108,17 +110,59 @@ AreaChart(
     show_legend=True,
 )
 ```
-```json Protocol {9}
+```json Protocol
 {
   "type": "AreaChart",
-  "data": "...",
+  "data": [
+    {
+      "month": "Jan",
+      "desktop": 186,
+      "mobile": 80
+    },
+    {
+      "month": "Feb",
+      "desktop": 305,
+      "mobile": 200
+    },
+    {
+      "month": "Mar",
+      "desktop": 237,
+      "mobile": 120
+    },
+    {
+      "month": "Apr",
+      "desktop": 73,
+      "mobile": 190
+    },
+    {
+      "month": "May",
+      "desktop": 209,
+      "mobile": 130
+    },
+    {
+      "month": "Jun",
+      "desktop": 214,
+      "mobile": 140
+    }
+  ],
   "series": [
-    {"dataKey": "desktop", "label": "Desktop"},
-    {"dataKey": "mobile", "label": "Mobile"}
+    {
+      "dataKey": "desktop",
+      "label": "Desktop"
+    },
+    {
+      "dataKey": "mobile",
+      "label": "Mobile"
+    }
   ],
   "xAxis": "month",
+  "height": 300,
   "stacked": true,
-  "showLegend": true
+  "curve": "linear",
+  "showDots": false,
+  "showLegend": true,
+  "showTooltip": true,
+  "showGrid": true
 }
 ```
 </CodeGroup>
@@ -128,7 +172,7 @@ AreaChart(
 
 Turn off the grid for a cleaner look.
 
-<ComponentPreview auto json={`{"type":"AreaChart","data":[{"month":"Jan","value":186},{"month":"Feb","value":305},{"month":"Mar","value":237},{"month":"Apr","value":273},{"month":"May","value":209},{"month":"Jun","value":314}],"series":[{"dataKey":"value","label":"Requests"}],"xAxis":"month","height":300,"showGrid":false}`}>
+<ComponentPreview auto json={`{"type":"AreaChart","data":[{"month":"Jan","desktop":186,"mobile":80},{"month":"Feb","desktop":305,"mobile":200},{"month":"Mar","desktop":237,"mobile":120},{"month":"Apr","desktop":73,"mobile":190},{"month":"May","desktop":209,"mobile":130},{"month":"Jun","desktop":214,"mobile":140}],"series":[{"dataKey":"value","label":"Requests"}],"xAxis":"month","height":300,"stacked":false,"curve":"linear","showDots":false,"showLegend":false,"showTooltip":true,"showGrid":false}`}>
 <CodeGroup>
 ```python Python {5}
 AreaChart(
@@ -138,12 +182,54 @@ AreaChart(
     show_grid=False,
 )
 ```
-```json Protocol {6}
+```json Protocol
 {
   "type": "AreaChart",
-  "data": "...",
-  "series": [{"dataKey": "value", "label": "Requests"}],
+  "data": [
+    {
+      "month": "Jan",
+      "desktop": 186,
+      "mobile": 80
+    },
+    {
+      "month": "Feb",
+      "desktop": 305,
+      "mobile": 200
+    },
+    {
+      "month": "Mar",
+      "desktop": 237,
+      "mobile": 120
+    },
+    {
+      "month": "Apr",
+      "desktop": 73,
+      "mobile": 190
+    },
+    {
+      "month": "May",
+      "desktop": 209,
+      "mobile": 130
+    },
+    {
+      "month": "Jun",
+      "desktop": 214,
+      "mobile": 140
+    }
+  ],
+  "series": [
+    {
+      "dataKey": "value",
+      "label": "Requests"
+    }
+  ],
   "xAxis": "month",
+  "height": 300,
+  "stacked": false,
+  "curve": "linear",
+  "showDots": false,
+  "showLegend": false,
+  "showTooltip": true,
   "showGrid": false
 }
 ```
@@ -154,7 +240,7 @@ AreaChart(
 
 Set `curve="smooth"` for gently curved lines between data points. The filled area follows the curve.
 
-<ComponentPreview auto json={`{"type":"AreaChart","data":[{"month":"Jan","desktop":186,"mobile":80},{"month":"Feb","desktop":305,"mobile":200},{"month":"Mar","desktop":237,"mobile":120},{"month":"Apr","desktop":73,"mobile":190},{"month":"May","desktop":209,"mobile":130},{"month":"Jun","desktop":214,"mobile":140}],"series":[{"dataKey":"desktop","label":"Desktop"},{"dataKey":"mobile","label":"Mobile"}],"xAxis":"month","height":300,"curve":"smooth","showLegend":true,"showTooltip":true,"showGrid":true}`}>
+<ComponentPreview auto json={`{"type":"AreaChart","data":[{"month":"Jan","desktop":186,"mobile":80},{"month":"Feb","desktop":305,"mobile":200},{"month":"Mar","desktop":237,"mobile":120},{"month":"Apr","desktop":73,"mobile":190},{"month":"May","desktop":209,"mobile":130},{"month":"Jun","desktop":214,"mobile":140}],"series":[{"dataKey":"desktop","label":"Desktop"},{"dataKey":"mobile","label":"Mobile"}],"xAxis":"month","height":300,"stacked":false,"curve":"smooth","showDots":false,"showLegend":true,"showTooltip":true,"showGrid":true}`}>
 <CodeGroup>
 ```python Python {8}
 AreaChart(
@@ -168,17 +254,59 @@ AreaChart(
     show_legend=True,
 )
 ```
-```json Protocol {9}
+```json Protocol
 {
   "type": "AreaChart",
-  "data": "...",
+  "data": [
+    {
+      "month": "Jan",
+      "desktop": 186,
+      "mobile": 80
+    },
+    {
+      "month": "Feb",
+      "desktop": 305,
+      "mobile": 200
+    },
+    {
+      "month": "Mar",
+      "desktop": 237,
+      "mobile": 120
+    },
+    {
+      "month": "Apr",
+      "desktop": 73,
+      "mobile": 190
+    },
+    {
+      "month": "May",
+      "desktop": 209,
+      "mobile": 130
+    },
+    {
+      "month": "Jun",
+      "desktop": 214,
+      "mobile": 140
+    }
+  ],
   "series": [
-    {"dataKey": "desktop", "label": "Desktop"},
-    {"dataKey": "mobile", "label": "Mobile"}
+    {
+      "dataKey": "desktop",
+      "label": "Desktop"
+    },
+    {
+      "dataKey": "mobile",
+      "label": "Mobile"
+    }
   ],
   "xAxis": "month",
+  "height": 300,
+  "stacked": false,
   "curve": "smooth",
-  "showLegend": true
+  "showDots": false,
+  "showLegend": true,
+  "showTooltip": true,
+  "showGrid": true
 }
 ```
 </CodeGroup>
@@ -188,7 +316,7 @@ AreaChart(
 
 Set `curve="step"` to connect points with step-shaped lines. The filled area follows the stepped edges.
 
-<ComponentPreview auto json={`{"type":"AreaChart","data":[{"month":"Jan","desktop":186,"mobile":80},{"month":"Feb","desktop":305,"mobile":200},{"month":"Mar","desktop":237,"mobile":120},{"month":"Apr","desktop":73,"mobile":190},{"month":"May","desktop":209,"mobile":130},{"month":"Jun","desktop":214,"mobile":140}],"series":[{"dataKey":"desktop","label":"Desktop"},{"dataKey":"mobile","label":"Mobile"}],"xAxis":"month","height":300,"curve":"step","showLegend":true,"showTooltip":true,"showGrid":true}`}>
+<ComponentPreview auto json={`{"type":"AreaChart","data":[{"month":"Jan","desktop":186,"mobile":80},{"month":"Feb","desktop":305,"mobile":200},{"month":"Mar","desktop":237,"mobile":120},{"month":"Apr","desktop":73,"mobile":190},{"month":"May","desktop":209,"mobile":130},{"month":"Jun","desktop":214,"mobile":140}],"series":[{"dataKey":"desktop","label":"Desktop"},{"dataKey":"mobile","label":"Mobile"}],"xAxis":"month","height":300,"stacked":false,"curve":"step","showDots":false,"showLegend":true,"showTooltip":true,"showGrid":true}`}>
 <CodeGroup>
 ```python Python {8}
 AreaChart(
@@ -202,17 +330,59 @@ AreaChart(
     show_legend=True,
 )
 ```
-```json Protocol {9}
+```json Protocol
 {
   "type": "AreaChart",
-  "data": "...",
+  "data": [
+    {
+      "month": "Jan",
+      "desktop": 186,
+      "mobile": 80
+    },
+    {
+      "month": "Feb",
+      "desktop": 305,
+      "mobile": 200
+    },
+    {
+      "month": "Mar",
+      "desktop": 237,
+      "mobile": 120
+    },
+    {
+      "month": "Apr",
+      "desktop": 73,
+      "mobile": 190
+    },
+    {
+      "month": "May",
+      "desktop": 209,
+      "mobile": 130
+    },
+    {
+      "month": "Jun",
+      "desktop": 214,
+      "mobile": 140
+    }
+  ],
   "series": [
-    {"dataKey": "desktop", "label": "Desktop"},
-    {"dataKey": "mobile", "label": "Mobile"}
+    {
+      "dataKey": "desktop",
+      "label": "Desktop"
+    },
+    {
+      "dataKey": "mobile",
+      "label": "Mobile"
+    }
   ],
   "xAxis": "month",
+  "height": 300,
+  "stacked": false,
   "curve": "step",
-  "showLegend": true
+  "showDots": false,
+  "showLegend": true,
+  "showTooltip": true,
+  "showGrid": true
 }
 ```
 </CodeGroup>

--- a/docs/components/bar-chart.mdx
+++ b/docs/components/bar-chart.mdx
@@ -15,15 +15,17 @@ BarChart renders one or more data series as vertical bars. Each `ChartSeries` ma
 ```python Python
 from prefab_ui.components import BarChart, ChartSeries
 
+data = [
+    {"month": "Jan", "desktop": 186, "mobile": 80},
+    {"month": "Feb", "desktop": 305, "mobile": 200},
+    {"month": "Mar", "desktop": 237, "mobile": 120},
+    {"month": "Apr", "desktop": 73, "mobile": 190},
+    {"month": "May", "desktop": 209, "mobile": 130},
+    {"month": "Jun", "desktop": 214, "mobile": 140},
+]
+
 BarChart(
-    data=[
-        {"month": "Jan", "desktop": 186, "mobile": 80},
-        {"month": "Feb", "desktop": 305, "mobile": 200},
-        {"month": "Mar", "desktop": 237, "mobile": 120},
-        {"month": "Apr", "desktop": 73, "mobile": 190},
-        {"month": "May", "desktop": 209, "mobile": 130},
-        {"month": "Jun", "desktop": 214, "mobile": 140},
-    ],
+    data=data,
     series=[
         ChartSeries(data_key="desktop", label="Desktop"),
         ChartSeries(data_key="mobile", label="Mobile"),
@@ -94,7 +96,7 @@ BarChart(
 
 Set `stacked=True` to stack series on top of each other instead of placing them side by side. This is useful when you want to show both individual values and the total.
 
-<ComponentPreview auto json={`{"type":"BarChart","data":[{"month":"Jan","desktop":186,"mobile":80},{"month":"Feb","desktop":305,"mobile":200},{"month":"Mar","desktop":237,"mobile":120},{"month":"Apr","desktop":73,"mobile":190},{"month":"May","desktop":209,"mobile":130},{"month":"Jun","desktop":214,"mobile":140}],"series":[{"dataKey":"desktop","label":"Desktop"},{"dataKey":"mobile","label":"Mobile"}],"xAxis":"month","height":300,"stacked":true,"showLegend":true}`}>
+<ComponentPreview auto json={`{"type":"BarChart","data":[{"month":"Jan","desktop":186,"mobile":80},{"month":"Feb","desktop":305,"mobile":200},{"month":"Mar","desktop":237,"mobile":120},{"month":"Apr","desktop":73,"mobile":190},{"month":"May","desktop":209,"mobile":130},{"month":"Jun","desktop":214,"mobile":140}],"series":[{"dataKey":"desktop","label":"Desktop"},{"dataKey":"mobile","label":"Mobile"}],"xAxis":"month","height":300,"stacked":true,"horizontal":false,"barRadius":4,"showLegend":true,"showTooltip":true,"showGrid":true}`}>
 <CodeGroup>
 ```python Python {8}
 BarChart(
@@ -108,17 +110,59 @@ BarChart(
     show_legend=True,
 )
 ```
-```json Protocol {9}
+```json Protocol
 {
   "type": "BarChart",
-  "data": "...",
+  "data": [
+    {
+      "month": "Jan",
+      "desktop": 186,
+      "mobile": 80
+    },
+    {
+      "month": "Feb",
+      "desktop": 305,
+      "mobile": 200
+    },
+    {
+      "month": "Mar",
+      "desktop": 237,
+      "mobile": 120
+    },
+    {
+      "month": "Apr",
+      "desktop": 73,
+      "mobile": 190
+    },
+    {
+      "month": "May",
+      "desktop": 209,
+      "mobile": 130
+    },
+    {
+      "month": "Jun",
+      "desktop": 214,
+      "mobile": 140
+    }
+  ],
   "series": [
-    {"dataKey": "desktop", "label": "Desktop"},
-    {"dataKey": "mobile", "label": "Mobile"}
+    {
+      "dataKey": "desktop",
+      "label": "Desktop"
+    },
+    {
+      "dataKey": "mobile",
+      "label": "Mobile"
+    }
   ],
   "xAxis": "month",
+  "height": 300,
   "stacked": true,
-  "showLegend": true
+  "horizontal": false,
+  "barRadius": 4,
+  "showLegend": true,
+  "showTooltip": true,
+  "showGrid": true
 }
 ```
 </CodeGroup>
@@ -128,7 +172,7 @@ BarChart(
 
 Turn off the grid for a cleaner look.
 
-<ComponentPreview auto json={`{"type":"BarChart","data":[{"month":"Jan","revenue":4000},{"month":"Feb","revenue":3000},{"month":"Mar","revenue":5000},{"month":"Apr","revenue":4500},{"month":"May","revenue":6000},{"month":"Jun","revenue":5500}],"series":[{"dataKey":"revenue","label":"Revenue"}],"xAxis":"month","height":300,"showGrid":false}`}>
+<ComponentPreview auto json={`{"type":"BarChart","data":[{"month":"Jan","desktop":186,"mobile":80},{"month":"Feb","desktop":305,"mobile":200},{"month":"Mar","desktop":237,"mobile":120},{"month":"Apr","desktop":73,"mobile":190},{"month":"May","desktop":209,"mobile":130},{"month":"Jun","desktop":214,"mobile":140}],"series":[{"dataKey":"revenue","label":"Revenue"}],"xAxis":"month","height":300,"stacked":false,"horizontal":false,"barRadius":4,"showLegend":false,"showTooltip":true,"showGrid":false}`}>
 <CodeGroup>
 ```python Python {5}
 BarChart(
@@ -138,12 +182,54 @@ BarChart(
     show_grid=False,
 )
 ```
-```json Protocol {6}
+```json Protocol
 {
   "type": "BarChart",
-  "data": "...",
-  "series": [{"dataKey": "revenue", "label": "Revenue"}],
+  "data": [
+    {
+      "month": "Jan",
+      "desktop": 186,
+      "mobile": 80
+    },
+    {
+      "month": "Feb",
+      "desktop": 305,
+      "mobile": 200
+    },
+    {
+      "month": "Mar",
+      "desktop": 237,
+      "mobile": 120
+    },
+    {
+      "month": "Apr",
+      "desktop": 73,
+      "mobile": 190
+    },
+    {
+      "month": "May",
+      "desktop": 209,
+      "mobile": 130
+    },
+    {
+      "month": "Jun",
+      "desktop": 214,
+      "mobile": 140
+    }
+  ],
+  "series": [
+    {
+      "dataKey": "revenue",
+      "label": "Revenue"
+    }
+  ],
   "xAxis": "month",
+  "height": 300,
+  "stacked": false,
+  "horizontal": false,
+  "barRadius": 4,
+  "showLegend": false,
+  "showTooltip": true,
   "showGrid": false
 }
 ```
@@ -154,7 +240,7 @@ BarChart(
 
 Set `horizontal=True` to render bars horizontally. Categories appear along the y-axis and values extend to the right.
 
-<ComponentPreview auto json={`{"type":"BarChart","data":[{"month":"Jan","desktop":186,"mobile":80},{"month":"Feb","desktop":305,"mobile":200},{"month":"Mar","desktop":237,"mobile":120},{"month":"Apr","desktop":73,"mobile":190},{"month":"May","desktop":209,"mobile":130},{"month":"Jun","desktop":214,"mobile":140}],"series":[{"dataKey":"desktop","label":"Desktop"},{"dataKey":"mobile","label":"Mobile"}],"xAxis":"month","height":300,"horizontal":true,"barRadius":4,"stacked":false,"showLegend":true,"showTooltip":true,"showGrid":true}`}>
+<ComponentPreview auto json={`{"type":"BarChart","data":[{"month":"Jan","desktop":186,"mobile":80},{"month":"Feb","desktop":305,"mobile":200},{"month":"Mar","desktop":237,"mobile":120},{"month":"Apr","desktop":73,"mobile":190},{"month":"May","desktop":209,"mobile":130},{"month":"Jun","desktop":214,"mobile":140}],"series":[{"dataKey":"desktop","label":"Desktop"},{"dataKey":"mobile","label":"Mobile"}],"xAxis":"month","height":300,"stacked":false,"horizontal":true,"barRadius":4,"showLegend":true,"showTooltip":true,"showGrid":true}`}>
 <CodeGroup>
 ```python Python {8}
 BarChart(
@@ -168,17 +254,59 @@ BarChart(
     show_legend=True,
 )
 ```
-```json Protocol {9}
+```json Protocol
 {
   "type": "BarChart",
-  "data": "...",
+  "data": [
+    {
+      "month": "Jan",
+      "desktop": 186,
+      "mobile": 80
+    },
+    {
+      "month": "Feb",
+      "desktop": 305,
+      "mobile": 200
+    },
+    {
+      "month": "Mar",
+      "desktop": 237,
+      "mobile": 120
+    },
+    {
+      "month": "Apr",
+      "desktop": 73,
+      "mobile": 190
+    },
+    {
+      "month": "May",
+      "desktop": 209,
+      "mobile": 130
+    },
+    {
+      "month": "Jun",
+      "desktop": 214,
+      "mobile": 140
+    }
+  ],
   "series": [
-    {"dataKey": "desktop", "label": "Desktop"},
-    {"dataKey": "mobile", "label": "Mobile"}
+    {
+      "dataKey": "desktop",
+      "label": "Desktop"
+    },
+    {
+      "dataKey": "mobile",
+      "label": "Mobile"
+    }
   ],
   "xAxis": "month",
+  "height": 300,
+  "stacked": false,
   "horizontal": true,
-  "showLegend": true
+  "barRadius": 4,
+  "showLegend": true,
+  "showTooltip": true,
+  "showGrid": true
 }
 ```
 </CodeGroup>

--- a/docs/components/line-chart.mdx
+++ b/docs/components/line-chart.mdx
@@ -15,15 +15,17 @@ LineChart connects data points with lines, making it ideal for showing trends ov
 ```python Python
 from prefab_ui.components import LineChart, ChartSeries
 
+data = [
+    {"month": "Jan", "desktop": 186, "mobile": 80},
+    {"month": "Feb", "desktop": 305, "mobile": 200},
+    {"month": "Mar", "desktop": 237, "mobile": 120},
+    {"month": "Apr", "desktop": 73, "mobile": 190},
+    {"month": "May", "desktop": 209, "mobile": 130},
+    {"month": "Jun", "desktop": 214, "mobile": 140},
+]
+
 LineChart(
-    data=[
-        {"month": "Jan", "desktop": 186, "mobile": 80},
-        {"month": "Feb", "desktop": 305, "mobile": 200},
-        {"month": "Mar", "desktop": 237, "mobile": 120},
-        {"month": "Apr", "desktop": 73, "mobile": 190},
-        {"month": "May", "desktop": 209, "mobile": 130},
-        {"month": "Jun", "desktop": 214, "mobile": 140},
-    ],
+    data=data,
     series=[
         ChartSeries(data_key="desktop", label="Desktop"),
         ChartSeries(data_key="mobile", label="Mobile"),
@@ -93,7 +95,7 @@ LineChart(
 
 Turn off the grid for a cleaner look.
 
-<ComponentPreview auto json={`{"type":"LineChart","data":[{"month":"Jan","value":186},{"month":"Feb","value":305},{"month":"Mar","value":237},{"month":"Apr","value":273},{"month":"May","value":209},{"month":"Jun","value":314}],"series":[{"dataKey":"value","label":"Requests"}],"xAxis":"month","height":300,"showGrid":false}`}>
+<ComponentPreview auto json={`{"type":"LineChart","data":[{"month":"Jan","desktop":186,"mobile":80},{"month":"Feb","desktop":305,"mobile":200},{"month":"Mar","desktop":237,"mobile":120},{"month":"Apr","desktop":73,"mobile":190},{"month":"May","desktop":209,"mobile":130},{"month":"Jun","desktop":214,"mobile":140}],"series":[{"dataKey":"value","label":"Requests"}],"xAxis":"month","height":300,"curve":"linear","showDots":false,"showLegend":false,"showTooltip":true,"showGrid":false}`}>
 <CodeGroup>
 ```python Python {5}
 LineChart(
@@ -103,12 +105,53 @@ LineChart(
     show_grid=False,
 )
 ```
-```json Protocol {6}
+```json Protocol
 {
   "type": "LineChart",
-  "data": "...",
-  "series": [{"dataKey": "value", "label": "Requests"}],
+  "data": [
+    {
+      "month": "Jan",
+      "desktop": 186,
+      "mobile": 80
+    },
+    {
+      "month": "Feb",
+      "desktop": 305,
+      "mobile": 200
+    },
+    {
+      "month": "Mar",
+      "desktop": 237,
+      "mobile": 120
+    },
+    {
+      "month": "Apr",
+      "desktop": 73,
+      "mobile": 190
+    },
+    {
+      "month": "May",
+      "desktop": 209,
+      "mobile": 130
+    },
+    {
+      "month": "Jun",
+      "desktop": 214,
+      "mobile": 140
+    }
+  ],
+  "series": [
+    {
+      "dataKey": "value",
+      "label": "Requests"
+    }
+  ],
   "xAxis": "month",
+  "height": 300,
+  "curve": "linear",
+  "showDots": false,
+  "showLegend": false,
+  "showTooltip": true,
   "showGrid": false
 }
 ```
@@ -119,7 +162,7 @@ LineChart(
 
 Set `curve="smooth"` for gently curved lines between data points.
 
-<ComponentPreview auto json={`{"type":"LineChart","data":[{"month":"Jan","desktop":186,"mobile":80},{"month":"Feb","desktop":305,"mobile":200},{"month":"Mar","desktop":237,"mobile":120},{"month":"Apr","desktop":73,"mobile":190},{"month":"May","desktop":209,"mobile":130},{"month":"Jun","desktop":214,"mobile":140}],"series":[{"dataKey":"desktop","label":"Desktop"},{"dataKey":"mobile","label":"Mobile"}],"xAxis":"month","height":300,"curve":"smooth","showLegend":true,"showTooltip":true,"showGrid":true}`}>
+<ComponentPreview auto json={`{"type":"LineChart","data":[{"month":"Jan","desktop":186,"mobile":80},{"month":"Feb","desktop":305,"mobile":200},{"month":"Mar","desktop":237,"mobile":120},{"month":"Apr","desktop":73,"mobile":190},{"month":"May","desktop":209,"mobile":130},{"month":"Jun","desktop":214,"mobile":140}],"series":[{"dataKey":"desktop","label":"Desktop"},{"dataKey":"mobile","label":"Mobile"}],"xAxis":"month","height":300,"curve":"smooth","showDots":false,"showLegend":true,"showTooltip":true,"showGrid":true}`}>
 <CodeGroup>
 ```python Python {8}
 LineChart(
@@ -133,17 +176,58 @@ LineChart(
     show_legend=True,
 )
 ```
-```json Protocol {9}
+```json Protocol
 {
   "type": "LineChart",
-  "data": "...",
+  "data": [
+    {
+      "month": "Jan",
+      "desktop": 186,
+      "mobile": 80
+    },
+    {
+      "month": "Feb",
+      "desktop": 305,
+      "mobile": 200
+    },
+    {
+      "month": "Mar",
+      "desktop": 237,
+      "mobile": 120
+    },
+    {
+      "month": "Apr",
+      "desktop": 73,
+      "mobile": 190
+    },
+    {
+      "month": "May",
+      "desktop": 209,
+      "mobile": 130
+    },
+    {
+      "month": "Jun",
+      "desktop": 214,
+      "mobile": 140
+    }
+  ],
   "series": [
-    {"dataKey": "desktop", "label": "Desktop"},
-    {"dataKey": "mobile", "label": "Mobile"}
+    {
+      "dataKey": "desktop",
+      "label": "Desktop"
+    },
+    {
+      "dataKey": "mobile",
+      "label": "Mobile"
+    }
   ],
   "xAxis": "month",
+  "height": 300,
   "curve": "smooth",
-  "showLegend": true
+  "showDots": false,
+  "showLegend": true,
+  "showTooltip": true,
+  "showGrid": true
 }
 ```
 </CodeGroup>
@@ -153,7 +237,7 @@ LineChart(
 
 Set `curve="step"` to connect points with step-shaped lines. This is useful for data that changes in discrete jumps.
 
-<ComponentPreview auto json={`{"type":"LineChart","data":[{"month":"Jan","desktop":186,"mobile":80},{"month":"Feb","desktop":305,"mobile":200},{"month":"Mar","desktop":237,"mobile":120},{"month":"Apr","desktop":73,"mobile":190},{"month":"May","desktop":209,"mobile":130},{"month":"Jun","desktop":214,"mobile":140}],"series":[{"dataKey":"desktop","label":"Desktop"},{"dataKey":"mobile","label":"Mobile"}],"xAxis":"month","height":300,"curve":"step","showLegend":true,"showTooltip":true,"showGrid":true}`}>
+<ComponentPreview auto json={`{"type":"LineChart","data":[{"month":"Jan","desktop":186,"mobile":80},{"month":"Feb","desktop":305,"mobile":200},{"month":"Mar","desktop":237,"mobile":120},{"month":"Apr","desktop":73,"mobile":190},{"month":"May","desktop":209,"mobile":130},{"month":"Jun","desktop":214,"mobile":140}],"series":[{"dataKey":"desktop","label":"Desktop"},{"dataKey":"mobile","label":"Mobile"}],"xAxis":"month","height":300,"curve":"step","showDots":false,"showLegend":true,"showTooltip":true,"showGrid":true}`}>
 <CodeGroup>
 ```python Python {8}
 LineChart(
@@ -167,17 +251,58 @@ LineChart(
     show_legend=True,
 )
 ```
-```json Protocol {9}
+```json Protocol
 {
   "type": "LineChart",
-  "data": "...",
+  "data": [
+    {
+      "month": "Jan",
+      "desktop": 186,
+      "mobile": 80
+    },
+    {
+      "month": "Feb",
+      "desktop": 305,
+      "mobile": 200
+    },
+    {
+      "month": "Mar",
+      "desktop": 237,
+      "mobile": 120
+    },
+    {
+      "month": "Apr",
+      "desktop": 73,
+      "mobile": 190
+    },
+    {
+      "month": "May",
+      "desktop": 209,
+      "mobile": 130
+    },
+    {
+      "month": "Jun",
+      "desktop": 214,
+      "mobile": 140
+    }
+  ],
   "series": [
-    {"dataKey": "desktop", "label": "Desktop"},
-    {"dataKey": "mobile", "label": "Mobile"}
+    {
+      "dataKey": "desktop",
+      "label": "Desktop"
+    },
+    {
+      "dataKey": "mobile",
+      "label": "Mobile"
+    }
   ],
   "xAxis": "month",
+  "height": 300,
   "curve": "step",
-  "showLegend": true
+  "showDots": false,
+  "showLegend": true,
+  "showTooltip": true,
+  "showGrid": true
 }
 ```
 </CodeGroup>
@@ -187,7 +312,7 @@ LineChart(
 
 Set `show_dots=True` to render a dot at each data point along the lines.
 
-<ComponentPreview auto json={`{"type":"LineChart","data":[{"month":"Jan","desktop":186,"mobile":80},{"month":"Feb","desktop":305,"mobile":200},{"month":"Mar","desktop":237,"mobile":120},{"month":"Apr","desktop":73,"mobile":190},{"month":"May","desktop":209,"mobile":130},{"month":"Jun","desktop":214,"mobile":140}],"series":[{"dataKey":"desktop","label":"Desktop"},{"dataKey":"mobile","label":"Mobile"}],"xAxis":"month","height":300,"showDots":true,"showLegend":true,"showTooltip":true,"showGrid":true}`}>
+<ComponentPreview auto json={`{"type":"LineChart","data":[{"month":"Jan","desktop":186,"mobile":80},{"month":"Feb","desktop":305,"mobile":200},{"month":"Mar","desktop":237,"mobile":120},{"month":"Apr","desktop":73,"mobile":190},{"month":"May","desktop":209,"mobile":130},{"month":"Jun","desktop":214,"mobile":140}],"series":[{"dataKey":"desktop","label":"Desktop"},{"dataKey":"mobile","label":"Mobile"}],"xAxis":"month","height":300,"curve":"linear","showDots":true,"showLegend":true,"showTooltip":true,"showGrid":true}`}>
 <CodeGroup>
 ```python Python {8}
 LineChart(
@@ -201,17 +326,58 @@ LineChart(
     show_legend=True,
 )
 ```
-```json Protocol {9}
+```json Protocol
 {
   "type": "LineChart",
-  "data": "...",
+  "data": [
+    {
+      "month": "Jan",
+      "desktop": 186,
+      "mobile": 80
+    },
+    {
+      "month": "Feb",
+      "desktop": 305,
+      "mobile": 200
+    },
+    {
+      "month": "Mar",
+      "desktop": 237,
+      "mobile": 120
+    },
+    {
+      "month": "Apr",
+      "desktop": 73,
+      "mobile": 190
+    },
+    {
+      "month": "May",
+      "desktop": 209,
+      "mobile": 130
+    },
+    {
+      "month": "Jun",
+      "desktop": 214,
+      "mobile": 140
+    }
+  ],
   "series": [
-    {"dataKey": "desktop", "label": "Desktop"},
-    {"dataKey": "mobile", "label": "Mobile"}
+    {
+      "dataKey": "desktop",
+      "label": "Desktop"
+    },
+    {
+      "dataKey": "mobile",
+      "label": "Mobile"
+    }
   ],
   "xAxis": "month",
+  "height": 300,
+  "curve": "linear",
   "showDots": true,
-  "showLegend": true
+  "showLegend": true,
+  "showTooltip": true,
+  "showGrid": true
 }
 ```
 </CodeGroup>

--- a/docs/components/pie-chart.mdx
+++ b/docs/components/pie-chart.mdx
@@ -15,14 +15,16 @@ PieChart shows how parts relate to a whole. Unlike the other chart types, it doe
 ```python Python
 from prefab_ui.components import PieChart
 
+data = [
+    {"browser": "Chrome", "visitors": 275},
+    {"browser": "Safari", "visitors": 200},
+    {"browser": "Firefox", "visitors": 187},
+    {"browser": "Edge", "visitors": 173},
+    {"browser": "Other", "visitors": 90},
+]
+
 PieChart(
-    data=[
-        {"browser": "Chrome", "visitors": 275},
-        {"browser": "Safari", "visitors": 200},
-        {"browser": "Firefox", "visitors": 187},
-        {"browser": "Edge", "visitors": 173},
-        {"browser": "Other", "visitors": 90},
-    ],
+    data=data,
     data_key="visitors",
     name_key="browser",
     show_legend=True,
@@ -129,7 +131,7 @@ PieChart(
 
 Set `show_label=True` to display a label on each slice, making values readable without tooltips.
 
-<ComponentPreview auto json={`{"type":"PieChart","data":[{"browser":"Chrome","visitors":275},{"browser":"Safari","visitors":200},{"browser":"Firefox","visitors":187},{"browser":"Edge","visitors":173},{"browser":"Other","visitors":90}],"dataKey":"visitors","nameKey":"browser","height":300,"innerRadius":0,"paddingAngle":0,"showLabel":true,"showLegend":true,"showTooltip":true}`}>
+<ComponentPreview auto json={`{"type":"PieChart","data":[{"browser":"Chrome","visitors":275},{"browser":"Safari","visitors":200},{"browser":"Firefox","visitors":187},{"browser":"Edge","visitors":173},{"browser":"Other","visitors":90}],"dataKey":"visitors","nameKey":"browser","height":300,"innerRadius":0,"showLabel":true,"paddingAngle":0,"showLegend":true,"showTooltip":true}`}>
 <CodeGroup>
 ```python Python {5}
 PieChart(
@@ -140,14 +142,39 @@ PieChart(
     show_legend=True,
 )
 ```
-```json Protocol {6}
+```json Protocol
 {
   "type": "PieChart",
-  "data": "...",
+  "data": [
+    {
+      "browser": "Chrome",
+      "visitors": 275
+    },
+    {
+      "browser": "Safari",
+      "visitors": 200
+    },
+    {
+      "browser": "Firefox",
+      "visitors": 187
+    },
+    {
+      "browser": "Edge",
+      "visitors": 173
+    },
+    {
+      "browser": "Other",
+      "visitors": 90
+    }
+  ],
   "dataKey": "visitors",
   "nameKey": "browser",
+  "height": 300,
+  "innerRadius": 0,
   "showLabel": true,
-  "showLegend": true
+  "paddingAngle": 0,
+  "showLegend": true,
+  "showTooltip": true
 }
 ```
 </CodeGroup>
@@ -157,7 +184,7 @@ PieChart(
 
 Set `padding_angle` to add space between slices, visually separating each segment.
 
-<ComponentPreview auto json={`{"type":"PieChart","data":[{"browser":"Chrome","visitors":275},{"browser":"Safari","visitors":200},{"browser":"Firefox","visitors":187},{"browser":"Edge","visitors":173},{"browser":"Other","visitors":90}],"dataKey":"visitors","nameKey":"browser","height":300,"innerRadius":60,"paddingAngle":5,"showLabel":false,"showLegend":true,"showTooltip":true}`}>
+<ComponentPreview auto json={`{"type":"PieChart","data":[{"browser":"Chrome","visitors":275},{"browser":"Safari","visitors":200},{"browser":"Firefox","visitors":187},{"browser":"Edge","visitors":173},{"browser":"Other","visitors":90}],"dataKey":"visitors","nameKey":"browser","height":300,"innerRadius":60,"showLabel":false,"paddingAngle":5,"showLegend":true,"showTooltip":true}`}>
 <CodeGroup>
 ```python Python {6}
 PieChart(
@@ -169,15 +196,39 @@ PieChart(
     show_legend=True,
 )
 ```
-```json Protocol {7}
+```json Protocol
 {
   "type": "PieChart",
-  "data": "...",
+  "data": [
+    {
+      "browser": "Chrome",
+      "visitors": 275
+    },
+    {
+      "browser": "Safari",
+      "visitors": 200
+    },
+    {
+      "browser": "Firefox",
+      "visitors": 187
+    },
+    {
+      "browser": "Edge",
+      "visitors": 173
+    },
+    {
+      "browser": "Other",
+      "visitors": 90
+    }
+  ],
   "dataKey": "visitors",
   "nameKey": "browser",
+  "height": 300,
   "innerRadius": 60,
+  "showLabel": false,
   "paddingAngle": 5,
-  "showLegend": true
+  "showLegend": true,
+  "showTooltip": true
 }
 ```
 </CodeGroup>

--- a/docs/components/radar-chart.mdx
+++ b/docs/components/radar-chart.mdx
@@ -15,14 +15,16 @@ RadarChart plots data across multiple axes radiating from a center point, formin
 ```python Python
 from prefab_ui.components import RadarChart, ChartSeries
 
+data = [
+    {"subject": "Math", "alice": 120, "bob": 98},
+    {"subject": "English", "alice": 98, "bob": 130},
+    {"subject": "Science", "alice": 86, "bob": 110},
+    {"subject": "History", "alice": 99, "bob": 95},
+    {"subject": "Art", "alice": 85, "bob": 90},
+]
+
 RadarChart(
-    data=[
-        {"subject": "Math", "alice": 120, "bob": 98},
-        {"subject": "English", "alice": 98, "bob": 130},
-        {"subject": "Science", "alice": 86, "bob": 110},
-        {"subject": "History", "alice": 99, "bob": 95},
-        {"subject": "Art", "alice": 85, "bob": 90},
-    ],
+    data=data,
     series=[
         ChartSeries(data_key="alice", label="Alice"),
         ChartSeries(data_key="bob", label="Bob"),
@@ -87,7 +89,7 @@ RadarChart(
 
 Hide the polar grid for a cleaner look.
 
-<ComponentPreview auto json={`{"type":"RadarChart","data":[{"subject":"Math","score":120},{"subject":"English","score":98},{"subject":"Science","score":86},{"subject":"History","score":99},{"subject":"Art","score":85}],"series":[{"dataKey":"score","label":"Score"}],"axisKey":"subject","height":300,"showGrid":false}`}>
+<ComponentPreview auto json={`{"type":"RadarChart","data":[{"subject":"Math","alice":120,"bob":98},{"subject":"English","alice":98,"bob":130},{"subject":"Science","alice":86,"bob":110},{"subject":"History","alice":99,"bob":95},{"subject":"Art","alice":85,"bob":90}],"series":[{"dataKey":"score","label":"Score"}],"axisKey":"subject","height":300,"filled":true,"showDots":false,"showLegend":false,"showTooltip":true,"showGrid":false}`}>
 <CodeGroup>
 ```python Python {5}
 RadarChart(
@@ -97,12 +99,48 @@ RadarChart(
     show_grid=False,
 )
 ```
-```json Protocol {6}
+```json Protocol
 {
   "type": "RadarChart",
-  "data": "...",
-  "series": [{"dataKey": "score", "label": "Score"}],
+  "data": [
+    {
+      "subject": "Math",
+      "alice": 120,
+      "bob": 98
+    },
+    {
+      "subject": "English",
+      "alice": 98,
+      "bob": 130
+    },
+    {
+      "subject": "Science",
+      "alice": 86,
+      "bob": 110
+    },
+    {
+      "subject": "History",
+      "alice": 99,
+      "bob": 95
+    },
+    {
+      "subject": "Art",
+      "alice": 85,
+      "bob": 90
+    }
+  ],
+  "series": [
+    {
+      "dataKey": "score",
+      "label": "Score"
+    }
+  ],
   "axisKey": "subject",
+  "height": 300,
+  "filled": true,
+  "showDots": false,
+  "showLegend": false,
+  "showTooltip": true,
   "showGrid": false
 }
 ```
@@ -127,17 +165,53 @@ RadarChart(
     show_legend=True,
 )
 ```
-```json Protocol {9}
+```json Protocol
 {
   "type": "RadarChart",
-  "data": "...",
+  "data": [
+    {
+      "subject": "Math",
+      "alice": 120,
+      "bob": 98
+    },
+    {
+      "subject": "English",
+      "alice": 98,
+      "bob": 130
+    },
+    {
+      "subject": "Science",
+      "alice": 86,
+      "bob": 110
+    },
+    {
+      "subject": "History",
+      "alice": 99,
+      "bob": 95
+    },
+    {
+      "subject": "Art",
+      "alice": 85,
+      "bob": 90
+    }
+  ],
   "series": [
-    {"dataKey": "alice", "label": "Alice"},
-    {"dataKey": "bob", "label": "Bob"}
+    {
+      "dataKey": "alice",
+      "label": "Alice"
+    },
+    {
+      "dataKey": "bob",
+      "label": "Bob"
+    }
   ],
   "axisKey": "subject",
+  "height": 300,
   "filled": false,
-  "showLegend": true
+  "showDots": false,
+  "showLegend": true,
+  "showTooltip": true,
+  "showGrid": true
 }
 ```
 </CodeGroup>

--- a/docs/components/radial-chart.mdx
+++ b/docs/components/radial-chart.mdx
@@ -15,14 +15,16 @@ RadialChart renders each data item as a concentric ring, with length proportiona
 ```python Python
 from prefab_ui.components import RadialChart
 
+data = [
+    {"browser": "Chrome", "visitors": 275},
+    {"browser": "Safari", "visitors": 200},
+    {"browser": "Firefox", "visitors": 187},
+    {"browser": "Edge", "visitors": 173},
+    {"browser": "Other", "visitors": 90},
+]
+
 RadialChart(
-    data=[
-        {"browser": "Chrome", "visitors": 275},
-        {"browser": "Safari", "visitors": 200},
-        {"browser": "Firefox", "visitors": 187},
-        {"browser": "Edge", "visitors": 173},
-        {"browser": "Other", "visitors": 90},
-    ],
+    data=data,
     data_key="visitors",
     name_key="browser",
     show_legend=True,
@@ -141,15 +143,39 @@ RadialChart(
     show_legend=True,
 )
 ```
-```json Protocol {6-7}
+```json Protocol
 {
   "type": "RadialChart",
-  "data": "...",
+  "data": [
+    {
+      "browser": "Chrome",
+      "visitors": 275
+    },
+    {
+      "browser": "Safari",
+      "visitors": 200
+    },
+    {
+      "browser": "Firefox",
+      "visitors": 187
+    },
+    {
+      "browser": "Edge",
+      "visitors": 173
+    },
+    {
+      "browser": "Other",
+      "visitors": 90
+    }
+  ],
   "dataKey": "visitors",
   "nameKey": "browser",
+  "height": 300,
+  "innerRadius": 30,
   "startAngle": 90,
   "endAngle": -270,
-  "showLegend": true
+  "showLegend": true,
+  "showTooltip": true
 }
 ```
 </CodeGroup>

--- a/docs/welcome.mdx
+++ b/docs/welcome.mdx
@@ -5,6 +5,8 @@ description: The agentic frontend framework that even humans can use.
 icon: hand-wave
 ---
 
+import { ComponentPreview } from '/snippets/component-preview.mdx'
+
 <img
   src="/assets/banner.png"
   alt="Prefab"
@@ -14,35 +16,84 @@ icon: hand-wave
 
 **Prefab is a JSON component format that renders to real interactive frontends.** Describe a UI — from an MCP server, a ChatGPT app, an AI agent, or a Python script — and Prefab renders it as a live React application with forms, tables, state management, and real-time interactivity.
 
-For human authors, there's a Python DSL:
+<ComponentPreview auto json={`{"_tree":{"type":"Card","children":[{"type":"CardContent","children":[{"cssClass":"gap-3","type":"Column","children":[{"content":"Hello, {{ name }}!","type":"H3"},{"content":"Type below and watch this update in real time.","type":"Muted"},{"type":"Input","inputType":"text","placeholder":"Your name...","name":"name","disabled":false,"required":false},{"cssClass":"gap-2","type":"Row","children":[{"type":"Badge","label":"{{ name }}","variant":"default"},{"type":"Badge","label":"Prefab","variant":"secondary"}]}]}]}]},"_state":{"name":"world"}}`}>
+<CodeGroup>
+```python Python icon="python"
+from prefab_ui.components import Card, CardContent, Column, H3, Muted, Input, Badge, Row
 
-```python
-from prefab_ui import UIResponse, Column, Heading, Text
-from prefab_ui.components import Card, CardContent, Input, Button, Row
-from prefab_ui.actions import ToolCall
+set_initial_state(name="world")
 
-def search_dashboard(query: str = "") -> UIResponse:
-    with Column() as view:
-        Heading("Search")
-        with Row():
-            Input(name="query", placeholder="Search...")
-            Button(
-                "Go",
-                on_click=ToolCall(
-                    name="search",
-                    arguments={"q": "{{ query }}"},
-                    result_key="results",
-                ),
-            )
-        with Card():
-            with CardContent():
-                Text("{{ results.length }} results found")
-
-    return UIResponse(
-        state={"query": query, "results": []},
-        view=view,
-    )
+with Card():
+    with CardContent():
+        with Column(gap=3):
+            H3("Hello, {{ name }}!")
+            Muted("Type below and watch this update in real time.")
+            Input(name="name", placeholder="Your name...")
+            with Row(gap=2):
+                Badge("{{ name }}", variant="default")
+                Badge("Prefab", variant="secondary")
 ```
+```json Protocol icon="brackets-curly"
+{
+  "_tree": {
+    "type": "Card",
+    "children": [
+      {
+        "type": "CardContent",
+        "children": [
+          {
+            "cssClass": "gap-3",
+            "type": "Column",
+            "children": [
+              {
+                "content": "Hello, {{ name }}!",
+                "type": "H3"
+              },
+              {
+                "content": "Type below and watch this update in real time.",
+                "type": "Muted"
+              },
+              {
+                "type": "Input",
+                "inputType": "text",
+                "placeholder": "Your name...",
+                "name": "name",
+                "disabled": false,
+                "required": false
+              },
+              {
+                "cssClass": "gap-2",
+                "type": "Row",
+                "children": [
+                  {
+                    "type": "Badge",
+                    "label": "{{ name }}",
+                    "variant": "default"
+                  },
+                  {
+                    "type": "Badge",
+                    "label": "Prefab",
+                    "variant": "secondary"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "_state": {
+    "name": "world"
+  }
+}
+```
+</CodeGroup>
+</ComponentPreview>
+
+<Tip>
+Every example in the Prefab docs — including this one! — is rendered with Prefab from the Python code.
+</Tip>
 
 Prefab is made with 💙 by [Prefect](https://www.prefect.io/).
 
@@ -63,10 +114,6 @@ The core idea is a pipeline: **JSON → React**. For Python authors, it's **Pyth
 3. A React renderer (shipped as `@prefecthq/prefab-ui` on npm) compiles the JSON into a live interface
 
 State flows through templates. When you write `{{ query }}`, the renderer interpolates the current value of `query` from client-side state. Actions like `ToolCall` and `SetState` update that state, keeping the UI reactive.
-
-<Tip>
-Every component example in these docs is written in Python and rendered by Prefab itself — the same pipeline your own code uses.
-</Tip>
 
 ## Installation
 

--- a/renderer/src/playground/examples.json
+++ b/renderer/src/playground/examples.json
@@ -152,7 +152,7 @@
   {
     "title": "Python",
     "category": "Components",
-    "code": "from prefab_ui.components import AreaChart, ChartSeries\n\nAreaChart(\n    data=[\n        {\"month\": \"Jan\", \"desktop\": 186, \"mobile\": 80},\n        {\"month\": \"Feb\", \"desktop\": 305, \"mobile\": 200},\n        {\"month\": \"Mar\", \"desktop\": 237, \"mobile\": 120},\n        {\"month\": \"Apr\", \"desktop\": 73, \"mobile\": 190},\n        {\"month\": \"May\", \"desktop\": 209, \"mobile\": 130},\n        {\"month\": \"Jun\", \"desktop\": 214, \"mobile\": 140},\n    ],\n    series=[\n        ChartSeries(data_key=\"desktop\", label=\"Desktop\"),\n        ChartSeries(data_key=\"mobile\", label=\"Mobile\"),\n    ],\n    x_axis=\"month\",\n    show_legend=True,\n)"
+    "code": "from prefab_ui.components import AreaChart, ChartSeries\n\ndata = [\n    {\"month\": \"Jan\", \"desktop\": 186, \"mobile\": 80},\n    {\"month\": \"Feb\", \"desktop\": 305, \"mobile\": 200},\n    {\"month\": \"Mar\", \"desktop\": 237, \"mobile\": 120},\n    {\"month\": \"Apr\", \"desktop\": 73, \"mobile\": 190},\n    {\"month\": \"May\", \"desktop\": 209, \"mobile\": 130},\n    {\"month\": \"Jun\", \"desktop\": 214, \"mobile\": 140},\n]\n\nAreaChart(\n    data=data,\n    series=[\n        ChartSeries(data_key=\"desktop\", label=\"Desktop\"),\n        ChartSeries(data_key=\"mobile\", label=\"Mobile\"),\n    ],\n    x_axis=\"month\",\n    show_legend=True,\n)"
   },
   {
     "title": "Python {8}",
@@ -192,7 +192,7 @@
   {
     "title": "Python",
     "category": "Components",
-    "code": "from prefab_ui.components import BarChart, ChartSeries\n\nBarChart(\n    data=[\n        {\"month\": \"Jan\", \"desktop\": 186, \"mobile\": 80},\n        {\"month\": \"Feb\", \"desktop\": 305, \"mobile\": 200},\n        {\"month\": \"Mar\", \"desktop\": 237, \"mobile\": 120},\n        {\"month\": \"Apr\", \"desktop\": 73, \"mobile\": 190},\n        {\"month\": \"May\", \"desktop\": 209, \"mobile\": 130},\n        {\"month\": \"Jun\", \"desktop\": 214, \"mobile\": 140},\n    ],\n    series=[\n        ChartSeries(data_key=\"desktop\", label=\"Desktop\"),\n        ChartSeries(data_key=\"mobile\", label=\"Mobile\"),\n    ],\n    x_axis=\"month\",\n    show_legend=True,\n)"
+    "code": "from prefab_ui.components import BarChart, ChartSeries\n\ndata = [\n    {\"month\": \"Jan\", \"desktop\": 186, \"mobile\": 80},\n    {\"month\": \"Feb\", \"desktop\": 305, \"mobile\": 200},\n    {\"month\": \"Mar\", \"desktop\": 237, \"mobile\": 120},\n    {\"month\": \"Apr\", \"desktop\": 73, \"mobile\": 190},\n    {\"month\": \"May\", \"desktop\": 209, \"mobile\": 130},\n    {\"month\": \"Jun\", \"desktop\": 214, \"mobile\": 140},\n]\n\nBarChart(\n    data=data,\n    series=[\n        ChartSeries(data_key=\"desktop\", label=\"Desktop\"),\n        ChartSeries(data_key=\"mobile\", label=\"Mobile\"),\n    ],\n    x_axis=\"month\",\n    show_legend=True,\n)"
   },
   {
     "title": "Python {8}",
@@ -572,7 +572,7 @@
   {
     "title": "Python",
     "category": "Components",
-    "code": "from prefab_ui.components import LineChart, ChartSeries\n\nLineChart(\n    data=[\n        {\"month\": \"Jan\", \"desktop\": 186, \"mobile\": 80},\n        {\"month\": \"Feb\", \"desktop\": 305, \"mobile\": 200},\n        {\"month\": \"Mar\", \"desktop\": 237, \"mobile\": 120},\n        {\"month\": \"Apr\", \"desktop\": 73, \"mobile\": 190},\n        {\"month\": \"May\", \"desktop\": 209, \"mobile\": 130},\n        {\"month\": \"Jun\", \"desktop\": 214, \"mobile\": 140},\n    ],\n    series=[\n        ChartSeries(data_key=\"desktop\", label=\"Desktop\"),\n        ChartSeries(data_key=\"mobile\", label=\"Mobile\"),\n    ],\n    x_axis=\"month\",\n    show_legend=True,\n)"
+    "code": "from prefab_ui.components import LineChart, ChartSeries\n\ndata = [\n    {\"month\": \"Jan\", \"desktop\": 186, \"mobile\": 80},\n    {\"month\": \"Feb\", \"desktop\": 305, \"mobile\": 200},\n    {\"month\": \"Mar\", \"desktop\": 237, \"mobile\": 120},\n    {\"month\": \"Apr\", \"desktop\": 73, \"mobile\": 190},\n    {\"month\": \"May\", \"desktop\": 209, \"mobile\": 130},\n    {\"month\": \"Jun\", \"desktop\": 214, \"mobile\": 140},\n]\n\nLineChart(\n    data=data,\n    series=[\n        ChartSeries(data_key=\"desktop\", label=\"Desktop\"),\n        ChartSeries(data_key=\"mobile\", label=\"Mobile\"),\n    ],\n    x_axis=\"month\",\n    show_legend=True,\n)"
   },
   {
     "title": "Python {5}",
@@ -612,7 +612,7 @@
   {
     "title": "Python",
     "category": "Components",
-    "code": "from prefab_ui.components import PieChart\n\nPieChart(\n    data=[\n        {\"browser\": \"Chrome\", \"visitors\": 275},\n        {\"browser\": \"Safari\", \"visitors\": 200},\n        {\"browser\": \"Firefox\", \"visitors\": 187},\n        {\"browser\": \"Edge\", \"visitors\": 173},\n        {\"browser\": \"Other\", \"visitors\": 90},\n    ],\n    data_key=\"visitors\",\n    name_key=\"browser\",\n    show_legend=True,\n)"
+    "code": "from prefab_ui.components import PieChart\n\ndata = [\n    {\"browser\": \"Chrome\", \"visitors\": 275},\n    {\"browser\": \"Safari\", \"visitors\": 200},\n    {\"browser\": \"Firefox\", \"visitors\": 187},\n    {\"browser\": \"Edge\", \"visitors\": 173},\n    {\"browser\": \"Other\", \"visitors\": 90},\n]\n\nPieChart(\n    data=data,\n    data_key=\"visitors\",\n    name_key=\"browser\",\n    show_legend=True,\n)"
   },
   {
     "title": "Python",
@@ -667,7 +667,7 @@
   {
     "title": "Python",
     "category": "Components",
-    "code": "from prefab_ui.components import RadarChart, ChartSeries\n\nRadarChart(\n    data=[\n        {\"subject\": \"Math\", \"alice\": 120, \"bob\": 98},\n        {\"subject\": \"English\", \"alice\": 98, \"bob\": 130},\n        {\"subject\": \"Science\", \"alice\": 86, \"bob\": 110},\n        {\"subject\": \"History\", \"alice\": 99, \"bob\": 95},\n        {\"subject\": \"Art\", \"alice\": 85, \"bob\": 90},\n    ],\n    series=[\n        ChartSeries(data_key=\"alice\", label=\"Alice\"),\n        ChartSeries(data_key=\"bob\", label=\"Bob\"),\n    ],\n    axis_key=\"subject\",\n    show_legend=True,\n)"
+    "code": "from prefab_ui.components import RadarChart, ChartSeries\n\ndata = [\n    {\"subject\": \"Math\", \"alice\": 120, \"bob\": 98},\n    {\"subject\": \"English\", \"alice\": 98, \"bob\": 130},\n    {\"subject\": \"Science\", \"alice\": 86, \"bob\": 110},\n    {\"subject\": \"History\", \"alice\": 99, \"bob\": 95},\n    {\"subject\": \"Art\", \"alice\": 85, \"bob\": 90},\n]\n\nRadarChart(\n    data=data,\n    series=[\n        ChartSeries(data_key=\"alice\", label=\"Alice\"),\n        ChartSeries(data_key=\"bob\", label=\"Bob\"),\n    ],\n    axis_key=\"subject\",\n    show_legend=True,\n)"
   },
   {
     "title": "Python {5}",
@@ -682,7 +682,7 @@
   {
     "title": "Python",
     "category": "Components",
-    "code": "from prefab_ui.components import RadialChart\n\nRadialChart(\n    data=[\n        {\"browser\": \"Chrome\", \"visitors\": 275},\n        {\"browser\": \"Safari\", \"visitors\": 200},\n        {\"browser\": \"Firefox\", \"visitors\": 187},\n        {\"browser\": \"Edge\", \"visitors\": 173},\n        {\"browser\": \"Other\", \"visitors\": 90},\n    ],\n    data_key=\"visitors\",\n    name_key=\"browser\",\n    show_legend=True,\n)"
+    "code": "from prefab_ui.components import RadialChart\n\ndata = [\n    {\"browser\": \"Chrome\", \"visitors\": 275},\n    {\"browser\": \"Safari\", \"visitors\": 200},\n    {\"browser\": \"Firefox\", \"visitors\": 187},\n    {\"browser\": \"Edge\", \"visitors\": 173},\n    {\"browser\": \"Other\", \"visitors\": 90},\n]\n\nRadialChart(\n    data=data,\n    data_key=\"visitors\",\n    name_key=\"browser\",\n    show_legend=True,\n)"
   },
   {
     "title": "Python",
@@ -1300,8 +1300,8 @@
     "code": "from prefab_ui import Define, Use, UIResponse\nfrom prefab_ui.components import (\n    Card, CardHeader, CardTitle, CardDescription,\n    Column, ForEach, Heading,\n)\n\nwith Define(\"project-card\") as project_card:\n    with Card():\n        with CardHeader():\n            CardTitle(\"{{ name }}\")\n            CardDescription(\"{{ description }}\")\n\nwith Column(gap=4) as view:\n    Heading(\"Featured\")\n    Use(\"project-card\", name=\"Prefab\", description=\"The agentic frontend framework\")\n\n    Heading(\"All Projects\")\n    with ForEach(\"projects\"):\n        Use(\"project-card\")\n\nUIResponse(\n    view=view,\n    defs=[project_card],\n    data={\"projects\": [\n        {\"name\": \"Alpha\", \"description\": \"First project\"},\n        {\"name\": \"Beta\", \"description\": \"Second project\"},\n    ]},\n)"
   },
   {
-    "title": "from prefab_ui import UIResponse, Column, Heading, Text",
+    "title": "Python",
     "category": "General",
-    "code": "from prefab_ui.components import Card, CardContent, Input, Button, Row\nfrom prefab_ui.actions import ToolCall\n\ndef search_dashboard(query: str = \"\") -> UIResponse:\n    with Column() as view:\n        Heading(\"Search\")\n        with Row():\n            Input(name=\"query\", placeholder=\"Search...\")\n            Button(\n                \"Go\",\n                on_click=ToolCall(\n                    name=\"search\",\n                    arguments={\"q\": \"{{ query }}\"},\n                    result_key=\"results\",\n                ),\n            )\n        with Card():\n            with CardContent():\n                Text(\"{{ results.length }} results found\")\n\n    return UIResponse(\n        state={\"query\": query, \"results\": []},\n        view=view,\n    )"
+    "code": "from prefab_ui.components import Card, CardContent, Column, H3, Muted, Input, Badge, Row\n\nset_initial_state(name=\"world\")\n\nwith Card():\n    with CardContent():\n        with Column(gap=3):\n            H3(\"Hello, {{ name }}!\")\n            Muted(\"Type below and watch this update in real time.\")\n            Input(name=\"name\", placeholder=\"Your name...\")\n            with Row(gap=2):\n                Badge(\"{{ name }}\", variant=\"default\")\n                Badge(\"Prefab\", variant=\"secondary\")"
   }
 ]


### PR DESCRIPTION
The welcome page showed a big code block with no visual payoff. Now it leads with a live `ComponentPreview` — an interactive card with reactive `{{ name }}` interpolation — so visitors immediately see what Prefab renders before reading any code.

While wiring this up, fixed two build pipeline issues:

**Auto `npm install`** — `prefab dev build-docs` now checks whether `renderer/node_modules` is missing or stale relative to `package-lock.json` and runs `npm install` automatically. No more cryptic vite errors after switching machines.

**Chart doc shared namespace** — The 6 chart component docs (`area-chart`, `bar-chart`, `line-chart`, `pie-chart`, `radar-chart`, `radial-chart`) defined data inline as a keyword arg in the first preview, so `data` never entered the shared namespace for later previews. Extracted `data = [...]` as a standalone variable so subsequent blocks can reference it. Fixes all 16 `name 'data' is not defined` errors during build.