### PR TITLE
Add icons to code block tabs and fix hover propagation

### DIFF
--- a/docs/_preview-build/render_previews.py
+++ b/docs/_preview-build/render_previews.py
@@ -154,6 +154,9 @@ def _rebuild_block(
     python_fence_open = python_m.group(1)  # ```python {3} Python\n etc.
     python_source = python_m.group(2)  # the code
     python_fence_close = python_m.group(3)  # ```
+    # Ensure the Python fence line has the icon attribute
+    if "icon=" not in python_fence_open:
+        python_fence_open = python_fence_open.rstrip("\n") + ' icon="python"\n'
     python_block = python_fence_open + python_source + python_fence_close
 
     # Execute the Python and get JSON
@@ -170,7 +173,7 @@ def _rebuild_block(
     if hide_json:
         new_interior = f"\n{python_block}\n"
     else:
-        json_block = f"```json Protocol\n{pretty_json}\n```"
+        json_block = f'```json Protocol icon="brackets-curly"\n{pretty_json}\n```'
         new_interior = f"\n<CodeGroup>\n{python_block}\n{json_block}\n</CodeGroup>\n"
 
     return new_opening + new_interior + closing_tag

--- a/docs/actions/call-tool.mdx
+++ b/docs/actions/call-tool.mdx
@@ -10,13 +10,13 @@ import { ComponentPreview } from '/snippets/component-preview.mdx'
 
 <ComponentPreview auto json={`{"type":"Button","label":"Refresh Data","variant":"default","size":"default","disabled":false,"onClick":{"action":"toolCall","tool":"get_latest_data","arguments":{}}}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import Button
 from prefab_ui import ToolCall
 
 Button("Refresh Data", on_click=ToolCall("get_latest_data"))
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "Button",
   "label": "Refresh Data",
@@ -41,7 +41,7 @@ Use `{{ key }}` interpolation in the `arguments` dict to pass client state to th
 
 <ComponentPreview auto json={`{"cssClass":"gap-3","type":"Column","children":[{"type":"Input","inputType":"text","placeholder":"Enter a city...","name":"city","disabled":false,"required":false},{"type":"Button","label":"Get Weather","variant":"default","size":"default","disabled":false,"onClick":{"action":"toolCall","tool":"get_weather","arguments":{"location":"{{ city }}"}}}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import Input, Button, Column
 from prefab_ui import ToolCall
 
@@ -52,7 +52,7 @@ with Column(gap=3):
         arguments={"location": "{{ city }}"},
     ))
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-3",
   "type": "Column",

--- a/docs/actions/open-link.mdx
+++ b/docs/actions/open-link.mdx
@@ -10,14 +10,14 @@ import { ComponentPreview } from '/snippets/component-preview.mdx'
 
 <ComponentPreview auto json={`{"type":"Button","label":"View Documentation","variant":"link","size":"default","disabled":false,"onClick":{"action":"openLink","url":"https://prefab-ui.dev"}}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import Button
 from prefab_ui import OpenLink
 
 Button("View Documentation", variant="link",
        on_click=OpenLink("https://prefab-ui.dev"))
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "Button",
   "label": "View Documentation",
@@ -39,7 +39,7 @@ Pair `OpenLink` with the `link` button variant for a natural look:
 
 <ComponentPreview auto json={`{"cssClass":"gap-4","type":"Row","children":[{"type":"Button","label":"GitHub","variant":"link","size":"default","disabled":false,"onClick":{"action":"openLink","url":"https://github.com/prefecthq/prefab"}},{"type":"Button","label":"PyPI","variant":"link","size":"default","disabled":false,"onClick":{"action":"openLink","url":"https://pypi.org/project/prefab-ui"}}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import Button, Row
 from prefab_ui import OpenLink
 
@@ -49,7 +49,7 @@ with Row(gap=4):
     Button("PyPI", variant="link",
            on_click=OpenLink("https://pypi.org/project/prefab-ui"))
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-4",
   "type": "Row",
@@ -88,7 +88,7 @@ Build URLs from client state using interpolation:
 
 <ComponentPreview auto json={`{"cssClass":"gap-3","type":"Column","children":[{"type":"Input","inputType":"text","placeholder":"owner/repo","name":"repo","disabled":false,"required":false},{"type":"Button","label":"Open on GitHub","variant":"default","size":"default","disabled":false,"onClick":{"action":"openLink","url":"https://github.com/{{ repo }}"}}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import Input, Button, Column
 from prefab_ui import OpenLink
 
@@ -98,7 +98,7 @@ with Column(gap=3):
         "https://github.com/{{ repo }}"
     ))
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-3",
   "type": "Column",

--- a/docs/actions/send-message.mdx
+++ b/docs/actions/send-message.mdx
@@ -10,13 +10,13 @@ import { ComponentPreview } from '/snippets/component-preview.mdx'
 
 <ComponentPreview auto json={`{"type":"Button","label":"Summarize","variant":"default","size":"default","disabled":false,"onClick":{"action":"sendMessage","content":"Please summarize the data above."}}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import Button
 from prefab_ui import SendMessage
 
 Button("Summarize", on_click=SendMessage("Please summarize the data above."))
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "Button",
   "label": "Summarize",
@@ -40,7 +40,7 @@ Build a row of follow-up actions that save the user from typing:
 
 <ComponentPreview auto json={`{"cssClass":"gap-3","type":"Column","children":[{"content":"Quick Actions","type":"H3"},{"cssClass":"gap-2","type":"Row","children":[{"type":"Button","label":"Summarize","variant":"outline","size":"default","disabled":false,"onClick":{"action":"sendMessage","content":"Summarize these results."}},{"type":"Button","label":"Explain Further","variant":"outline","size":"default","disabled":false,"onClick":{"action":"sendMessage","content":"Explain these results in more detail."}},{"type":"Button","label":"Compare Options","variant":"outline","size":"default","disabled":false,"onClick":{"action":"sendMessage","content":"Compare the top options and recommend one."}}]}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import Button, Row, H3, Column
 from prefab_ui import SendMessage
 
@@ -54,7 +54,7 @@ with Column(gap=3):
         Button("Compare Options", variant="outline",
                on_click=SendMessage("Compare the top options and recommend one."))
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-3",
   "type": "Column",
@@ -114,7 +114,7 @@ Combine with state interpolation to include UI context in the message:
 
 <ComponentPreview auto json={`{"cssClass":"gap-3","type":"Column","children":[{"type":"Input","inputType":"text","placeholder":"Ask a follow-up question...","name":"question","disabled":false,"required":false},{"type":"Button","label":"Ask","variant":"default","size":"default","disabled":false,"onClick":{"action":"sendMessage","content":"{{ question }}"}}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import Input, Button, Column
 from prefab_ui import SendMessage
 
@@ -122,7 +122,7 @@ with Column(gap=3):
     Input(name="question", placeholder="Ask a follow-up question...")
     Button("Ask", on_click=SendMessage("{{ question }}"))
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-3",
   "type": "Column",

--- a/docs/actions/set-state.mdx
+++ b/docs/actions/set-state.mdx
@@ -10,7 +10,7 @@ import { ComponentPreview } from '/snippets/component-preview.mdx'
 
 <ComponentPreview auto json={`{"_tree":{"cssClass":"gap-3","type":"Column","children":[{"type":"Slider","min":0.0,"max":100.0,"name":"brightness","disabled":false,"onChange":{"action":"setState","key":"brightness","value":"{{ $event }}"}},{"content":"Brightness: {{ brightness }}%","type":"Muted"}]},"_state":{"brightness":50}}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import Slider, Muted, Column
 from prefab_ui import SetState
 
@@ -21,7 +21,7 @@ with Column(gap=3):
            on_change=SetState("brightness"))
     Muted("Brightness: {{ brightness }}%")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "_tree": {
     "cssClass": "gap-3",
@@ -76,7 +76,7 @@ Pass a second argument to set a specific value instead of capturing the event. C
 
 <ComponentPreview auto json={`{"_tree":{"cssClass":"gap-3","type":"Column","children":[{"cssClass":"gap-2","type":"Row","children":[{"cssClass":"bg-blue-500 text-white","type":"Button","label":"Blue","variant":"default","size":"default","disabled":false,"onClick":{"action":"setState","key":"color","value":"bg-blue-500"}},{"cssClass":"bg-emerald-500 text-white","type":"Button","label":"Emerald","variant":"default","size":"default","disabled":false,"onClick":{"action":"setState","key":"color","value":"bg-emerald-500"}},{"cssClass":"bg-rose-500 text-white","type":"Button","label":"Rose","variant":"default","size":"default","disabled":false,"onClick":{"action":"setState","key":"color","value":"bg-rose-500"}},{"cssClass":"bg-amber-500 text-white","type":"Button","label":"Amber","variant":"default","size":"default","disabled":false,"onClick":{"action":"setState","key":"color","value":"bg-amber-500"}}]},{"cssClass":"{{ color }} h-10 rounded-md","type":"Div"}]},"_state":{"color":"bg-blue-500"}}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import Button, Div, Row, Column
 from prefab_ui import SetState
 
@@ -94,7 +94,7 @@ with Column(gap=3):
                on_click=SetState("color", "bg-amber-500"))
     Div(css_class="{{ color }} h-10 rounded-md")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "_tree": {
     "cssClass": "gap-3",
@@ -180,7 +180,7 @@ Use explicit values to build reset buttons:
 
 <ComponentPreview auto json={`{"_tree":{"cssClass":"gap-3","type":"Column","children":[{"type":"Slider","min":0.0,"max":100.0,"name":"volume","disabled":false,"onChange":{"action":"setState","key":"volume","value":"{{ $event }}"}},{"content":"Volume: {{ volume }}","type":"Muted"},{"type":"Button","label":"Reset to 50","variant":"outline","size":"default","disabled":false,"onClick":{"action":"setState","key":"volume","value":50}}]},"_state":{"volume":75}}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import Button, Slider, Muted, Column
 from prefab_ui import SetState
 
@@ -193,7 +193,7 @@ with Column(gap=3):
     Button("Reset to 50", variant="outline",
            on_click=SetState("volume", 50))
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "_tree": {
     "cssClass": "gap-3",
@@ -243,7 +243,7 @@ with Column(gap=3):
 
 <ComponentPreview auto json={`{"cssClass":"gap-2","type":"Column","children":[{"type":"Button","label":"Toggle Details","variant":"outline","size":"default","disabled":false,"onClick":{"action":"toggleState","key":"showDetails"}},{"visibleWhen":"showDetails","type":"Alert","variant":"default","children":[{"type":"AlertTitle","content":"Here are the details!"}]}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import Button, Alert, AlertTitle, Column
 from prefab_ui import ToggleState
 
@@ -253,7 +253,7 @@ with Column(gap=2):
     with Alert(visible_when="showDetails"):
         AlertTitle("Here are the details!")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-2",
   "type": "Column",
@@ -294,7 +294,7 @@ Each `ToggleState` key is independent, so you can manage multiple visibility sta
 
 <ComponentPreview auto json={`{"cssClass":"gap-3","type":"Column","children":[{"cssClass":"gap-2","type":"Row","children":[{"type":"Button","label":"Section A","variant":"outline","size":"default","disabled":false,"onClick":{"action":"toggleState","key":"showA"}},{"type":"Button","label":"Section B","variant":"outline","size":"default","disabled":false,"onClick":{"action":"toggleState","key":"showB"}},{"type":"Button","label":"Section C","variant":"outline","size":"default","disabled":false,"onClick":{"action":"toggleState","key":"showC"}}]},{"visibleWhen":"showA","content":"Content for section A","type":"P"},{"visibleWhen":"showB","content":"Content for section B","type":"P"},{"visibleWhen":"showC","content":"Content for section C","type":"P"}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import Button, P, Row, Column
 from prefab_ui import ToggleState
 
@@ -310,7 +310,7 @@ with Column(gap=3):
     P("Content for section B", visible_when="showB")
     P("Content for section C", visible_when="showC")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-3",
   "type": "Column",

--- a/docs/actions/update-context.mdx
+++ b/docs/actions/update-context.mdx
@@ -10,7 +10,7 @@ import { ComponentPreview } from '/snippets/component-preview.mdx'
 
 <ComponentPreview auto json={`{"type":"Button","label":"Use Advanced Mode","variant":"default","size":"default","disabled":false,"onClick":{"action":"updateContext","content":"User has selected advanced mode. Provide detailed technical responses."}}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import Button
 from prefab_ui import UpdateContext
 
@@ -18,7 +18,7 @@ Button("Use Advanced Mode", on_click=UpdateContext(
     content="User has selected advanced mode. Provide detailed technical responses."
 ))
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "Button",
   "label": "Use Advanced Mode",
@@ -48,7 +48,7 @@ For richer data, pass a dict instead of plain text:
 
 <ComponentPreview auto json={`{"cssClass":"gap-3","type":"Column","children":[{"type":"Select","placeholder":"Thinking level...","name":"thinking","size":"default","disabled":false,"required":false,"children":[{"type":"SelectOption","value":"low","label":"Low","selected":false,"disabled":false},{"type":"SelectOption","value":"medium","label":"Medium","selected":false,"disabled":false},{"type":"SelectOption","value":"high","label":"High","selected":false,"disabled":false}]},{"type":"Button","label":"Set Preference","variant":"default","size":"default","disabled":false,"onClick":{"action":"updateContext","structuredContent":{"preference":{"thinking":"{{ thinking }}"}}}}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import Button, Select, SelectOption, Column
 from prefab_ui import UpdateContext
 
@@ -61,7 +61,7 @@ with Column(gap=3):
         structured_content={"preference": {"thinking": "{{ thinking }}"}},
     ))
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-3",
   "type": "Column",

--- a/docs/components/accordion.mdx
+++ b/docs/components/accordion.mdx
@@ -12,7 +12,7 @@ Accordions let users expand and collapse sections to reveal content progressivel
 
 <ComponentPreview auto json={`{"type":"Accordion","multiple":false,"collapsible":true,"children":[{"type":"AccordionItem","title":"What is the Answer?","children":[{"type":"Text","content":"Forty-two. The Answer to the Ultimate Question of Life, the Universe, and Everything."}]},{"type":"AccordionItem","title":"What is the Heart of Gold?","children":[{"type":"Text","content":"A starship powered by the Infinite Improbability Drive. It can pass through every conceivable point in every conceivable universe almost simultaneously."}]},{"type":"AccordionItem","title":"What is Deep Thought?","children":[{"type":"Text","content":"A supercomputer designed to find the Answer to the Ultimate Question. It took 7.5 million years to compute: 42."}]}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import Accordion, AccordionItem, Text
 
 with Accordion():
@@ -36,7 +36,7 @@ with Accordion():
             "7.5 million years to compute: 42."
         )
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "Accordion",
   "multiple": false,
@@ -84,7 +84,7 @@ Use `default_open_items` to expand items when the accordion first renders. Pass 
 
 <ComponentPreview auto json={`{"type":"Accordion","multiple":false,"collapsible":true,"defaultValues":["What is the Answer?"],"children":[{"type":"AccordionItem","title":"What is the Answer?","children":[{"type":"Text","content":"Forty-two. The Answer to the Ultimate Question of Life, the Universe, and Everything."}]},{"type":"AccordionItem","title":"What is the Heart of Gold?","children":[{"type":"Text","content":"A starship powered by the Infinite Improbability Drive. It can pass through every conceivable point in every conceivable universe almost simultaneously."}]},{"type":"AccordionItem","title":"What is Deep Thought?","children":[{"type":"Text","content":"A supercomputer designed to find the Answer to the Ultimate Question. It took 7.5 million years to compute: 42."}]}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import Accordion, AccordionItem, Text
 
 with Accordion(default_open_items=0):
@@ -108,7 +108,7 @@ with Accordion(default_open_items=0):
             "7.5 million years to compute: 42."
         )
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "Accordion",
   "multiple": false,
@@ -169,7 +169,7 @@ Set `multiple=True` to allow more than one section open at a time.
 
 <ComponentPreview auto json={`{"type":"Accordion","multiple":true,"collapsible":true,"defaultValues":["Who is Arthur Dent?","Who is Ford Prefect?"],"children":[{"type":"AccordionItem","title":"Who is Arthur Dent?","children":[{"type":"Text","content":"An ordinary human from Earth, unexpectedly swept into the cosmos when his planet is demolished to make way for a hyperspace bypass."}]},{"type":"AccordionItem","title":"Who is Ford Prefect?","children":[{"type":"Text","content":"A researcher for the Hitchhiker's Guide to the Galaxy, and Arthur's best friend. He's from a small planet somewhere in the vicinity of Betelgeuse."}]},{"type":"AccordionItem","title":"What is the Guide?","children":[{"type":"Text","content":"A digital reference with the words 'Don't Panic' written in large, friendly letters on the cover."}]}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import Accordion, AccordionItem, Text
 
 with Accordion(
@@ -197,7 +197,7 @@ with Accordion(
             "letters on the cover."
         )
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "Accordion",
   "multiple": true,

--- a/docs/components/alert.mdx
+++ b/docs/components/alert.mdx
@@ -12,7 +12,7 @@ Alerts draw attention to important information. They pair a title with a descrip
 
 <ComponentPreview auto json={`{"type":"Alert","variant":"default","children":[{"type":"AlertTitle","content":"Heads up!"},{"type":"AlertDescription","content":"You can add components to your app using the CLI."}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import (
     Alert,
     AlertTitle,
@@ -23,7 +23,7 @@ with Alert():
     AlertTitle("Heads up!")
     AlertDescription("You can add components to your app using the CLI.")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "Alert",
   "variant": "default",
@@ -48,7 +48,7 @@ Pass an `icon` prop to render a lucide icon alongside the alert content. The ico
 
 <ComponentPreview auto json={`{"cssClass":"gap-4","type":"Column","children":[{"type":"Alert","variant":"default","icon":"circle-alert","children":[{"type":"AlertTitle","content":"Heads up!"},{"type":"AlertDescription","content":"You can add components to your app using the CLI."}]},{"type":"Alert","variant":"destructive","icon":"circle-x","children":[{"type":"AlertTitle","content":"Error"},{"type":"AlertDescription","content":"Your session has expired. Please log in again."}]},{"type":"Alert","variant":"success","icon":"circle-check","children":[{"type":"AlertTitle","content":"Success"},{"type":"AlertDescription","content":"Your changes have been saved successfully."}]}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import (
     Alert,
     AlertDescription,
@@ -78,7 +78,7 @@ with Column(gap=4):
             "successfully."
         )
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-4",
   "type": "Column",
@@ -140,7 +140,7 @@ Five variants cover different semantic intents — from neutral information to s
 
 <ComponentPreview auto json={`{"cssClass":"gap-4","type":"Column","children":[{"type":"Alert","variant":"default","children":[{"type":"AlertTitle","content":"Default"},{"type":"AlertDescription","content":"A neutral informational message."}]},{"type":"Alert","variant":"destructive","children":[{"type":"AlertTitle","content":"Error"},{"type":"AlertDescription","content":"Your session has expired. Please log in again."}]},{"type":"Alert","variant":"success","children":[{"type":"AlertTitle","content":"Success"},{"type":"AlertDescription","content":"Your changes have been saved successfully."}]},{"type":"Alert","variant":"warning","children":[{"type":"AlertTitle","content":"Warning"},{"type":"AlertDescription","content":"Your trial expires in 3 days."}]},{"type":"Alert","variant":"info","children":[{"type":"AlertTitle","content":"Info"},{"type":"AlertDescription","content":"A new version is available for download."}]}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import (
     Alert,
     AlertDescription,
@@ -169,7 +169,7 @@ with Column(gap=4):
         AlertTitle("Info")
         AlertDescription("A new version is available for download.")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-4",
   "type": "Column",
@@ -256,7 +256,7 @@ For simple messages, you can use just a description:
 
 <ComponentPreview auto json={`{"type":"Alert","variant":"default","children":[{"type":"AlertDescription","content":"Your changes have been saved."}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import (
     Alert,
     AlertDescription,
@@ -265,7 +265,7 @@ from prefab_ui.components import (
 with Alert():
     AlertDescription("Your changes have been saved.")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "Alert",
   "variant": "default",
@@ -286,7 +286,7 @@ Alerts work well inside cards or at the top of a page to communicate status:
 
 <ComponentPreview auto json={`{"type":"Card","children":[{"type":"CardHeader","children":[{"type":"CardTitle","content":"Deployment"}]},{"type":"CardContent","children":[{"cssClass":"gap-4","type":"Column","children":[{"type":"Alert","variant":"default","children":[{"type":"AlertTitle","content":"Maintenance Window"},{"type":"AlertDescription","content":"Deployments are paused from 2:00\\u20134:00 AM UTC."}]},{"type":"Alert","variant":"default","children":[{"type":"AlertTitle","content":"Latest Deploy"},{"type":"AlertDescription","content":"v2.1.0 deployed successfully 3 hours ago."}]}]}]}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import (
     Card,
     CardHeader,
@@ -310,7 +310,7 @@ with Card():
                 AlertTitle("Latest Deploy")
                 AlertDescription("v2.1.0 deployed successfully 3 hours ago.")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "Card",
   "children": [

--- a/docs/components/area-chart.mdx
+++ b/docs/components/area-chart.mdx
@@ -12,7 +12,7 @@ AreaChart fills the region between a line and the axis, emphasizing the magnitud
 
 <ComponentPreview auto json={`{"type":"AreaChart","data":[{"month":"Jan","desktop":186,"mobile":80},{"month":"Feb","desktop":305,"mobile":200},{"month":"Mar","desktop":237,"mobile":120},{"month":"Apr","desktop":73,"mobile":190},{"month":"May","desktop":209,"mobile":130},{"month":"Jun","desktop":214,"mobile":140}],"series":[{"dataKey":"desktop","label":"Desktop"},{"dataKey":"mobile","label":"Mobile"}],"xAxis":"month","height":300,"stacked":false,"curve":"linear","showDots":false,"showLegend":true,"showTooltip":true,"showGrid":true}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import AreaChart, ChartSeries
 
 data = [
@@ -34,7 +34,7 @@ AreaChart(
     show_legend=True,
 )
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "AreaChart",
   "data": [
@@ -98,7 +98,7 @@ Stacking shows how each series contributes to the total. The topmost line repres
 
 <ComponentPreview auto json={`{"type":"AreaChart","data":[{"month":"Jan","desktop":186,"mobile":80},{"month":"Feb","desktop":305,"mobile":200},{"month":"Mar","desktop":237,"mobile":120},{"month":"Apr","desktop":73,"mobile":190},{"month":"May","desktop":209,"mobile":130},{"month":"Jun","desktop":214,"mobile":140}],"series":[{"dataKey":"desktop","label":"Desktop"},{"dataKey":"mobile","label":"Mobile"}],"xAxis":"month","height":300,"stacked":true,"curve":"linear","showDots":false,"showLegend":true,"showTooltip":true,"showGrid":true}`}>
 <CodeGroup>
-```python Python {8}
+```python Python {8} icon="python"
 AreaChart(
     data=data,
     series=[
@@ -110,7 +110,7 @@ AreaChart(
     show_legend=True,
 )
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "AreaChart",
   "data": [
@@ -174,7 +174,7 @@ Turn off the grid for a cleaner look.
 
 <ComponentPreview auto json={`{"type":"AreaChart","data":[{"month":"Jan","desktop":186,"mobile":80},{"month":"Feb","desktop":305,"mobile":200},{"month":"Mar","desktop":237,"mobile":120},{"month":"Apr","desktop":73,"mobile":190},{"month":"May","desktop":209,"mobile":130},{"month":"Jun","desktop":214,"mobile":140}],"series":[{"dataKey":"value","label":"Requests"}],"xAxis":"month","height":300,"stacked":false,"curve":"linear","showDots":false,"showLegend":false,"showTooltip":true,"showGrid":false}`}>
 <CodeGroup>
-```python Python {5}
+```python Python {5} icon="python"
 AreaChart(
     data=data,
     series=[ChartSeries(data_key="value", label="Requests")],
@@ -182,7 +182,7 @@ AreaChart(
     show_grid=False,
 )
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "AreaChart",
   "data": [
@@ -242,7 +242,7 @@ Set `curve="smooth"` for gently curved lines between data points. The filled are
 
 <ComponentPreview auto json={`{"type":"AreaChart","data":[{"month":"Jan","desktop":186,"mobile":80},{"month":"Feb","desktop":305,"mobile":200},{"month":"Mar","desktop":237,"mobile":120},{"month":"Apr","desktop":73,"mobile":190},{"month":"May","desktop":209,"mobile":130},{"month":"Jun","desktop":214,"mobile":140}],"series":[{"dataKey":"desktop","label":"Desktop"},{"dataKey":"mobile","label":"Mobile"}],"xAxis":"month","height":300,"stacked":false,"curve":"smooth","showDots":false,"showLegend":true,"showTooltip":true,"showGrid":true}`}>
 <CodeGroup>
-```python Python {8}
+```python Python {8} icon="python"
 AreaChart(
     data=data,
     series=[
@@ -254,7 +254,7 @@ AreaChart(
     show_legend=True,
 )
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "AreaChart",
   "data": [
@@ -318,7 +318,7 @@ Set `curve="step"` to connect points with step-shaped lines. The filled area fol
 
 <ComponentPreview auto json={`{"type":"AreaChart","data":[{"month":"Jan","desktop":186,"mobile":80},{"month":"Feb","desktop":305,"mobile":200},{"month":"Mar","desktop":237,"mobile":120},{"month":"Apr","desktop":73,"mobile":190},{"month":"May","desktop":209,"mobile":130},{"month":"Jun","desktop":214,"mobile":140}],"series":[{"dataKey":"desktop","label":"Desktop"},{"dataKey":"mobile","label":"Mobile"}],"xAxis":"month","height":300,"stacked":false,"curve":"step","showDots":false,"showLegend":true,"showTooltip":true,"showGrid":true}`}>
 <CodeGroup>
-```python Python {8}
+```python Python {8} icon="python"
 AreaChart(
     data=data,
     series=[
@@ -330,7 +330,7 @@ AreaChart(
     show_legend=True,
 )
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "AreaChart",
   "data": [

--- a/docs/components/badge.mdx
+++ b/docs/components/badge.mdx
@@ -12,12 +12,12 @@ Badges are small, pill-shaped labels for status indicators, counts, and categori
 
 <ComponentPreview auto json={`{"type":"Badge","label":"Mostly Harmless","variant":"default"}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import Badge
 
 Badge("Mostly Harmless")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "Badge",
   "label": "Mostly Harmless",
@@ -33,7 +33,7 @@ Eight variants cover the most common use cases — five base styles from shadcn 
 
 <ComponentPreview auto json={`{"cssClass":"gap-8 grid-cols-4 place-items-center","type":"Grid","children":[{"type":"Badge","label":"Default","variant":"default"},{"type":"Badge","label":"Secondary","variant":"secondary"},{"type":"Badge","label":"Destructive","variant":"destructive"},{"type":"Badge","label":"Outline","variant":"outline"},{"type":"Badge","label":"Ghost","variant":"ghost"},{"type":"Badge","label":"Success","variant":"success"},{"type":"Badge","label":"Warning","variant":"warning"},{"type":"Badge","label":"Info","variant":"info"}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import Badge, Grid
 
 with Grid(gap=8, columns=4, css_class="place-items-center"):
@@ -46,7 +46,7 @@ with Grid(gap=8, columns=4, css_class="place-items-center"):
     Badge("Warning", variant="warning")
     Badge("Info", variant="info")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-8 grid-cols-4 place-items-center",
   "type": "Grid",
@@ -103,7 +103,7 @@ Badges pair well with cards and other layout components as inline status indicat
 
 <ComponentPreview auto json={`{"cssClass":"gap-3","type":"Column","children":[{"type":"Card","children":[{"type":"CardHeader","children":[{"cssClass":"gap-2 items-center","type":"Row","children":[{"type":"CardTitle","content":"Heart of Gold"},{"type":"Badge","label":"Online","variant":"success"}]},{"type":"CardDescription","content":"Infinite Improbability Drive engaged"}]}]},{"type":"Card","children":[{"type":"CardHeader","children":[{"cssClass":"gap-2 items-center","type":"Row","children":[{"type":"CardTitle","content":"Vogon Fleet"},{"type":"Badge","label":"Approaching","variant":"warning"}]},{"type":"CardDescription","content":"Demolition order filed with local planning authority"}]}]}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import (
     Badge,
     Card,
@@ -128,7 +128,7 @@ with Column(gap=3):
                 Badge("Approaching", variant="warning")
             CardDescription("Demolition order filed with local planning authority")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-3",
   "type": "Column",

--- a/docs/components/bar-chart.mdx
+++ b/docs/components/bar-chart.mdx
@@ -12,7 +12,7 @@ BarChart renders one or more data series as vertical bars. Each `ChartSeries` ma
 
 <ComponentPreview auto json={`{"type":"BarChart","data":[{"month":"Jan","desktop":186,"mobile":80},{"month":"Feb","desktop":305,"mobile":200},{"month":"Mar","desktop":237,"mobile":120},{"month":"Apr","desktop":73,"mobile":190},{"month":"May","desktop":209,"mobile":130},{"month":"Jun","desktop":214,"mobile":140}],"series":[{"dataKey":"desktop","label":"Desktop"},{"dataKey":"mobile","label":"Mobile"}],"xAxis":"month","height":300,"stacked":false,"horizontal":false,"barRadius":4,"showLegend":true,"showTooltip":true,"showGrid":true}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import BarChart, ChartSeries
 
 data = [
@@ -34,7 +34,7 @@ BarChart(
     show_legend=True,
 )
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "BarChart",
   "data": [
@@ -98,7 +98,7 @@ Set `stacked=True` to stack series on top of each other instead of placing them 
 
 <ComponentPreview auto json={`{"type":"BarChart","data":[{"month":"Jan","desktop":186,"mobile":80},{"month":"Feb","desktop":305,"mobile":200},{"month":"Mar","desktop":237,"mobile":120},{"month":"Apr","desktop":73,"mobile":190},{"month":"May","desktop":209,"mobile":130},{"month":"Jun","desktop":214,"mobile":140}],"series":[{"dataKey":"desktop","label":"Desktop"},{"dataKey":"mobile","label":"Mobile"}],"xAxis":"month","height":300,"stacked":true,"horizontal":false,"barRadius":4,"showLegend":true,"showTooltip":true,"showGrid":true}`}>
 <CodeGroup>
-```python Python {8}
+```python Python {8} icon="python"
 BarChart(
     data=data,
     series=[
@@ -110,7 +110,7 @@ BarChart(
     show_legend=True,
 )
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "BarChart",
   "data": [
@@ -174,7 +174,7 @@ Turn off the grid for a cleaner look.
 
 <ComponentPreview auto json={`{"type":"BarChart","data":[{"month":"Jan","desktop":186,"mobile":80},{"month":"Feb","desktop":305,"mobile":200},{"month":"Mar","desktop":237,"mobile":120},{"month":"Apr","desktop":73,"mobile":190},{"month":"May","desktop":209,"mobile":130},{"month":"Jun","desktop":214,"mobile":140}],"series":[{"dataKey":"revenue","label":"Revenue"}],"xAxis":"month","height":300,"stacked":false,"horizontal":false,"barRadius":4,"showLegend":false,"showTooltip":true,"showGrid":false}`}>
 <CodeGroup>
-```python Python {5}
+```python Python {5} icon="python"
 BarChart(
     data=data,
     series=[ChartSeries(data_key="revenue", label="Revenue")],
@@ -182,7 +182,7 @@ BarChart(
     show_grid=False,
 )
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "BarChart",
   "data": [
@@ -242,7 +242,7 @@ Set `horizontal=True` to render bars horizontally. Categories appear along the y
 
 <ComponentPreview auto json={`{"type":"BarChart","data":[{"month":"Jan","desktop":186,"mobile":80},{"month":"Feb","desktop":305,"mobile":200},{"month":"Mar","desktop":237,"mobile":120},{"month":"Apr","desktop":73,"mobile":190},{"month":"May","desktop":209,"mobile":130},{"month":"Jun","desktop":214,"mobile":140}],"series":[{"dataKey":"desktop","label":"Desktop"},{"dataKey":"mobile","label":"Mobile"}],"xAxis":"month","height":300,"stacked":false,"horizontal":true,"barRadius":4,"showLegend":true,"showTooltip":true,"showGrid":true}`}>
 <CodeGroup>
-```python Python {8}
+```python Python {8} icon="python"
 BarChart(
     data=data,
     series=[
@@ -254,7 +254,7 @@ BarChart(
     show_legend=True,
 )
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "BarChart",
   "data": [

--- a/docs/components/button-group.mdx
+++ b/docs/components/button-group.mdx
@@ -12,14 +12,14 @@ Button groups join related actions into a single visual unit. Borders between bu
 
 <ComponentPreview auto json={`{"type":"ButtonGroup","orientation":"horizontal","children":[{"type":"Button","label":"Save","variant":"default","size":"default","disabled":false},{"type":"Button","label":"Cancel","variant":"outline","size":"default","disabled":false}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import Button, ButtonGroup
 
 with ButtonGroup():
     Button("Save")
     Button("Cancel", variant="outline")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "ButtonGroup",
   "orientation": "horizontal",
@@ -50,7 +50,7 @@ Horizontal (default) groups buttons side-by-side. Vertical stacks them:
 
 <ComponentPreview auto json={`{"type":"ButtonGroup","orientation":"vertical","children":[{"type":"Button","label":"Top","variant":"default","size":"default","disabled":false},{"type":"Button","label":"Middle","variant":"outline","size":"default","disabled":false},{"type":"Button","label":"Bottom","variant":"outline","size":"default","disabled":false}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import Button, ButtonGroup
 
 with ButtonGroup(orientation="vertical"):
@@ -58,7 +58,7 @@ with ButtonGroup(orientation="vertical"):
     Button("Middle", variant="outline")
     Button("Bottom", variant="outline")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "ButtonGroup",
   "orientation": "vertical",
@@ -96,7 +96,7 @@ Pagination controls, view toggles, and segmented controls all benefit from butto
 
 <ComponentPreview auto json={`{"type":"ButtonGroup","orientation":"horizontal","children":[{"type":"Button","label":"Previous","variant":"outline","size":"default","disabled":false},{"type":"Button","label":"1","variant":"default","size":"default","disabled":false},{"type":"Button","label":"2","variant":"outline","size":"default","disabled":false},{"type":"Button","label":"3","variant":"outline","size":"default","disabled":false},{"type":"Button","label":"Next","variant":"outline","size":"default","disabled":false}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import Button, ButtonGroup
 
 with ButtonGroup():
@@ -106,7 +106,7 @@ with ButtonGroup():
     Button("3", variant="outline")
     Button("Next", variant="outline")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "ButtonGroup",
   "orientation": "horizontal",

--- a/docs/components/button.mdx
+++ b/docs/components/button.mdx
@@ -13,12 +13,12 @@ Buttons trigger actions and communicate intent. The `variant` parameter signals 
 
 <ComponentPreview auto json={`{"type":"Button","label":"Save Changes","variant":"default","size":"default","disabled":false}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import Button
 
 Button("Save Changes")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "Button",
   "label": "Save Changes",
@@ -38,7 +38,7 @@ Each variant communicates a different intent to the user:
 
 <ComponentPreview auto json={`{"cssClass":"gap-8 grid-cols-3","type":"Grid","children":[{"type":"Button","label":"Default","variant":"default","size":"default","disabled":false},{"type":"Button","label":"Destructive","variant":"destructive","size":"default","disabled":false},{"type":"Button","label":"Outline","variant":"outline","size":"default","disabled":false},{"type":"Button","label":"Secondary","variant":"secondary","size":"default","disabled":false},{"type":"Button","label":"Ghost","variant":"ghost","size":"default","disabled":false},{"type":"Button","label":"Link","variant":"link","size":"default","disabled":false},{"type":"Button","label":"Success","variant":"success","size":"default","disabled":false},{"type":"Button","label":"Warning","variant":"warning","size":"default","disabled":false},{"type":"Button","label":"Info","variant":"info","size":"default","disabled":false}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import (
     Button,
     Grid,
@@ -55,7 +55,7 @@ with Grid(columns=3, gap=8):
     Button("Warning", variant="warning")
     Button("Info", variant="info")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-8 grid-cols-3",
   "type": "Grid",
@@ -133,7 +133,7 @@ with Grid(columns=3, gap=8):
 
 <ComponentPreview auto json={`{"cssClass":"gap-3 items-center","type":"Row","children":[{"type":"Button","label":"Tiny","variant":"default","size":"xs","disabled":false},{"type":"Button","label":"Small","variant":"default","size":"sm","disabled":false},{"type":"Button","label":"Default","variant":"default","size":"default","disabled":false},{"type":"Button","label":"Large","variant":"default","size":"lg","disabled":false}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import (
     Button,
     Row,
@@ -145,7 +145,7 @@ with Row(gap=3, css_class="items-center"):
     Button("Default", size="default")
     Button("Large", size="lg")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-3 items-center",
   "type": "Row",
@@ -190,7 +190,7 @@ Buttons accept an `icon` prop (any [lucide icon name](https://lucide.dev/icons) 
 
 <ComponentPreview auto json={`{"cssClass":"gap-3 items-center","type":"Row","children":[{"type":"Button","label":"Download","icon":"download","variant":"default","size":"default","disabled":false},{"type":"Button","label":"Settings","icon":"settings","variant":"outline","size":"default","disabled":false},{"type":"Button","label":"Delete","icon":"trash-2","variant":"destructive","size":"default","disabled":false}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import Button, Row
 
 with Row(gap=3, css_class="items-center"):
@@ -198,7 +198,7 @@ with Row(gap=3, css_class="items-center"):
     Button("Settings", icon="settings", variant="outline")
     Button("Delete", icon="trash-2", variant="destructive")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-3 items-center",
   "type": "Row",
@@ -239,7 +239,7 @@ Square buttons optimized for single icons. Use `icon` with an icon-size variant 
 
 <ComponentPreview auto json={`{"cssClass":"gap-3 items-center","type":"Row","children":[{"type":"Button","label":"","icon":"plus","variant":"default","size":"icon-xs","disabled":false},{"type":"Button","label":"","icon":"plus","variant":"default","size":"icon-sm","disabled":false},{"type":"Button","label":"","icon":"plus","variant":"default","size":"icon","disabled":false},{"type":"Button","label":"","icon":"plus","variant":"default","size":"icon-lg","disabled":false}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import Button, Row
 
 with Row(gap=3, css_class="items-center"):
@@ -248,7 +248,7 @@ with Row(gap=3, css_class="items-center"):
     Button("", icon="plus", size="icon")
     Button("", icon="plus", size="icon-lg")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-3 items-center",
   "type": "Row",
@@ -295,12 +295,12 @@ with Row(gap=3, css_class="items-center"):
 
 <ComponentPreview auto json={`{"type":"Button","label":"Unavailable","variant":"default","size":"default","disabled":true}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import Button
 
 Button("Unavailable", disabled=True)
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "Button",
   "label": "Unavailable",
@@ -318,7 +318,7 @@ Every component accepts `css_class` for additional Tailwind CSS classes. When yo
 
 <ComponentPreview auto json={`{"cssClass":"gap-3 items-start w-full","type":"Column","children":[{"cssClass":"w-full bg-emerald-500","type":"Button","label":"Full Width Emerald","variant":"default","size":"default","disabled":false},{"cssClass":"rounded-full bg-rose-500","type":"Button","label":"Pill Shape Rose","variant":"default","size":"default","disabled":false}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import (
     Button,
     Column,
@@ -328,7 +328,7 @@ with Column(gap=3, css_class="items-start w-full"):
     Button("Full Width Emerald", css_class="w-full bg-emerald-500")
     Button("Pill Shape Rose", css_class="rounded-full bg-rose-500")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-3 items-start w-full",
   "type": "Column",

--- a/docs/components/calendar.mdx
+++ b/docs/components/calendar.mdx
@@ -12,12 +12,12 @@ The Calendar component renders a month view for selecting dates. It supports sin
 
 <ComponentPreview auto json={`{"type":"Calendar","mode":"single","name":"selectedDate"}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import Calendar
 
 Calendar(name="selectedDate")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "Calendar",
   "mode": "single",
@@ -33,7 +33,7 @@ Set `mode="range"` to let users select a start and end date. The selected range 
 
 <ComponentPreview auto json={`{"_tree":{"type":"Calendar","mode":"range","name":"dateRange"},"_state":{"dateRange":"{\\"from\\": \\"2025-06-10T12:00:00.000Z\\", \\"to\\": \\"2025-06-20T12:00:00.000Z\\"}"}}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 import json
 from prefab_ui.components import Calendar
 
@@ -46,7 +46,7 @@ set_initial_state(
 
 Calendar(mode="range", name="dateRange")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "_tree": {
     "type": "Calendar",
@@ -67,7 +67,7 @@ Select multiple individual dates with `mode="multiple"`. Selected dates are stor
 
 <ComponentPreview auto json={`{"_tree":{"type":"Calendar","mode":"multiple","name":"selectedDates"},"_state":{"selectedDates":"[\\"2025-06-10T12:00:00.000Z\\", \\"2025-06-15T12:00:00.000Z\\", \\"2025-06-22T12:00:00.000Z\\"]"}}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 import json
 from prefab_ui.components import Calendar
 
@@ -81,7 +81,7 @@ set_initial_state(
 
 Calendar(mode="multiple", name="selectedDates")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "_tree": {
     "type": "Calendar",
@@ -102,7 +102,7 @@ Bind the calendar's state to a label using `{{ name | date }}` to show a formatt
 
 <ComponentPreview auto json={`{"_tree":{"cssClass":"gap-6","type":"Row","children":[{"type":"Calendar","mode":"single","name":"selectedDate"},{"cssClass":"gap-2","type":"Column","children":[{"type":"Text","content":"Selected date:"},{"type":"Text","content":"{{ selectedDate | date:long }}","bold":true},{"content":"Raw: {{ selectedDate }}","type":"Muted"}]}]},"_state":{"selectedDate":"2025-06-15T12:00:00.000Z"}}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import (
     Calendar,
     Column,
@@ -120,7 +120,7 @@ with Row(gap=6):
         Text("{{ selectedDate | date:long }}", bold=True)
         Muted("Raw: {{ selectedDate }}")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "_tree": {
     "cssClass": "gap-6",

--- a/docs/components/card.mdx
+++ b/docs/components/card.mdx
@@ -12,7 +12,7 @@ Cards group related content into a bordered, shadowed container. They're compose
 
 <ComponentPreview auto json={`{"type":"Card","children":[{"type":"CardHeader","children":[{"type":"CardTitle","content":"Create project"},{"type":"CardDescription","content":"Deploy your new project in one-click."}]},{"type":"CardContent","children":[{"content":"Your project will be created with default settings.","type":"P"}]},{"type":"CardFooter","children":[{"type":"Button","label":"Cancel","variant":"outline","size":"default","disabled":false},{"type":"Button","label":"Deploy","variant":"default","size":"default","disabled":false}]}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import (
     Card,
     CardHeader,
@@ -34,7 +34,7 @@ with Card():
         Button("Cancel", variant="outline")
         Button("Deploy")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "Card",
   "children": [
@@ -93,7 +93,7 @@ Cards follow a header → content → footer pattern. Each section is optional �
 
 <ComponentPreview auto json={`{"type":"Card","children":[{"type":"CardHeader","children":[{"type":"CardTitle","content":"Account Settings"},{"type":"CardDescription","content":"Manage your account preferences and security."}]},{"type":"CardContent","children":[{"content":"Update your display name, email, and notification preferences from this panel.","type":"P"},{"content":"Changes take effect immediately.","type":"Muted"}]},{"type":"CardFooter","children":[{"type":"Button","label":"Save changes","variant":"default","size":"default","disabled":false}]}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import (
     Card,
     CardHeader,
@@ -116,7 +116,7 @@ with Card():
     with CardFooter():
         Button("Save changes")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "Card",
   "children": [
@@ -170,7 +170,7 @@ For lightweight use cases, you can skip the sub-components entirely and use `css
 
 <ComponentPreview auto json={`{"cssClass":"p-6","type":"Card","children":[{"content":"Quick Stats","type":"H3"},{"content":"42 active connections, 3 pending requests.","type":"P"}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import (
     Card,
     H3,
@@ -181,7 +181,7 @@ with Card(css_class="p-6"):
     H3("Quick Stats")
     P("42 active connections, 3 pending requests.")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "p-6",
   "type": "Card",
@@ -206,7 +206,7 @@ Cards work naturally with `Grid` for dashboard-style layouts:
 
 <ComponentPreview auto json={`{"cssClass":"gap-4 grid-cols-3","type":"Grid","children":[{"type":"Card","children":[{"type":"CardHeader","children":[{"type":"CardDescription","content":"Revenue"},{"type":"CardTitle","content":"$12,450"}]}]},{"type":"Card","children":[{"type":"CardHeader","children":[{"type":"CardDescription","content":"Users"},{"type":"CardTitle","content":"1,234"}]}]},{"type":"Card","children":[{"type":"CardHeader","children":[{"type":"CardDescription","content":"Uptime"},{"type":"CardTitle","content":"99.9%"}]}]}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import (
     Card,
     CardHeader,
@@ -226,7 +226,7 @@ with Grid(columns=3, gap=4):
                 CardDescription(title)
                 CardTitle(desc)
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-4 grid-cols-3",
   "type": "Grid",

--- a/docs/components/checkbox.mdx
+++ b/docs/components/checkbox.mdx
@@ -12,12 +12,12 @@ Checkboxes let users select one or more options from a set.
 
 <ComponentPreview auto json={`{"type":"Checkbox","label":"Accept terms and conditions","checked":false,"disabled":false,"required":false}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import Checkbox
 
 Checkbox(label="Accept terms and conditions")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "Checkbox",
   "label": "Accept terms and conditions",
@@ -33,12 +33,12 @@ Checkbox(label="Accept terms and conditions")
 
 <ComponentPreview auto json={`{"type":"Checkbox","label":"Subscribe to newsletter","checked":true,"disabled":false,"required":false}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import Checkbox
 
 Checkbox(label="Subscribe to newsletter", checked=True)
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "Checkbox",
   "label": "Subscribe to newsletter",
@@ -54,7 +54,7 @@ Checkbox(label="Subscribe to newsletter", checked=True)
 
 <ComponentPreview auto json={`{"cssClass":"gap-3 w-fit mx-auto","type":"Column","children":[{"type":"Checkbox","label":"Email notifications","checked":true,"disabled":false,"required":false},{"type":"Checkbox","label":"SMS notifications","checked":false,"disabled":false,"required":false},{"type":"Checkbox","label":"Push notifications","checked":true,"disabled":false,"required":false}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import (
     Checkbox,
     Column,
@@ -65,7 +65,7 @@ with Column(gap=3, css_class="w-fit mx-auto"):
     Checkbox(label="SMS notifications")
     Checkbox(label="Push notifications", checked=True)
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-3 w-fit mx-auto",
   "type": "Column",
@@ -101,7 +101,7 @@ with Column(gap=3, css_class="w-fit mx-auto"):
 
 <ComponentPreview auto json={`{"cssClass":"gap-3 w-fit mx-auto","type":"Column","children":[{"type":"Checkbox","label":"Enabled option","checked":false,"disabled":false,"required":false},{"type":"Checkbox","label":"Disabled option","checked":false,"disabled":true,"required":false},{"type":"Checkbox","label":"Disabled & checked","checked":true,"disabled":true,"required":false}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import (
     Checkbox,
     Column,
@@ -112,7 +112,7 @@ with Column(gap=3, css_class="w-fit mx-auto"):
     Checkbox(label="Disabled option", disabled=True)
     Checkbox(label="Disabled & checked", checked=True, disabled=True)
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-3 w-fit mx-auto",
   "type": "Column",

--- a/docs/components/code.mdx
+++ b/docs/components/code.mdx
@@ -12,7 +12,7 @@ Code blocks display source code or configuration with automatic syntax highlight
 
 <ComponentPreview auto json={`{"type":"Code","content":"def answer() -> int:\\n    \\"\\"\\"Return the Answer to the Ultimate Question\\n    of Life, the Universe, and Everything.\\"\\"\\"\\n    return 42","language":"python"}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import Code
 
 Code("""
@@ -22,7 +22,7 @@ def answer() -> int:
     return 42
 """.strip(), language="python")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "Code",
   "content": "def answer() -> int:\n    \"\"\"Return the Answer to the Ultimate Question\n    of Life, the Universe, and Everything.\"\"\"\n    return 42",
@@ -36,7 +36,7 @@ def answer() -> int:
 
 <ComponentPreview auto json={`{"cssClass":"gap-3","type":"Column","children":[{"type":"Code","content":"pip install prefab-ui","language":"bash"},{"type":"Code","content":"SELECT name, designation\\nFROM crew\\nWHERE ship = 'Heart of Gold';","language":"sql"},{"type":"Code","content":"{ \\"ship\\": \\"Heart of Gold\\", \\"drive\\": \\"Infinite Improbability\\" }","language":"json"}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import Code, Column
 
 with Column(gap=3):
@@ -49,7 +49,7 @@ with Column(gap=3):
     )
     Code('{ "ship": "Heart of Gold", "drive": "Infinite Improbability" }', language="json")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-3",
   "type": "Column",

--- a/docs/components/column.mdx
+++ b/docs/components/column.mdx
@@ -12,7 +12,7 @@ Column arranges children vertically. Use `gap` to control spacing between items.
 
 <ComponentPreview auto json={`{"cssClass":"gap-4","type":"Column","children":[{"cssClass":"bg-emerald-500 rounded-md h-10","type":"Div"},{"cssClass":"bg-emerald-500 rounded-md h-10","type":"Div"},{"cssClass":"bg-emerald-500 rounded-md h-10","type":"Div"}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import (
     Column,
     Div,
@@ -23,7 +23,7 @@ with Column(gap=4):
     Div(css_class="bg-emerald-500 rounded-md h-10")
     Div(css_class="bg-emerald-500 rounded-md h-10")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-4",
   "type": "Column",
@@ -52,7 +52,7 @@ with Column(gap=4):
 <Tab title="gap=4">
 <ComponentPreview auto json={`{"cssClass":"gap-4 p-3 border-3 border-dashed","type":"Column","children":[{"cssClass":"bg-emerald-500 rounded-md h-10","type":"Div"},{"cssClass":"bg-emerald-500 rounded-md h-10","type":"Div"},{"cssClass":"bg-emerald-500 rounded-md h-10","type":"Div"}]}`}>
 <CodeGroup>
-```python Python highlight={3}
+```python Python highlight={3} icon="python"
 from prefab_ui.components import Column, Div
 
 with Column(gap=4, css_class="p-3 border-3 border-dashed"):
@@ -60,7 +60,7 @@ with Column(gap=4, css_class="p-3 border-3 border-dashed"):
     Div(css_class="bg-emerald-500 rounded-md h-10")
     Div(css_class="bg-emerald-500 rounded-md h-10")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-4 p-3 border-3 border-dashed",
   "type": "Column",
@@ -86,7 +86,7 @@ with Column(gap=4, css_class="p-3 border-3 border-dashed"):
 <Tab title="gap=8">
 <ComponentPreview auto json={`{"cssClass":"gap-8 p-3 border-3 border-dashed","type":"Column","children":[{"cssClass":"bg-emerald-500 rounded-md h-10","type":"Div"},{"cssClass":"bg-emerald-500 rounded-md h-10","type":"Div"},{"cssClass":"bg-emerald-500 rounded-md h-10","type":"Div"}]}`}>
 <CodeGroup>
-```python Python highlight={3}
+```python Python highlight={3} icon="python"
 from prefab_ui.components import Column, Div
 
 with Column(gap=8, css_class="p-3 border-3 border-dashed"):
@@ -94,7 +94,7 @@ with Column(gap=8, css_class="p-3 border-3 border-dashed"):
     Div(css_class="bg-emerald-500 rounded-md h-10")
     Div(css_class="bg-emerald-500 rounded-md h-10")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-8 p-3 border-3 border-dashed",
   "type": "Column",
@@ -120,7 +120,7 @@ with Column(gap=8, css_class="p-3 border-3 border-dashed"):
 <Tab title="gap=12">
 <ComponentPreview auto json={`{"cssClass":"gap-12 p-3 border-3 border-dashed","type":"Column","children":[{"cssClass":"bg-emerald-500 rounded-md h-10","type":"Div"},{"cssClass":"bg-emerald-500 rounded-md h-10","type":"Div"},{"cssClass":"bg-emerald-500 rounded-md h-10","type":"Div"}]}`}>
 <CodeGroup>
-```python Python highlight={3}
+```python Python highlight={3} icon="python"
 from prefab_ui.components import Column, Div
 
 with Column(gap=12, css_class="p-3 border-3 border-dashed"):
@@ -128,7 +128,7 @@ with Column(gap=12, css_class="p-3 border-3 border-dashed"):
     Div(css_class="bg-emerald-500 rounded-md h-10")
     Div(css_class="bg-emerald-500 rounded-md h-10")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-12 p-3 border-3 border-dashed",
   "type": "Column",
@@ -161,7 +161,7 @@ In a Column, `align` controls horizontal alignment. The difference is visible wh
 <Tab title='align="start"'>
 <ComponentPreview auto json={`{"cssClass":"gap-4 items-start p-3 border-3 border-dashed","type":"Column","children":[{"cssClass":"bg-emerald-500 rounded-md h-10 w-full","type":"Div"},{"cssClass":"bg-emerald-500 rounded-md h-10 w-3/4","type":"Div"},{"cssClass":"bg-emerald-500 rounded-md h-10 w-1/2","type":"Div"}]}`}>
 <CodeGroup>
-```python Python highlight={3}
+```python Python highlight={3} icon="python"
 from prefab_ui.components import Column, Div
 
 with Column(gap=4, align="start", css_class="p-3 border-3 border-dashed"):
@@ -169,7 +169,7 @@ with Column(gap=4, align="start", css_class="p-3 border-3 border-dashed"):
     Div(css_class="bg-emerald-500 rounded-md h-10 w-3/4")
     Div(css_class="bg-emerald-500 rounded-md h-10 w-1/2")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-4 items-start p-3 border-3 border-dashed",
   "type": "Column",
@@ -195,7 +195,7 @@ with Column(gap=4, align="start", css_class="p-3 border-3 border-dashed"):
 <Tab title='align="center"'>
 <ComponentPreview auto json={`{"cssClass":"gap-4 items-center p-3 border-3 border-dashed","type":"Column","children":[{"cssClass":"bg-emerald-500 rounded-md h-10 w-full","type":"Div"},{"cssClass":"bg-emerald-500 rounded-md h-10 w-3/4","type":"Div"},{"cssClass":"bg-emerald-500 rounded-md h-10 w-1/2","type":"Div"}]}`}>
 <CodeGroup>
-```python Python highlight={3}
+```python Python highlight={3} icon="python"
 from prefab_ui.components import Column, Div
 
 with Column(gap=4, align="center", css_class="p-3 border-3 border-dashed"):
@@ -203,7 +203,7 @@ with Column(gap=4, align="center", css_class="p-3 border-3 border-dashed"):
     Div(css_class="bg-emerald-500 rounded-md h-10 w-3/4")
     Div(css_class="bg-emerald-500 rounded-md h-10 w-1/2")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-4 items-center p-3 border-3 border-dashed",
   "type": "Column",
@@ -229,7 +229,7 @@ with Column(gap=4, align="center", css_class="p-3 border-3 border-dashed"):
 <Tab title='align="end"'>
 <ComponentPreview auto json={`{"cssClass":"gap-4 items-end p-3 border-3 border-dashed","type":"Column","children":[{"cssClass":"bg-emerald-500 rounded-md h-10 w-full","type":"Div"},{"cssClass":"bg-emerald-500 rounded-md h-10 w-3/4","type":"Div"},{"cssClass":"bg-emerald-500 rounded-md h-10 w-1/2","type":"Div"}]}`}>
 <CodeGroup>
-```python Python highlight={3}
+```python Python highlight={3} icon="python"
 from prefab_ui.components import Column, Div
 
 with Column(gap=4, align="end", css_class="p-3 border-3 border-dashed"):
@@ -237,7 +237,7 @@ with Column(gap=4, align="end", css_class="p-3 border-3 border-dashed"):
     Div(css_class="bg-emerald-500 rounded-md h-10 w-3/4")
     Div(css_class="bg-emerald-500 rounded-md h-10 w-1/2")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-4 items-end p-3 border-3 border-dashed",
   "type": "Column",

--- a/docs/components/combobox.mdx
+++ b/docs/components/combobox.mdx
@@ -14,7 +14,7 @@ Options are defined as `ComboboxOption` children. Each option needs a `label` (d
 
 <ComponentPreview auto json={`{"type":"Combobox","placeholder":"Select a framework...","name":"framework","disabled":false,"children":[{"type":"ComboboxOption","value":"nextjs","label":"Next.js","disabled":false},{"type":"ComboboxOption","value":"remix","label":"Remix","disabled":false},{"type":"ComboboxOption","value":"astro","label":"Astro","disabled":false},{"type":"ComboboxOption","value":"sveltekit","label":"SvelteKit","disabled":false},{"type":"ComboboxOption","value":"nuxt","label":"Nuxt","disabled":false}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import Combobox, ComboboxOption
 
 with Combobox(
@@ -27,7 +27,7 @@ with Combobox(
     ComboboxOption("SvelteKit", value="sveltekit")
     ComboboxOption("Nuxt", value="nuxt")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "Combobox",
   "placeholder": "Select a framework...",
@@ -76,7 +76,7 @@ The `name` prop creates a state key that holds the selected option's `value`. Us
 
 <ComponentPreview auto json={`{"cssClass":"gap-3","type":"Column","children":[{"type":"Combobox","placeholder":"Select a planet...","name":"planet","disabled":false,"children":[{"type":"ComboboxOption","value":"magrathea","label":"Magrathea","disabled":false},{"type":"ComboboxOption","value":"betelgeuse","label":"Betelgeuse","disabled":false},{"type":"ComboboxOption","value":"vogsphere","label":"Vogsphere","disabled":false}]},{"type":"Text","content":"Selected: {{ planet }}"}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import (
     Column,
     Combobox,
@@ -95,7 +95,7 @@ with Column(gap=3):
 
     Text("Selected: {{ planet }}")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-3",
   "type": "Column",
@@ -142,7 +142,7 @@ Customize the placeholder text shown in the search input.
 
 <ComponentPreview auto json={`{"type":"Combobox","placeholder":"Pick a language...","searchPlaceholder":"Filter languages...","name":"language","disabled":false,"children":[{"type":"ComboboxOption","value":"python","label":"Python","disabled":false},{"type":"ComboboxOption","value":"typescript","label":"TypeScript","disabled":false},{"type":"ComboboxOption","value":"rust","label":"Rust","disabled":false},{"type":"ComboboxOption","value":"go","label":"Go","disabled":false}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import Combobox, ComboboxOption
 
 with Combobox(
@@ -155,7 +155,7 @@ with Combobox(
     ComboboxOption("Rust", value="rust")
     ComboboxOption("Go", value="go")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "Combobox",
   "placeholder": "Pick a language...",
@@ -199,7 +199,7 @@ Individual options can be disabled.
 
 <ComponentPreview auto json={`{"type":"Combobox","placeholder":"Select a planet...","name":"planet","disabled":false,"children":[{"type":"ComboboxOption","value":"magrathea","label":"Magrathea","disabled":false},{"type":"ComboboxOption","value":"earth","label":"Earth","disabled":true},{"type":"ComboboxOption","value":"betelgeuse","label":"Betelgeuse","disabled":false},{"type":"ComboboxOption","value":"vogsphere","label":"Vogsphere","disabled":false}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import Combobox, ComboboxOption
 
 with Combobox(
@@ -215,7 +215,7 @@ with Combobox(
     ComboboxOption("Betelgeuse", value="betelgeuse")
     ComboboxOption("Vogsphere", value="vogsphere")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "Combobox",
   "placeholder": "Select a planet...",

--- a/docs/components/data-table.mdx
+++ b/docs/components/data-table.mdx
@@ -12,7 +12,7 @@ DataTable takes flat `columns` and `rows` and renders a full-featured table with
 
 <ComponentPreview auto json={`{"type":"DataTable","columns":[{"key":"name","header":"Name","sortable":true},{"key":"email","header":"Email","sortable":false},{"key":"role","header":"Role","sortable":true}],"rows":[{"name":"Alice Johnson","email":"alice@example.com","role":"Admin"},{"name":"Bob Smith","email":"bob@example.com","role":"Editor"},{"name":"Carol White","email":"carol@example.com","role":"Viewer"}],"searchable":true,"paginated":false,"pageSize":10}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import DataTable, DataTableColumn
 
 DataTable(
@@ -29,7 +29,7 @@ DataTable(
     searchable=True,
 )
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "DataTable",
   "columns": [
@@ -80,7 +80,7 @@ Enable pagination to handle large datasets. The table shows page controls and di
 
 <ComponentPreview auto json={`{"type":"DataTable","columns":[{"key":"id","header":"ID","sortable":false},{"key":"task","header":"Task","sortable":true},{"key":"status","header":"Status","sortable":false}],"rows":[{"id":"T-001","task":"Design system","status":"Complete"},{"id":"T-002","task":"API integration","status":"In Progress"},{"id":"T-003","task":"Testing","status":"Pending"},{"id":"T-004","task":"Documentation","status":"In Progress"},{"id":"T-005","task":"Deployment","status":"Pending"}],"searchable":false,"paginated":true,"pageSize":3,"caption":"Sprint tasks"}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import DataTable, DataTableColumn
 
 DataTable(
@@ -101,7 +101,7 @@ DataTable(
     caption="Sprint tasks",
 )
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "DataTable",
   "columns": [

--- a/docs/components/date-picker.mdx
+++ b/docs/components/date-picker.mdx
@@ -12,12 +12,12 @@ DatePicker combines a trigger button with a popover calendar. The button display
 
 <ComponentPreview auto height="400px" json={`{"type":"DatePicker","placeholder":"Select deadline","name":"deadline"}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import DatePicker
 
 DatePicker(placeholder="Select deadline", name="deadline")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "DatePicker",
   "placeholder": "Select deadline",
@@ -33,7 +33,7 @@ Give the DatePicker a `name` to store the selected date in state, then reference
 
 <ComponentPreview auto height="400px" json={`{"_tree":{"cssClass":"gap-3","type":"Column","children":[{"cssClass":"gap-4 items-center","type":"Row","children":[{"type":"DatePicker","placeholder":"Select deadline","name":"deadline"},{"type":"Text","content":"{{ deadline | date:long }}","bold":true}]}]},"_state":{"deadline":"2025-06-15T12:00:00.000Z"}}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import (
     Column,
     DatePicker,
@@ -48,7 +48,7 @@ with Column(gap=3):
         DatePicker(placeholder="Select deadline", name="deadline")
         Text("{{ deadline | date:long }}", bold=True)
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "_tree": {
     "cssClass": "gap-3",
@@ -86,7 +86,7 @@ DatePicker works naturally alongside other form controls, syncing its value to s
 
 <ComponentPreview auto json={`{"type":"Card","children":[{"type":"CardHeader","children":[{"type":"CardTitle","content":"New Event"}]},{"type":"CardContent","children":[{"cssClass":"gap-3","type":"Column","children":[{"type":"Label","text":"Event Name"},{"type":"Input","inputType":"text","placeholder":"Team standup","name":"eventName","disabled":false,"required":false},{"type":"Label","text":"Date"},{"type":"DatePicker","placeholder":"Pick a date","name":"eventDate"}]}]},{"type":"CardFooter","children":[{"type":"Button","label":"Create Event","variant":"default","size":"default","disabled":false}]}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import (
     Button,
     Card,
@@ -112,7 +112,7 @@ with Card():
     with CardFooter():
         Button("Create Event")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "Card",
   "children": [

--- a/docs/components/dialog.mdx
+++ b/docs/components/dialog.mdx
@@ -12,7 +12,7 @@ Dialogs display content in a modal overlay that focuses user attention. Like Pop
 
 <ComponentPreview auto height="400px" json={`{"type":"Dialog","title":"Crew Profile","description":"Update your details for the Heart of Gold crew manifest.","children":[{"type":"Button","label":"Edit Profile","variant":"outline","size":"default","disabled":false},{"cssClass":"gap-3","type":"Column","children":[{"type":"Label","text":"Name"},{"type":"Input","inputType":"text","placeholder":"Arthur Dent","name":"crewName","disabled":false,"required":false},{"type":"Label","text":"Designation"},{"type":"Input","inputType":"text","placeholder":"Sandwich Maker","name":"crewDesignation","disabled":false,"required":false}]},{"cssClass":"gap-2 justify-end","type":"Row","children":[{"type":"Button","label":"Save changes","variant":"default","size":"default","disabled":false}]}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import (
     Button,
     Column,
@@ -35,7 +35,7 @@ with Dialog(
     with Row(gap=2, css_class="justify-end"):
         Button("Save changes")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "Dialog",
   "title": "Crew Profile",
@@ -103,7 +103,7 @@ Dialogs work well for destructive actions that need explicit confirmation before
 
 <ComponentPreview auto height="360px" json={`{"type":"Dialog","title":"Activate Improbability Drive","description":"This action cannot be undone.","children":[{"type":"Button","label":"Engage Drive","variant":"destructive","size":"default","disabled":false},{"type":"Text","content":"Are you sure? The last time this was engaged, a sperm whale and a bowl of petunias materialized in mid-air."},{"cssClass":"gap-2 justify-end","type":"Row","children":[{"type":"Button","label":"Cancel","variant":"outline","size":"default","disabled":false},{"type":"Button","label":"Engage","variant":"destructive","size":"default","disabled":false}]}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import Button, Dialog, Row, Text
 
 with Dialog(
@@ -119,7 +119,7 @@ with Dialog(
         Button("Cancel", variant="outline")
         Button("Engage", variant="destructive")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "Dialog",
   "title": "Activate Improbability Drive",

--- a/docs/components/div-span.mdx
+++ b/docs/components/div-span.mdx
@@ -14,7 +14,7 @@ A block container with no default styling. Style it entirely through `css_class`
 
 <ComponentPreview auto json={`{"cssClass":"flex items-center gap-3 rounded-lg border p-4","type":"Div","children":[{"cssClass":"bg-emerald-500 rounded-md h-8 w-8","type":"Div"},{"content":"Custom layout with Div","type":"P"}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import (
     Div,
     P,
@@ -24,7 +24,7 @@ with Div(css_class="flex items-center gap-3 rounded-lg border p-4"):
     Div(css_class="bg-emerald-500 rounded-md h-8 w-8")
     P("Custom layout with Div")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "flex items-center gap-3 rounded-lg border p-4",
   "type": "Div",
@@ -49,7 +49,7 @@ An inline text element with no default styling. Useful for inline annotations or
 
 <ComponentPreview auto json={`{"cssClass":"gap-2 items-baseline","type":"Row","children":[{"content":"Status:","type":"P"},{"cssClass":"text-sm text-success font-medium","type":"Span","content":"Online"}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import (
     P,
     Row,
@@ -60,7 +60,7 @@ with Row(gap=2, align="baseline"):
     P("Status:")
     Span("Online", css_class="text-sm text-success font-medium")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-2 items-baseline",
   "type": "Row",

--- a/docs/components/field.mdx
+++ b/docs/components/field.mdx
@@ -14,7 +14,7 @@ Wrap any toggle-like control (Switch, Checkbox) inside a Field to get the choice
 
 <ComponentPreview auto json={`{"cssClass":"gap-4","type":"Column","children":[{"type":"Field","title":"Marketing emails","description":"Receive emails about new products and features.","disabled":false,"children":[{"type":"Switch","checked":false,"size":"default","disabled":false,"required":false}]},{"type":"Field","title":"Security emails","description":"Receive emails about your account activity.","disabled":false,"children":[{"type":"Switch","checked":true,"size":"default","disabled":false,"required":false}]}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import Column, Field, Switch
 
 with Column(gap=4):
@@ -32,7 +32,7 @@ with Column(gap=4):
     ):
         Switch(checked=True)
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-4",
   "type": "Column",
@@ -79,7 +79,7 @@ Field works with any toggle control.
 
 <ComponentPreview auto json={`{"cssClass":"gap-4","type":"Column","children":[{"type":"Field","title":"Accept terms","description":"You agree to our Terms of Service and Privacy Policy.","disabled":false,"children":[{"type":"Checkbox","checked":false,"disabled":false,"required":false}]},{"type":"Field","title":"Subscribe to newsletter","description":"Get weekly updates on new features.","disabled":false,"children":[{"type":"Checkbox","checked":true,"disabled":false,"required":false}]}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import Checkbox, Column, Field
 
 with Column(gap=4):
@@ -96,7 +96,7 @@ with Column(gap=4):
     ):
         Checkbox(checked=True)
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-4",
   "type": "Column",
@@ -141,7 +141,7 @@ A disabled Field dims the card and prevents interaction.
 
 <ComponentPreview auto json={`{"cssClass":"gap-4","type":"Column","children":[{"type":"Field","title":"Enabled option","description":"You can toggle this.","disabled":false,"children":[{"type":"Switch","checked":true,"size":"default","disabled":false,"required":false}]},{"type":"Field","title":"Disabled option","description":"This cannot be changed.","disabled":true,"children":[{"type":"Switch","checked":false,"size":"default","disabled":true,"required":false}]}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import Column, Field, Switch
 
 with Column(gap=4):
@@ -158,7 +158,7 @@ with Column(gap=4):
     ):
         Switch(disabled=True)
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-4",
   "type": "Column",

--- a/docs/components/foreach.mdx
+++ b/docs/components/foreach.mdx
@@ -12,7 +12,7 @@ import { ComponentPreview } from '/snippets/component-preview.mdx'
 
 <ComponentPreview auto json={`{"_tree":{"cssClass":"gap-2","type":"Column","children":[{"type":"ForEach","key":"crew","children":[{"type":"Card","children":[{"type":"CardHeader","children":[{"cssClass":"gap-2 items-center","type":"Row","children":[{"type":"CardTitle","content":"{{ name }}"},{"type":"Badge","label":"{{ designation }}","variant":"secondary"}]},{"type":"CardDescription","content":"{{ email }}"}]}]}]}]},"crew":[{"name":"Arthur Dent","designation":"Sandwich Maker","email":"arthur@heart-of-gold.ship"},{"name":"Ford Prefect","designation":"Researcher","email":"ford@megadodo.pub"},{"name":"Trillian","designation":"Astrophysicist","email":"trillian@heart-of-gold.ship"}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import (
     ForEach,
     Card,
@@ -39,7 +39,7 @@ with Column(gap=2):
                     Badge("{{ designation }}", variant="secondary")
                 CardDescription("{{ email }}")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "_tree": {
     "cssClass": "gap-2",
@@ -112,7 +112,7 @@ The `key` argument (passed positionally or as a keyword) names the field in the 
 
 <ComponentPreview auto json={`{"_tree":{"cssClass":"gap-2","type":"Row","children":[{"type":"ForEach","key":"tags","children":[{"type":"Badge","label":"{{ _item }}","variant":"secondary"}]}]},"tags":["earth","magrathea","vogon poetry","42"]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import (
     ForEach,
     Badge,
@@ -125,7 +125,7 @@ with Row(gap=2):
     with ForEach("tags"):
         Badge("{{ _item }}", variant="secondary")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "_tree": {
     "cssClass": "gap-2",
@@ -163,7 +163,7 @@ Since each item becomes the full interpolation context for that iteration, you c
 
 <ComponentPreview auto json={`{"_tree":{"cssClass":"gap-2","type":"Column","children":[{"type":"ForEach","key":"projects","children":[{"type":"Card","children":[{"type":"CardHeader","children":[{"type":"CardTitle","content":"{{ name }}"},{"type":"CardDescription","content":"Owner: {{ owner.name }}"}]}]}]}]},"projects":[{"name":"Heart of Gold","owner":{"name":"Zaphod Beeblebrox"}},{"name":"Hitchhiker's Guide","owner":{"name":"Ford Prefect"}}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import (
     ForEach,
     Card,
@@ -185,7 +185,7 @@ with Column(gap=2):
                 CardTitle("{{ name }}")
                 CardDescription("Owner: {{ owner.name }}")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "_tree": {
     "cssClass": "gap-2",

--- a/docs/components/grid.mdx
+++ b/docs/components/grid.mdx
@@ -12,7 +12,7 @@ Grid is a CSS grid with a configurable number of columns (1-12). Children fill c
 
 <ComponentPreview auto json={`{"cssClass":"gap-4 grid-cols-3","type":"Grid","children":[{"cssClass":"bg-emerald-500 rounded-md h-10","type":"Div"},{"cssClass":"bg-emerald-500 rounded-md h-10","type":"Div"},{"cssClass":"bg-emerald-500 rounded-md h-10","type":"Div"},{"cssClass":"bg-emerald-500 rounded-md h-10","type":"Div"},{"cssClass":"bg-emerald-500 rounded-md h-10","type":"Div"},{"cssClass":"bg-emerald-500 rounded-md h-10","type":"Div"}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import (
     Div,
     Grid,
@@ -22,7 +22,7 @@ with Grid(columns=3, gap=4):
     for _ in range(6):
         Div(css_class="bg-emerald-500 rounded-md h-10")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-4 grid-cols-3",
   "type": "Grid",
@@ -65,14 +65,14 @@ The same set of children reflows as the column count changes.
 <Tab title="columns=2">
 <ComponentPreview auto json={`{"cssClass":"gap-4 grid-cols-2 p-3 border-3 border-dashed","type":"Grid","children":[{"cssClass":"bg-emerald-500 rounded-md h-10","type":"Div"},{"cssClass":"bg-emerald-500 rounded-md h-10","type":"Div"},{"cssClass":"bg-emerald-500 rounded-md h-10","type":"Div"},{"cssClass":"bg-emerald-500 rounded-md h-10","type":"Div"},{"cssClass":"bg-emerald-500 rounded-md h-10","type":"Div"},{"cssClass":"bg-emerald-500 rounded-md h-10","type":"Div"}]}`}>
 <CodeGroup>
-```python Python highlight={3}
+```python Python highlight={3} icon="python"
 from prefab_ui.components import Div, Grid
 
 with Grid(columns=2, gap=4, css_class="p-3 border-3 border-dashed"):
     for _ in range(6):
         Div(css_class="bg-emerald-500 rounded-md h-10")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-4 grid-cols-2 p-3 border-3 border-dashed",
   "type": "Grid",
@@ -110,14 +110,14 @@ with Grid(columns=2, gap=4, css_class="p-3 border-3 border-dashed"):
 <Tab title="columns=3">
 <ComponentPreview auto json={`{"cssClass":"gap-4 grid-cols-3 p-3 border-3 border-dashed","type":"Grid","children":[{"cssClass":"bg-emerald-500 rounded-md h-10","type":"Div"},{"cssClass":"bg-emerald-500 rounded-md h-10","type":"Div"},{"cssClass":"bg-emerald-500 rounded-md h-10","type":"Div"},{"cssClass":"bg-emerald-500 rounded-md h-10","type":"Div"},{"cssClass":"bg-emerald-500 rounded-md h-10","type":"Div"},{"cssClass":"bg-emerald-500 rounded-md h-10","type":"Div"}]}`}>
 <CodeGroup>
-```python Python highlight={3}
+```python Python highlight={3} icon="python"
 from prefab_ui.components import Div, Grid
 
 with Grid(columns=3, gap=4, css_class="p-3 border-3 border-dashed"):
     for _ in range(6):
         Div(css_class="bg-emerald-500 rounded-md h-10")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-4 grid-cols-3 p-3 border-3 border-dashed",
   "type": "Grid",
@@ -155,14 +155,14 @@ with Grid(columns=3, gap=4, css_class="p-3 border-3 border-dashed"):
 <Tab title="columns=4">
 <ComponentPreview auto json={`{"cssClass":"gap-4 grid-cols-4 p-3 border-3 border-dashed","type":"Grid","children":[{"cssClass":"bg-emerald-500 rounded-md h-10","type":"Div"},{"cssClass":"bg-emerald-500 rounded-md h-10","type":"Div"},{"cssClass":"bg-emerald-500 rounded-md h-10","type":"Div"},{"cssClass":"bg-emerald-500 rounded-md h-10","type":"Div"},{"cssClass":"bg-emerald-500 rounded-md h-10","type":"Div"},{"cssClass":"bg-emerald-500 rounded-md h-10","type":"Div"}]}`}>
 <CodeGroup>
-```python Python highlight={3}
+```python Python highlight={3} icon="python"
 from prefab_ui.components import Div, Grid
 
 with Grid(columns=4, gap=4, css_class="p-3 border-3 border-dashed"):
     for _ in range(6):
         Div(css_class="bg-emerald-500 rounded-md h-10")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-4 grid-cols-4 p-3 border-3 border-dashed",
   "type": "Grid",
@@ -205,7 +205,7 @@ Grids nest naturally with other containers:
 
 <ComponentPreview auto json={`{"cssClass":"gap-6 grid-cols-2 p-3 border-3 border-dashed","type":"Grid","children":[{"cssClass":"p-3 border-3 border-dashed","type":"Column","children":[{"content":"Left Panel","type":"H3"},{"content":"Primary content goes here.","type":"P"}]},{"cssClass":"p-3 border-3 border-dashed","type":"Column","children":[{"content":"Right Panel","type":"H3"},{"content":"Secondary content goes here.","type":"P"}]}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import (
     Column,
     Grid,
@@ -221,7 +221,7 @@ with Grid(columns=2, gap=6, css_class="p-3 border-3 border-dashed"):
         H3("Right Panel")
         P("Secondary content goes here.")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-6 grid-cols-2 p-3 border-3 border-dashed",
   "type": "Grid",

--- a/docs/components/icon.mdx
+++ b/docs/components/icon.mdx
@@ -12,12 +12,12 @@ Icons render any [lucide icon](https://lucide.dev/icons) by name. Pass the icon 
 
 <ComponentPreview auto json={`{"type":"Icon","name":"rocket","size":"default"}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import Icon
 
 Icon("rocket")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "Icon",
   "name": "rocket",
@@ -33,7 +33,7 @@ Three size variants control the icon dimensions.
 
 <ComponentPreview auto json={`{"cssClass":"gap-4 items-center","type":"Row","children":[{"type":"Icon","name":"heart","size":"sm"},{"type":"Icon","name":"heart","size":"default"},{"type":"Icon","name":"heart","size":"lg"}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import Icon, Row
 
 with Row(gap=4, css_class="items-center"):
@@ -41,7 +41,7 @@ with Row(gap=4, css_class="items-center"):
     Icon("heart", size="default")
     Icon("heart", size="lg")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-4 items-center",
   "type": "Row",
@@ -73,7 +73,7 @@ Icons work inline alongside text and other components.
 
 <ComponentPreview auto json={`{"cssClass":"gap-3","type":"Column","children":[{"cssClass":"gap-2 items-center","type":"Row","children":[{"type":"Icon","name":"check","size":"sm"},{"type":"Text","content":"Task completed"}]},{"cssClass":"gap-2 items-center","type":"Row","children":[{"type":"Icon","name":"clock","size":"sm"},{"type":"Text","content":"Waiting for approval"}]},{"cssClass":"gap-2 items-center","type":"Row","children":[{"type":"Icon","name":"circle-x","size":"sm"},{"type":"Text","content":"Build failed"}]}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import (
     Column,
     Icon,
@@ -92,7 +92,7 @@ with Column(gap=3):
         Icon("circle-x", size="sm")
         Text("Build failed")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-3",
   "type": "Column",

--- a/docs/components/image.mdx
+++ b/docs/components/image.mdx
@@ -12,12 +12,12 @@ import { ComponentPreview } from '/snippets/component-preview.mdx'
 
 <ComponentPreview auto json={`{"type":"Image","src":"https://picsum.photos/400/300","alt":"Example image","width":"400px"}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import Image
 
 Image(src="https://picsum.photos/400/300", alt="Example image", width="400px")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "Image",
   "src": "https://picsum.photos/400/300",

--- a/docs/components/input.mdx
+++ b/docs/components/input.mdx
@@ -12,12 +12,12 @@ Inputs collect text, email, passwords, and other single-line data from users.
 
 <ComponentPreview auto json={`{"type":"Input","inputType":"text","placeholder":"Enter your email...","disabled":false,"required":false}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import Input
 
 Input(placeholder="Enter your email...")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "Input",
   "inputType": "text",
@@ -35,7 +35,7 @@ Different input types provide appropriate keyboards and validation on mobile dev
 
 <ComponentPreview auto json={`{"cssClass":"gap-4","type":"Column","children":[{"type":"Input","inputType":"email","placeholder":"Email","disabled":false,"required":false},{"type":"Input","inputType":"password","placeholder":"Password","disabled":false,"required":false},{"type":"Input","inputType":"number","placeholder":"Age","disabled":false,"required":false},{"type":"Input","inputType":"tel","placeholder":"Phone","disabled":false,"required":false}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import (
     Input,
     Column,
@@ -47,7 +47,7 @@ with Column(gap=4):
     Input(input_type="number", placeholder="Age")
     Input(input_type="tel", placeholder="Phone")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-4",
   "type": "Column",
@@ -92,7 +92,7 @@ Pair inputs with labels for accessible forms:
 
 <ComponentPreview auto json={`{"cssClass":"gap-2","type":"Column","children":[{"type":"Label","text":"Email address"},{"type":"Input","inputType":"email","placeholder":"you@example.com","disabled":false,"required":true}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import (
     Column,
     Input,
@@ -103,7 +103,7 @@ with Column(gap=2):
     Label("Email address")
     Input(input_type="email", placeholder="you@example.com", required=True)
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-2",
   "type": "Column",
@@ -131,7 +131,7 @@ Native date and time pickers use the browser's built-in UI:
 
 <ComponentPreview auto json={`{"cssClass":"gap-4","type":"Row","children":[{"cssClass":"gap-2 flex-1","type":"Column","children":[{"type":"Label","text":"Date"},{"type":"Input","inputType":"date","name":"date","disabled":false,"required":false}]},{"cssClass":"gap-2 flex-1","type":"Column","children":[{"type":"Label","text":"Time"},{"type":"Input","inputType":"time","name":"time","disabled":false,"required":false}]},{"cssClass":"gap-2 flex-1","type":"Column","children":[{"type":"Label","text":"Date & Time"},{"type":"Input","inputType":"datetime-local","name":"datetime","disabled":false,"required":false}]}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import (
     Column,
     Input,
@@ -150,7 +150,7 @@ with Row(gap=4):
         Label("Date & Time")
         Input(input_type="datetime-local", name="datetime")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-4",
   "type": "Row",
@@ -216,12 +216,12 @@ with Row(gap=4):
 
 <ComponentPreview auto json={`{"type":"Input","inputType":"text","placeholder":"Disabled input","disabled":true,"required":false}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import Input
 
 Input(placeholder="Disabled input", disabled=True)
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "Input",
   "inputType": "text",

--- a/docs/components/label.mdx
+++ b/docs/components/label.mdx
@@ -14,12 +14,12 @@ Labels can contain text directly or wrap other components.
 
 <ComponentPreview auto json={`{"type":"Label","text":"Email address"}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import Label
 
 Label("Email address")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "Label",
   "text": "Email address"
@@ -34,7 +34,7 @@ Labels are typically paired with inputs and other form controls:
 
 <ComponentPreview auto json={`{"cssClass":"gap-2","type":"Column","children":[{"type":"Label","text":"Username","forId":"username"},{"type":"Input","inputType":"text","placeholder":"Enter username","name":"username","disabled":false,"required":false}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import (
     Column,
     Input,
@@ -45,7 +45,7 @@ with Column(gap=2):
     Label("Username", for_id="username")
     Input(placeholder="Enter username", name="username")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-2",
   "type": "Column",

--- a/docs/components/line-chart.mdx
+++ b/docs/components/line-chart.mdx
@@ -12,7 +12,7 @@ LineChart connects data points with lines, making it ideal for showing trends ov
 
 <ComponentPreview auto json={`{"type":"LineChart","data":[{"month":"Jan","desktop":186,"mobile":80},{"month":"Feb","desktop":305,"mobile":200},{"month":"Mar","desktop":237,"mobile":120},{"month":"Apr","desktop":73,"mobile":190},{"month":"May","desktop":209,"mobile":130},{"month":"Jun","desktop":214,"mobile":140}],"series":[{"dataKey":"desktop","label":"Desktop"},{"dataKey":"mobile","label":"Mobile"}],"xAxis":"month","height":300,"curve":"linear","showDots":false,"showLegend":true,"showTooltip":true,"showGrid":true}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import LineChart, ChartSeries
 
 data = [
@@ -34,7 +34,7 @@ LineChart(
     show_legend=True,
 )
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "LineChart",
   "data": [
@@ -97,7 +97,7 @@ Turn off the grid for a cleaner look.
 
 <ComponentPreview auto json={`{"type":"LineChart","data":[{"month":"Jan","desktop":186,"mobile":80},{"month":"Feb","desktop":305,"mobile":200},{"month":"Mar","desktop":237,"mobile":120},{"month":"Apr","desktop":73,"mobile":190},{"month":"May","desktop":209,"mobile":130},{"month":"Jun","desktop":214,"mobile":140}],"series":[{"dataKey":"value","label":"Requests"}],"xAxis":"month","height":300,"curve":"linear","showDots":false,"showLegend":false,"showTooltip":true,"showGrid":false}`}>
 <CodeGroup>
-```python Python {5}
+```python Python {5} icon="python"
 LineChart(
     data=data,
     series=[ChartSeries(data_key="value", label="Requests")],
@@ -105,7 +105,7 @@ LineChart(
     show_grid=False,
 )
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "LineChart",
   "data": [
@@ -164,7 +164,7 @@ Set `curve="smooth"` for gently curved lines between data points.
 
 <ComponentPreview auto json={`{"type":"LineChart","data":[{"month":"Jan","desktop":186,"mobile":80},{"month":"Feb","desktop":305,"mobile":200},{"month":"Mar","desktop":237,"mobile":120},{"month":"Apr","desktop":73,"mobile":190},{"month":"May","desktop":209,"mobile":130},{"month":"Jun","desktop":214,"mobile":140}],"series":[{"dataKey":"desktop","label":"Desktop"},{"dataKey":"mobile","label":"Mobile"}],"xAxis":"month","height":300,"curve":"smooth","showDots":false,"showLegend":true,"showTooltip":true,"showGrid":true}`}>
 <CodeGroup>
-```python Python {8}
+```python Python {8} icon="python"
 LineChart(
     data=data,
     series=[
@@ -176,7 +176,7 @@ LineChart(
     show_legend=True,
 )
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "LineChart",
   "data": [
@@ -239,7 +239,7 @@ Set `curve="step"` to connect points with step-shaped lines. This is useful for 
 
 <ComponentPreview auto json={`{"type":"LineChart","data":[{"month":"Jan","desktop":186,"mobile":80},{"month":"Feb","desktop":305,"mobile":200},{"month":"Mar","desktop":237,"mobile":120},{"month":"Apr","desktop":73,"mobile":190},{"month":"May","desktop":209,"mobile":130},{"month":"Jun","desktop":214,"mobile":140}],"series":[{"dataKey":"desktop","label":"Desktop"},{"dataKey":"mobile","label":"Mobile"}],"xAxis":"month","height":300,"curve":"step","showDots":false,"showLegend":true,"showTooltip":true,"showGrid":true}`}>
 <CodeGroup>
-```python Python {8}
+```python Python {8} icon="python"
 LineChart(
     data=data,
     series=[
@@ -251,7 +251,7 @@ LineChart(
     show_legend=True,
 )
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "LineChart",
   "data": [
@@ -314,7 +314,7 @@ Set `show_dots=True` to render a dot at each data point along the lines.
 
 <ComponentPreview auto json={`{"type":"LineChart","data":[{"month":"Jan","desktop":186,"mobile":80},{"month":"Feb","desktop":305,"mobile":200},{"month":"Mar","desktop":237,"mobile":120},{"month":"Apr","desktop":73,"mobile":190},{"month":"May","desktop":209,"mobile":130},{"month":"Jun","desktop":214,"mobile":140}],"series":[{"dataKey":"desktop","label":"Desktop"},{"dataKey":"mobile","label":"Mobile"}],"xAxis":"month","height":300,"curve":"linear","showDots":true,"showLegend":true,"showTooltip":true,"showGrid":true}`}>
 <CodeGroup>
-```python Python {8}
+```python Python {8} icon="python"
 LineChart(
     data=data,
     series=[
@@ -326,7 +326,7 @@ LineChart(
     show_legend=True,
 )
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "LineChart",
   "data": [

--- a/docs/components/markdown.mdx
+++ b/docs/components/markdown.mdx
@@ -12,7 +12,7 @@ The Markdown component renders full markdown content — headings, bold, italic,
 
 <ComponentPreview auto json={`{"type":"Markdown","content":"\\n# Release Notes\\n\\nVersion **2.5.0** brings several improvements:\\n\\n## New Features\\n\\n- **Dark mode** with automatic system detection\\n- Keyboard shortcuts for *all* actions\\n- Inline \`code\` formatting support\\n\\n## Migration Guide\\n\\n> Update your config file before upgrading.\\n\\n| Setting | Old | New |\\n|---------|-----|-----|\\n| theme | \`light\` | \`auto\` |\\n| timeout | \`30s\` | \`60s\` |\\n"}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import Markdown
 
 Markdown("""
@@ -36,7 +36,7 @@ Version **2.5.0** brings several improvements:
 | timeout | `30s` | `60s` |
 """)
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "Markdown",
   "content": "\n# Release Notes\n\nVersion **2.5.0** brings several improvements:\n\n## New Features\n\n- **Dark mode** with automatic system detection\n- Keyboard shortcuts for *all* actions\n- Inline `code` formatting support\n\n## Migration Guide\n\n> Update your config file before upgrading.\n\n| Setting | Old | New |\n|---------|-----|-----|\n| theme | `light` | `auto` |\n| timeout | `30s` | `60s` |\n"

--- a/docs/components/pages.mdx
+++ b/docs/components/pages.mdx
@@ -12,7 +12,7 @@ Pages provide a multi-page layout where only the active page renders. Navigate b
 
 <ComponentPreview auto json={`{"cssClass":"gap-4","type":"Column","children":[{"cssClass":"gap-2","type":"Row","children":[{"type":"Button","label":"Earth","variant":"default","size":"default","disabled":false,"onClick":{"action":"setState","key":"entry","value":"earth"}},{"type":"Button","label":"Magrathea","variant":"outline","size":"default","disabled":false,"onClick":{"action":"setState","key":"entry","value":"magrathea"}},{"type":"Button","label":"Milliways","variant":"outline","size":"default","disabled":false,"onClick":{"action":"setState","key":"entry","value":"milliways"}}]},{"type":"Pages","defaultValue":"earth","name":"entry","children":[{"type":"Page","title":"Earth","value":"earth","children":[{"type":"Card","children":[{"type":"CardHeader","children":[{"type":"CardTitle","content":"Earth"},{"type":"CardDescription","content":"Mostly harmless."}]}]}]},{"type":"Page","title":"Magrathea","value":"magrathea","children":[{"type":"Card","children":[{"type":"CardHeader","children":[{"type":"CardTitle","content":"Magrathea"},{"type":"CardDescription","content":"Ancient planet-building civilization. Custom-built luxury planets for the ultra-rich."}]}]}]},{"type":"Page","title":"Milliways","value":"milliways","children":[{"type":"Card","children":[{"type":"CardHeader","children":[{"type":"CardTitle","content":"Milliways"},{"type":"CardDescription","content":"The Restaurant at the End of the Universe. Reservations recommended."}]}]}]}]}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import (
     Button,
     Card,
@@ -55,7 +55,7 @@ with Column(gap=4):
                         "Reservations recommended."
                     )
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-4",
   "type": "Column",
@@ -198,7 +198,7 @@ Pages pair naturally with `SetState` to build wizard flows. Each page's button a
 
 <ComponentPreview auto json={`{"cssClass":"gap-4","type":"Column","children":[{"type":"Pages","defaultValue":"setup","name":"step","children":[{"type":"Page","title":"Setup","value":"setup","children":[{"cssClass":"gap-4","type":"Column","children":[{"type":"Text","content":"Configure your settings."},{"type":"Row","children":[{"type":"Button","label":"Next","variant":"default","size":"default","disabled":false,"onClick":{"action":"setState","key":"step","value":"review"}}]}]}]},{"type":"Page","title":"Review","value":"review","children":[{"cssClass":"gap-4","type":"Column","children":[{"type":"Text","content":"Review your choices."},{"cssClass":"gap-2","type":"Row","children":[{"type":"Button","label":"Back","variant":"outline","size":"default","disabled":false,"onClick":{"action":"setState","key":"step","value":"setup"}},{"type":"Button","label":"Next","variant":"default","size":"default","disabled":false,"onClick":{"action":"setState","key":"step","value":"complete"}}]}]}]},{"type":"Page","title":"Complete","value":"complete","children":[{"type":"Text","content":"All done!"}]}]}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import Button, Column, Page, Pages, Row, Text
 from prefab_ui.actions import SetState
 
@@ -218,7 +218,7 @@ with Column(gap=4):
         with Page("Complete", value="complete"):
             Text("All done!")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-4",
   "type": "Column",

--- a/docs/components/pie-chart.mdx
+++ b/docs/components/pie-chart.mdx
@@ -12,7 +12,7 @@ PieChart shows how parts relate to a whole. Unlike the other chart types, it doe
 
 <ComponentPreview auto json={`{"type":"PieChart","data":[{"browser":"Chrome","visitors":275},{"browser":"Safari","visitors":200},{"browser":"Firefox","visitors":187},{"browser":"Edge","visitors":173},{"browser":"Other","visitors":90}],"dataKey":"visitors","nameKey":"browser","height":300,"innerRadius":0,"showLabel":false,"paddingAngle":0,"showLegend":true,"showTooltip":true}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import PieChart
 
 data = [
@@ -30,7 +30,7 @@ PieChart(
     show_legend=True,
 )
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "PieChart",
   "data": [
@@ -74,7 +74,7 @@ Set `inner_radius` to a value greater than 0 to hollow out the center. This crea
 
 <ComponentPreview auto json={`{"type":"PieChart","data":[{"browser":"Chrome","visitors":275},{"browser":"Safari","visitors":200},{"browser":"Firefox","visitors":187},{"browser":"Edge","visitors":173},{"browser":"Other","visitors":90}],"dataKey":"visitors","nameKey":"browser","height":300,"innerRadius":60,"showLabel":false,"paddingAngle":0,"showLegend":true,"showTooltip":true}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 PieChart(
     data=[
         {"browser": "Chrome", "visitors": 275},
@@ -89,7 +89,7 @@ PieChart(
     show_legend=True,
 )
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "PieChart",
   "data": [
@@ -133,7 +133,7 @@ Set `show_label=True` to display a label on each slice, making values readable w
 
 <ComponentPreview auto json={`{"type":"PieChart","data":[{"browser":"Chrome","visitors":275},{"browser":"Safari","visitors":200},{"browser":"Firefox","visitors":187},{"browser":"Edge","visitors":173},{"browser":"Other","visitors":90}],"dataKey":"visitors","nameKey":"browser","height":300,"innerRadius":0,"showLabel":true,"paddingAngle":0,"showLegend":true,"showTooltip":true}`}>
 <CodeGroup>
-```python Python {5}
+```python Python {5} icon="python"
 PieChart(
     data=data,
     data_key="visitors",
@@ -142,7 +142,7 @@ PieChart(
     show_legend=True,
 )
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "PieChart",
   "data": [
@@ -186,7 +186,7 @@ Set `padding_angle` to add space between slices, visually separating each segmen
 
 <ComponentPreview auto json={`{"type":"PieChart","data":[{"browser":"Chrome","visitors":275},{"browser":"Safari","visitors":200},{"browser":"Firefox","visitors":187},{"browser":"Edge","visitors":173},{"browser":"Other","visitors":90}],"dataKey":"visitors","nameKey":"browser","height":300,"innerRadius":60,"showLabel":false,"paddingAngle":5,"showLegend":true,"showTooltip":true}`}>
 <CodeGroup>
-```python Python {6}
+```python Python {6} icon="python"
 PieChart(
     data=data,
     data_key="visitors",
@@ -196,7 +196,7 @@ PieChart(
     show_legend=True,
 )
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "PieChart",
   "data": [

--- a/docs/components/popover.mdx
+++ b/docs/components/popover.mdx
@@ -12,7 +12,7 @@ Popovers display rich content in a floating panel when users click a trigger ele
 
 <ComponentPreview auto height="340px" json={`{"type":"Popover","title":"Babel Fish Settings","description":"Configure your universal translator.","children":[{"type":"Button","label":"Open popover","variant":"outline","size":"default","disabled":false},{"cssClass":"gap-3","type":"Column","children":[{"type":"Label","text":"Source Language"},{"type":"Input","inputType":"text","placeholder":"Vogon","name":"sourceLang","disabled":false,"required":false},{"type":"Label","text":"Target Language"},{"type":"Input","inputType":"text","placeholder":"Galactic Standard","name":"targetLang","disabled":false,"required":false}]}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import (
     Button,
     Column,
@@ -29,7 +29,7 @@ with Popover(title="Babel Fish Settings", description="Configure your universal 
         Label("Target Language")
         Input(name="targetLang", placeholder="Galactic Standard")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "Popover",
   "title": "Babel Fish Settings",
@@ -84,7 +84,7 @@ Skip the `title` and `description` to render content directly in the panel.
 
 <ComponentPreview auto height="260px" json={`{"type":"Popover","children":[{"type":"Button","label":"Settings","variant":"outline","size":"default","disabled":false},{"cssClass":"gap-3","type":"Column","children":[{"type":"Label","text":"Improbability Factor"},{"type":"Slider","min":0.0,"max":100.0,"value":42.0,"name":"improbability","disabled":false}]}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import (
     Button,
     Column,
@@ -99,7 +99,7 @@ with Popover():
         Label("Improbability Factor")
         Slider(min=0, max=100, value=42, name="improbability")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "Popover",
   "children": [

--- a/docs/components/progress.mdx
+++ b/docs/components/progress.mdx
@@ -12,12 +12,12 @@ Progress bars show how far along a process is. They fill from left to right as `
 
 <ComponentPreview auto json={`{"type":"Progress","value":60.0,"max":100}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import Progress
 
 Progress(value=60)
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "Progress",
   "value": 60.0,
@@ -33,7 +33,7 @@ By default `max` is 100, but you can set it to any positive number. The renderer
 
 <ComponentPreview auto json={`{"cssClass":"gap-4","type":"Column","children":[{"cssClass":"gap-2","type":"Column","children":[{"type":"Label","text":"3 of 5 steps"},{"type":"Progress","value":3.0,"max":5.0}]},{"cssClass":"gap-2","type":"Column","children":[{"type":"Label","text":"75%"},{"type":"Progress","value":75.0,"max":100}]}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import Column, Label, Progress
 
 with Column(gap=4):
@@ -44,7 +44,7 @@ with Column(gap=4):
         Label("75%")
         Progress(value=75)
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-4",
   "type": "Column",
@@ -91,7 +91,7 @@ Use `indicator_class` to change the progress bar color:
 
 <ComponentPreview auto json={`{"cssClass":"gap-4","type":"Column","children":[{"cssClass":"gap-2","type":"Column","children":[{"type":"Label","text":"Storage Used"},{"type":"Progress","value":85.0,"max":100,"indicatorClass":"bg-red-500"}]},{"cssClass":"gap-2","type":"Column","children":[{"type":"Label","text":"Upload Progress"},{"type":"Progress","value":45.0,"max":100,"indicatorClass":"bg-blue-500"}]},{"cssClass":"gap-2","type":"Column","children":[{"type":"Label","text":"Tasks Complete"},{"type":"Progress","value":100.0,"max":100,"indicatorClass":"bg-green-500"}]}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import Column, Label, Progress
 
 with Column(gap=4):
@@ -105,7 +105,7 @@ with Column(gap=4):
         Label("Tasks Complete")
         Progress(value=100, indicator_class="bg-green-500")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-4",
   "type": "Column",
@@ -170,7 +170,7 @@ Bind a slider to a progress bar so the label reflects the actual value. The `per
 
 <ComponentPreview auto json={`{"_tree":{"cssClass":"gap-3","type":"Column","children":[{"cssClass":"justify-between items-center","type":"Row","children":[{"type":"Text","content":"Upload progress"},{"type":"Text","content":"{{ progress | percent }}","bold":true}]},{"type":"Progress","value":"{{ progress }}","max":1.0},{"type":"Slider","min":0.0,"max":1.0,"value":0.65,"step":0.01,"name":"progress","disabled":false}]},"_state":{"progress":0.65}}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import (
     Column,
     Progress,
@@ -188,7 +188,7 @@ with Column(gap=3):
     Progress(value="{{ progress }}", max=1)
     Slider(name="progress", min=0, max=1, step=0.01, value=0.65)
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "_tree": {
     "cssClass": "gap-3",

--- a/docs/components/radar-chart.mdx
+++ b/docs/components/radar-chart.mdx
@@ -12,7 +12,7 @@ RadarChart plots data across multiple axes radiating from a center point, formin
 
 <ComponentPreview auto json={`{"type":"RadarChart","data":[{"subject":"Math","alice":120,"bob":98},{"subject":"English","alice":98,"bob":130},{"subject":"Science","alice":86,"bob":110},{"subject":"History","alice":99,"bob":95},{"subject":"Art","alice":85,"bob":90}],"series":[{"dataKey":"alice","label":"Alice"},{"dataKey":"bob","label":"Bob"}],"axisKey":"subject","height":300,"filled":true,"showDots":false,"showLegend":true,"showTooltip":true,"showGrid":true}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import RadarChart, ChartSeries
 
 data = [
@@ -33,7 +33,7 @@ RadarChart(
     show_legend=True,
 )
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "RadarChart",
   "data": [
@@ -91,7 +91,7 @@ Hide the polar grid for a cleaner look.
 
 <ComponentPreview auto json={`{"type":"RadarChart","data":[{"subject":"Math","alice":120,"bob":98},{"subject":"English","alice":98,"bob":130},{"subject":"Science","alice":86,"bob":110},{"subject":"History","alice":99,"bob":95},{"subject":"Art","alice":85,"bob":90}],"series":[{"dataKey":"score","label":"Score"}],"axisKey":"subject","height":300,"filled":true,"showDots":false,"showLegend":false,"showTooltip":true,"showGrid":false}`}>
 <CodeGroup>
-```python Python {5}
+```python Python {5} icon="python"
 RadarChart(
     data=data,
     series=[ChartSeries(data_key="score", label="Score")],
@@ -99,7 +99,7 @@ RadarChart(
     show_grid=False,
 )
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "RadarChart",
   "data": [
@@ -153,7 +153,7 @@ Set `filled=False` to render outlines without filled polygons, which can be easi
 
 <ComponentPreview auto json={`{"type":"RadarChart","data":[{"subject":"Math","alice":120,"bob":98},{"subject":"English","alice":98,"bob":130},{"subject":"Science","alice":86,"bob":110},{"subject":"History","alice":99,"bob":95},{"subject":"Art","alice":85,"bob":90}],"series":[{"dataKey":"alice","label":"Alice"},{"dataKey":"bob","label":"Bob"}],"axisKey":"subject","height":300,"filled":false,"showDots":false,"showLegend":true,"showTooltip":true,"showGrid":true}`}>
 <CodeGroup>
-```python Python {8}
+```python Python {8} icon="python"
 RadarChart(
     data=data,
     series=[
@@ -165,7 +165,7 @@ RadarChart(
     show_legend=True,
 )
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "RadarChart",
   "data": [

--- a/docs/components/radial-chart.mdx
+++ b/docs/components/radial-chart.mdx
@@ -12,7 +12,7 @@ RadialChart renders each data item as a concentric ring, with length proportiona
 
 <ComponentPreview auto json={`{"type":"RadialChart","data":[{"browser":"Chrome","visitors":275},{"browser":"Safari","visitors":200},{"browser":"Firefox","visitors":187},{"browser":"Edge","visitors":173},{"browser":"Other","visitors":90}],"dataKey":"visitors","nameKey":"browser","height":300,"innerRadius":30,"startAngle":180,"endAngle":0,"showLegend":true,"showTooltip":true}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import RadialChart
 
 data = [
@@ -30,7 +30,7 @@ RadialChart(
     show_legend=True,
 )
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "RadialChart",
   "data": [
@@ -74,7 +74,7 @@ Increase `inner_radius` to push rings outward, creating a tighter radial layout.
 
 <ComponentPreview auto json={`{"type":"RadialChart","data":[{"browser":"Chrome","visitors":275},{"browser":"Safari","visitors":200},{"browser":"Firefox","visitors":187},{"browser":"Edge","visitors":173},{"browser":"Other","visitors":90}],"dataKey":"visitors","nameKey":"browser","height":300,"innerRadius":80,"startAngle":180,"endAngle":0,"showLegend":true,"showTooltip":true}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 RadialChart(
     data=[
         {"browser": "Chrome", "visitors": 275},
@@ -89,7 +89,7 @@ RadialChart(
     show_legend=True,
 )
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "RadialChart",
   "data": [
@@ -133,7 +133,7 @@ Adjust `start_angle` and `end_angle` to render rings as a partial arc instead of
 
 <ComponentPreview auto json={`{"type":"RadialChart","data":[{"browser":"Chrome","visitors":275},{"browser":"Safari","visitors":200},{"browser":"Firefox","visitors":187},{"browser":"Edge","visitors":173},{"browser":"Other","visitors":90}],"dataKey":"visitors","nameKey":"browser","height":300,"innerRadius":30,"startAngle":90,"endAngle":-270,"showLegend":true,"showTooltip":true}`}>
 <CodeGroup>
-```python Python {5-6}
+```python Python {5-6} icon="python"
 RadialChart(
     data=data,
     data_key="visitors",
@@ -143,7 +143,7 @@ RadialChart(
     show_legend=True,
 )
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "RadialChart",
   "data": [

--- a/docs/components/radio.mdx
+++ b/docs/components/radio.mdx
@@ -12,7 +12,7 @@ Radio buttons let users select exactly one option from a set of choices.
 
 <ComponentPreview auto json={`{"type":"RadioGroup","name":"size","children":[{"type":"Radio","value":"sm","label":"Small","checked":false,"disabled":false,"required":false},{"type":"Radio","value":"md","label":"Medium","checked":true,"disabled":false,"required":false},{"type":"Radio","value":"lg","label":"Large","checked":false,"disabled":false,"required":false}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import (
     Radio,
     RadioGroup,
@@ -23,7 +23,7 @@ with RadioGroup(name="size"):
     Radio(value="md", label="Medium", checked=True)
     Radio(value="lg", label="Large")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "RadioGroup",
   "name": "size",
@@ -64,7 +64,7 @@ Individual radio buttons can be used independently:
 
 <ComponentPreview auto json={`{"cssClass":"gap-3","type":"Column","children":[{"type":"Radio","value":"yes","label":"Yes","checked":false,"name":"answer","disabled":false,"required":false},{"type":"Radio","value":"no","label":"No","checked":true,"name":"answer","disabled":false,"required":false}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import (
     Column,
     Radio,
@@ -74,7 +74,7 @@ with Column(gap=3):
     Radio(value="yes", label="Yes", name="answer")
     Radio(value="no", label="No", name="answer", checked=True)
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-3",
   "type": "Column",
@@ -107,7 +107,7 @@ with Column(gap=3):
 
 <ComponentPreview auto json={`{"type":"RadioGroup","name":"plan","children":[{"type":"Radio","value":"free","label":"Free","checked":true,"disabled":false,"required":false},{"type":"Radio","value":"pro","label":"Pro","checked":false,"disabled":false,"required":false},{"type":"Radio","value":"enterprise","label":"Enterprise","checked":false,"disabled":true,"required":false}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import (
     Radio,
     RadioGroup,
@@ -118,7 +118,7 @@ with RadioGroup(name="plan"):
     Radio(value="pro", label="Pro")
     Radio(value="enterprise", label="Enterprise", disabled=True)
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "RadioGroup",
   "name": "plan",

--- a/docs/components/row.mdx
+++ b/docs/components/row.mdx
@@ -12,7 +12,7 @@ Row arranges children horizontally with flexbox. Use `gap` to control spacing be
 
 <ComponentPreview auto json={`{"cssClass":"gap-4","type":"Row","children":[{"cssClass":"bg-emerald-500 rounded-md h-10 w-20","type":"Div"},{"cssClass":"bg-emerald-500 rounded-md h-10 w-20","type":"Div"},{"cssClass":"bg-emerald-500 rounded-md h-10 w-20","type":"Div"}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import (
     Div,
     Row,
@@ -23,7 +23,7 @@ with Row(gap=4):
     Div(css_class="bg-emerald-500 rounded-md h-10 w-20")
     Div(css_class="bg-emerald-500 rounded-md h-10 w-20")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-4",
   "type": "Row",
@@ -54,7 +54,7 @@ Gap controls the spacing between children. Larger values give more visual separa
 <Tab title="gap=4">
 <ComponentPreview auto json={`{"cssClass":"gap-4 p-3 border-3 border-dashed","type":"Row","children":[{"cssClass":"bg-emerald-500 rounded-md h-10 w-20","type":"Div"},{"cssClass":"bg-emerald-500 rounded-md h-10 w-20","type":"Div"},{"cssClass":"bg-emerald-500 rounded-md h-10 w-20","type":"Div"}]}`}>
 <CodeGroup>
-```python Python highlight={3}
+```python Python highlight={3} icon="python"
 from prefab_ui.components import Div, Row
 
 with Row(gap=4, css_class="p-3 border-3 border-dashed"):
@@ -62,7 +62,7 @@ with Row(gap=4, css_class="p-3 border-3 border-dashed"):
     Div(css_class="bg-emerald-500 rounded-md h-10 w-20")
     Div(css_class="bg-emerald-500 rounded-md h-10 w-20")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-4 p-3 border-3 border-dashed",
   "type": "Row",
@@ -88,7 +88,7 @@ with Row(gap=4, css_class="p-3 border-3 border-dashed"):
 <Tab title="gap=8">
 <ComponentPreview auto json={`{"cssClass":"gap-8 p-3 border-3 border-dashed","type":"Row","children":[{"cssClass":"bg-emerald-500 rounded-md h-10 w-20","type":"Div"},{"cssClass":"bg-emerald-500 rounded-md h-10 w-20","type":"Div"},{"cssClass":"bg-emerald-500 rounded-md h-10 w-20","type":"Div"}]}`}>
 <CodeGroup>
-```python Python highlight={3}
+```python Python highlight={3} icon="python"
 from prefab_ui.components import Div, Row
 
 with Row(gap=8, css_class="p-3 border-3 border-dashed"):
@@ -96,7 +96,7 @@ with Row(gap=8, css_class="p-3 border-3 border-dashed"):
     Div(css_class="bg-emerald-500 rounded-md h-10 w-20")
     Div(css_class="bg-emerald-500 rounded-md h-10 w-20")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-8 p-3 border-3 border-dashed",
   "type": "Row",
@@ -122,7 +122,7 @@ with Row(gap=8, css_class="p-3 border-3 border-dashed"):
 <Tab title="gap=12">
 <ComponentPreview auto json={`{"cssClass":"gap-12 p-3 border-3 border-dashed","type":"Row","children":[{"cssClass":"bg-emerald-500 rounded-md h-10 w-20","type":"Div"},{"cssClass":"bg-emerald-500 rounded-md h-10 w-20","type":"Div"},{"cssClass":"bg-emerald-500 rounded-md h-10 w-20","type":"Div"}]}`}>
 <CodeGroup>
-```python Python highlight={3}
+```python Python highlight={3} icon="python"
 from prefab_ui.components import Div, Row
 
 with Row(gap=12, css_class="p-3 border-3 border-dashed"):
@@ -130,7 +130,7 @@ with Row(gap=12, css_class="p-3 border-3 border-dashed"):
     Div(css_class="bg-emerald-500 rounded-md h-10 w-20")
     Div(css_class="bg-emerald-500 rounded-md h-10 w-20")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-12 p-3 border-3 border-dashed",
   "type": "Row",
@@ -163,7 +163,7 @@ with Row(gap=12, css_class="p-3 border-3 border-dashed"):
 <Tab title='align="start"'>
 <ComponentPreview auto json={`{"cssClass":"gap-4 items-start p-3 border-3 border-dashed","type":"Row","children":[{"cssClass":"bg-emerald-500 rounded-md h-8 w-20","type":"Div"},{"cssClass":"bg-emerald-500 rounded-md h-16 w-20","type":"Div"},{"cssClass":"bg-emerald-500 rounded-md h-10 w-20","type":"Div"}]}`}>
 <CodeGroup>
-```python Python highlight={3}
+```python Python highlight={3} icon="python"
 from prefab_ui.components import Div, Row
 
 with Row(gap=4, align="start", css_class="p-3 border-3 border-dashed"):
@@ -171,7 +171,7 @@ with Row(gap=4, align="start", css_class="p-3 border-3 border-dashed"):
     Div(css_class="bg-emerald-500 rounded-md h-16 w-20")
     Div(css_class="bg-emerald-500 rounded-md h-10 w-20")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-4 items-start p-3 border-3 border-dashed",
   "type": "Row",
@@ -197,7 +197,7 @@ with Row(gap=4, align="start", css_class="p-3 border-3 border-dashed"):
 <Tab title='align="center"'>
 <ComponentPreview auto json={`{"cssClass":"gap-4 items-center p-3 border-3 border-dashed","type":"Row","children":[{"cssClass":"bg-emerald-500 rounded-md h-8 w-20","type":"Div"},{"cssClass":"bg-emerald-500 rounded-md h-16 w-20","type":"Div"},{"cssClass":"bg-emerald-500 rounded-md h-10 w-20","type":"Div"}]}`}>
 <CodeGroup>
-```python Python highlight={3}
+```python Python highlight={3} icon="python"
 from prefab_ui.components import Div, Row
 
 with Row(gap=4, align="center", css_class="p-3 border-3 border-dashed"):
@@ -205,7 +205,7 @@ with Row(gap=4, align="center", css_class="p-3 border-3 border-dashed"):
     Div(css_class="bg-emerald-500 rounded-md h-16 w-20")
     Div(css_class="bg-emerald-500 rounded-md h-10 w-20")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-4 items-center p-3 border-3 border-dashed",
   "type": "Row",
@@ -231,7 +231,7 @@ with Row(gap=4, align="center", css_class="p-3 border-3 border-dashed"):
 <Tab title='align="end"'>
 <ComponentPreview auto json={`{"cssClass":"gap-4 items-end p-3 border-3 border-dashed","type":"Row","children":[{"cssClass":"bg-emerald-500 rounded-md h-8 w-20","type":"Div"},{"cssClass":"bg-emerald-500 rounded-md h-16 w-20","type":"Div"},{"cssClass":"bg-emerald-500 rounded-md h-10 w-20","type":"Div"}]}`}>
 <CodeGroup>
-```python Python highlight={3}
+```python Python highlight={3} icon="python"
 from prefab_ui.components import Div, Row
 
 with Row(gap=4, align="end", css_class="p-3 border-3 border-dashed"):
@@ -239,7 +239,7 @@ with Row(gap=4, align="end", css_class="p-3 border-3 border-dashed"):
     Div(css_class="bg-emerald-500 rounded-md h-16 w-20")
     Div(css_class="bg-emerald-500 rounded-md h-10 w-20")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-4 items-end p-3 border-3 border-dashed",
   "type": "Row",
@@ -267,7 +267,7 @@ Baseline aligns children along the invisible line that text sits on. Unlike `cen
 
 <ComponentPreview auto json={`{"cssClass":"gap-4 items-baseline p-3 border-3 border-dashed","type":"Row","children":[{"cssClass":"bg-emerald-500 rounded-md px-3 py-1 text-white text-sm","type":"Span","content":"Small"},{"cssClass":"bg-emerald-500 rounded-md px-3 py-2 text-white text-2xl","type":"Span","content":"Large"},{"cssClass":"bg-emerald-500 rounded-md px-3 py-1 text-white text-base","type":"Span","content":"Medium"}]}`}>
 <CodeGroup>
-```python Python highlight={3}
+```python Python highlight={3} icon="python"
 from prefab_ui.components import Row, Span
 
 with Row(gap=4, align="baseline", css_class="p-3 border-3 border-dashed"):
@@ -287,7 +287,7 @@ with Row(gap=4, align="baseline", css_class="p-3 border-3 border-dashed"):
         "px-3 py-1 text-white text-base",
     )
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-4 items-baseline p-3 border-3 border-dashed",
   "type": "Row",
@@ -323,7 +323,7 @@ with Row(gap=4, align="baseline", css_class="p-3 border-3 border-dashed"):
 <Tab title='justify="start"'>
 <ComponentPreview auto json={`{"cssClass":"gap-1 justify-start w-full p-3 border-3 border-dashed","type":"Row","children":[{"cssClass":"bg-emerald-500 rounded-md h-10 w-20","type":"Div"},{"cssClass":"bg-emerald-500 rounded-md h-10 w-20","type":"Div"},{"cssClass":"bg-emerald-500 rounded-md h-10 w-20","type":"Div"}]}`}>
 <CodeGroup>
-```python Python highlight={3}
+```python Python highlight={3} icon="python"
 from prefab_ui.components import Div, Row
 
 with Row(gap=1, justify="start", css_class="w-full p-3 border-3 border-dashed"):
@@ -331,7 +331,7 @@ with Row(gap=1, justify="start", css_class="w-full p-3 border-3 border-dashed"):
     Div(css_class="bg-emerald-500 rounded-md h-10 w-20")
     Div(css_class="bg-emerald-500 rounded-md h-10 w-20")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-1 justify-start w-full p-3 border-3 border-dashed",
   "type": "Row",
@@ -357,7 +357,7 @@ with Row(gap=1, justify="start", css_class="w-full p-3 border-3 border-dashed"):
 <Tab title='justify="center"'>
 <ComponentPreview auto json={`{"cssClass":"gap-1 justify-center w-full p-3 border-3 border-dashed","type":"Row","children":[{"cssClass":"bg-emerald-500 rounded-md h-10 w-20","type":"Div"},{"cssClass":"bg-emerald-500 rounded-md h-10 w-20","type":"Div"},{"cssClass":"bg-emerald-500 rounded-md h-10 w-20","type":"Div"}]}`}>
 <CodeGroup>
-```python Python highlight={3}
+```python Python highlight={3} icon="python"
 from prefab_ui.components import Div, Row
 
 with Row(gap=1, justify="center", css_class="w-full p-3 border-3 border-dashed"):
@@ -365,7 +365,7 @@ with Row(gap=1, justify="center", css_class="w-full p-3 border-3 border-dashed")
     Div(css_class="bg-emerald-500 rounded-md h-10 w-20")
     Div(css_class="bg-emerald-500 rounded-md h-10 w-20")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-1 justify-center w-full p-3 border-3 border-dashed",
   "type": "Row",
@@ -391,7 +391,7 @@ with Row(gap=1, justify="center", css_class="w-full p-3 border-3 border-dashed")
 <Tab title='justify="end"'>
 <ComponentPreview auto json={`{"cssClass":"gap-1 justify-end w-full p-3 border-3 border-dashed","type":"Row","children":[{"cssClass":"bg-emerald-500 rounded-md h-10 w-20","type":"Div"},{"cssClass":"bg-emerald-500 rounded-md h-10 w-20","type":"Div"},{"cssClass":"bg-emerald-500 rounded-md h-10 w-20","type":"Div"}]}`}>
 <CodeGroup>
-```python Python highlight={3}
+```python Python highlight={3} icon="python"
 from prefab_ui.components import Div, Row
 
 with Row(gap=1, justify="end", css_class="w-full p-3 border-3 border-dashed"):
@@ -399,7 +399,7 @@ with Row(gap=1, justify="end", css_class="w-full p-3 border-3 border-dashed"):
     Div(css_class="bg-emerald-500 rounded-md h-10 w-20")
     Div(css_class="bg-emerald-500 rounded-md h-10 w-20")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-1 justify-end w-full p-3 border-3 border-dashed",
   "type": "Row",
@@ -425,7 +425,7 @@ with Row(gap=1, justify="end", css_class="w-full p-3 border-3 border-dashed"):
 <Tab title='justify="between"'>
 <ComponentPreview auto json={`{"cssClass":"gap-1 justify-between w-full p-3 border-3 border-dashed","type":"Row","children":[{"cssClass":"bg-emerald-500 rounded-md h-10 w-20","type":"Div"},{"cssClass":"bg-emerald-500 rounded-md h-10 w-20","type":"Div"},{"cssClass":"bg-emerald-500 rounded-md h-10 w-20","type":"Div"}]}`}>
 <CodeGroup>
-```python Python highlight={3}
+```python Python highlight={3} icon="python"
 from prefab_ui.components import Div, Row
 
 with Row(gap=1, justify="between", css_class="w-full p-3 border-3 border-dashed"):
@@ -433,7 +433,7 @@ with Row(gap=1, justify="between", css_class="w-full p-3 border-3 border-dashed"
     Div(css_class="bg-emerald-500 rounded-md h-10 w-20")
     Div(css_class="bg-emerald-500 rounded-md h-10 w-20")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-1 justify-between w-full p-3 border-3 border-dashed",
   "type": "Row",
@@ -459,7 +459,7 @@ with Row(gap=1, justify="between", css_class="w-full p-3 border-3 border-dashed"
 <Tab title='justify="around"'>
 <ComponentPreview auto json={`{"cssClass":"gap-1 justify-around w-full p-3 border-3 border-dashed","type":"Row","children":[{"cssClass":"bg-emerald-500 rounded-md h-10 w-20","type":"Div"},{"cssClass":"bg-emerald-500 rounded-md h-10 w-20","type":"Div"},{"cssClass":"bg-emerald-500 rounded-md h-10 w-20","type":"Div"}]}`}>
 <CodeGroup>
-```python Python highlight={3}
+```python Python highlight={3} icon="python"
 from prefab_ui.components import Div, Row
 
 with Row(gap=1, justify="around", css_class="w-full p-3 border-3 border-dashed"):
@@ -467,7 +467,7 @@ with Row(gap=1, justify="around", css_class="w-full p-3 border-3 border-dashed")
     Div(css_class="bg-emerald-500 rounded-md h-10 w-20")
     Div(css_class="bg-emerald-500 rounded-md h-10 w-20")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-1 justify-around w-full p-3 border-3 border-dashed",
   "type": "Row",
@@ -493,7 +493,7 @@ with Row(gap=1, justify="around", css_class="w-full p-3 border-3 border-dashed")
 <Tab title='justify="evenly"'>
 <ComponentPreview auto json={`{"cssClass":"gap-1 justify-evenly w-full p-3 border-3 border-dashed","type":"Row","children":[{"cssClass":"bg-emerald-500 rounded-md h-10 w-20","type":"Div"},{"cssClass":"bg-emerald-500 rounded-md h-10 w-20","type":"Div"},{"cssClass":"bg-emerald-500 rounded-md h-10 w-20","type":"Div"}]}`}>
 <CodeGroup>
-```python Python highlight={3}
+```python Python highlight={3} icon="python"
 from prefab_ui.components import Div, Row
 
 with Row(gap=1, justify="evenly", css_class="w-full p-3 border-3 border-dashed"):
@@ -501,7 +501,7 @@ with Row(gap=1, justify="evenly", css_class="w-full p-3 border-3 border-dashed")
     Div(css_class="bg-emerald-500 rounded-md h-10 w-20")
     Div(css_class="bg-emerald-500 rounded-md h-10 w-20")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-1 justify-evenly w-full p-3 border-3 border-dashed",
   "type": "Row",

--- a/docs/components/select.mdx
+++ b/docs/components/select.mdx
@@ -12,7 +12,7 @@ Select dropdowns let users pick one option from a list.
 
 <ComponentPreview auto json={`{"type":"Select","placeholder":"Choose size...","size":"default","disabled":false,"required":false,"children":[{"type":"SelectOption","value":"sm","label":"Small","selected":false,"disabled":false},{"type":"SelectOption","value":"md","label":"Medium","selected":false,"disabled":false},{"type":"SelectOption","value":"lg","label":"Large","selected":false,"disabled":false}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import (
     Select,
     SelectOption,
@@ -23,7 +23,7 @@ with Select(placeholder="Choose size..."):
     SelectOption(value="md", label="Medium")
     SelectOption(value="lg", label="Large")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "Select",
   "placeholder": "Choose size...",
@@ -62,7 +62,7 @@ with Select(placeholder="Choose size..."):
 
 <ComponentPreview auto json={`{"type":"Select","placeholder":"Select country","size":"default","disabled":false,"required":false,"children":[{"type":"SelectOption","value":"us","label":"United States","selected":false,"disabled":false},{"type":"SelectOption","value":"uk","label":"United Kingdom","selected":true,"disabled":false},{"type":"SelectOption","value":"ca","label":"Canada","selected":false,"disabled":false}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import (
     Select,
     SelectOption,
@@ -73,7 +73,7 @@ with Select(placeholder="Select country"):
     SelectOption(value="uk", label="United Kingdom", selected=True)
     SelectOption(value="ca", label="Canada")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "Select",
   "placeholder": "Select country",
@@ -112,7 +112,7 @@ with Select(placeholder="Select country"):
 
 <ComponentPreview auto json={`{"cssClass":"gap-4","type":"Column","children":[{"type":"Select","placeholder":"Default size","size":"default","disabled":false,"required":false,"children":[{"type":"SelectOption","value":"1","label":"Option 1","selected":false,"disabled":false},{"type":"SelectOption","value":"2","label":"Option 2","selected":false,"disabled":false}]},{"type":"Select","placeholder":"Small size","size":"sm","disabled":false,"required":false,"children":[{"type":"SelectOption","value":"1","label":"Option 1","selected":false,"disabled":false},{"type":"SelectOption","value":"2","label":"Option 2","selected":false,"disabled":false}]}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import (
     Column,
     Select,
@@ -128,7 +128,7 @@ with Column(gap=4):
         SelectOption(value="1", label="Option 1")
         SelectOption(value="2", label="Option 2")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-4",
   "type": "Column",
@@ -189,7 +189,7 @@ with Column(gap=4):
 
 <ComponentPreview auto json={`{"cssClass":"gap-2","type":"Column","children":[{"type":"Label","text":"Preferred language"},{"type":"Select","placeholder":"Choose language","size":"default","disabled":false,"required":false,"children":[{"type":"SelectOption","value":"en","label":"English","selected":false,"disabled":false},{"type":"SelectOption","value":"es","label":"Spanish","selected":false,"disabled":false},{"type":"SelectOption","value":"fr","label":"French","selected":false,"disabled":false}]}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import (
     Column,
     Label,
@@ -204,7 +204,7 @@ with Column(gap=2):
         SelectOption(value="es", label="Spanish")
         SelectOption(value="fr", label="French")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-2",
   "type": "Column",

--- a/docs/components/separator.mdx
+++ b/docs/components/separator.mdx
@@ -12,7 +12,7 @@ Separators create visual divisions between content areas.
 
 <ComponentPreview auto json={`{"type":"Column","children":[{"content":"Content above the separator","type":"P"},{"cssClass":"my-4","type":"Separator","orientation":"horizontal"},{"content":"Content below the separator","type":"P"}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import (
     Column,
     P,
@@ -24,7 +24,7 @@ with Column():
     Separator(css_class="my-4")
     P("Content below the separator")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "Column",
   "children": [
@@ -51,7 +51,7 @@ with Column():
 
 <ComponentPreview auto json={`{"cssClass":"gap-4 items-center","type":"Row","children":[{"type":"Span","content":"Left"},{"cssClass":"h-4","type":"Separator","orientation":"vertical"},{"type":"Span","content":"Middle"},{"cssClass":"h-4","type":"Separator","orientation":"vertical"},{"type":"Span","content":"Right"}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import (
     Row,
     Separator,
@@ -65,7 +65,7 @@ with Row(gap=4, css_class="items-center"):
     Separator(orientation="vertical", css_class="h-4")
     Span("Right")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-4 items-center",
   "type": "Row",
@@ -102,7 +102,7 @@ with Row(gap=4, css_class="items-center"):
 
 <ComponentPreview auto json={`{"type":"Card","children":[{"type":"CardContent","children":[{"content":"First section","type":"P"},{"cssClass":"my-4","type":"Separator","orientation":"horizontal"},{"content":"Second section","type":"P"},{"cssClass":"my-4","type":"Separator","orientation":"horizontal"},{"content":"Third section","type":"P"}]}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import (
     Card,
     CardContent,
@@ -118,7 +118,7 @@ with Card():
         Separator(css_class="my-4")
         P("Third section")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "Card",
   "children": [

--- a/docs/components/slider.mdx
+++ b/docs/components/slider.mdx
@@ -12,12 +12,12 @@ Sliders let users select a numeric value from a range by dragging a handle.
 
 <ComponentPreview auto json={`{"type":"Slider","min":0.0,"max":100.0,"value":50.0,"disabled":false}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import Slider
 
 Slider(min=0, max=100, value=50)
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "Slider",
   "min": 0.0,
@@ -33,12 +33,12 @@ Slider(min=0, max=100, value=50)
 
 <ComponentPreview auto json={`{"type":"Slider","min":0.0,"max":10.0,"value":5.0,"step":0.5,"disabled":false}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import Slider
 
 Slider(min=0, max=10, step=0.5, value=5)
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "Slider",
   "min": 0.0,
@@ -55,7 +55,7 @@ Slider(min=0, max=10, step=0.5, value=5)
 
 <ComponentPreview auto json={`{"cssClass":"gap-4","type":"Column","children":[{"cssClass":"gap-2","type":"Column","children":[{"type":"Label","text":"Volume (0-100)"},{"type":"Slider","min":0.0,"max":100.0,"value":75.0,"disabled":false}]},{"cssClass":"gap-2","type":"Column","children":[{"type":"Label","text":"Temperature (0-10)"},{"type":"Slider","min":0.0,"max":10.0,"value":7.0,"disabled":false}]}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import (
     Column,
     Label,
@@ -71,7 +71,7 @@ with Column(gap=4):
         Label("Temperature (0-10)")
         Slider(min=0, max=10, value=7)
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-4",
   "type": "Column",
@@ -122,7 +122,7 @@ Give the slider a `name` to store its value in state, then reference it with `{{
 
 <ComponentPreview auto json={`{"_tree":{"cssClass":"gap-4","type":"Column","children":[{"cssClass":"gap-2","type":"Column","children":[{"cssClass":"justify-between","type":"Row","children":[{"type":"Label","text":"Volume"},{"type":"Text","content":"{{ volume | number }}%","bold":true}]},{"type":"Slider","min":0.0,"max":100.0,"value":75.0,"name":"volume","disabled":false}]},{"type":"Progress","value":"{{ volume }}","max":100.0}]},"_state":{"volume":75}}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import (
     Column,
     Label,
@@ -142,7 +142,7 @@ with Column(gap=4):
         Slider(name="volume", min=0, max=100, value=75)
     Progress(value="{{ volume }}", max=100)
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "_tree": {
     "cssClass": "gap-4",
@@ -198,12 +198,12 @@ The slider, label, and progress bar all stay in sync — drag the slider and the
 
 <ComponentPreview auto json={`{"type":"Slider","min":0.0,"max":100.0,"value":30.0,"disabled":true}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import Slider
 
 Slider(min=0, max=100, value=30, disabled=True)
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "Slider",
   "min": 0.0,

--- a/docs/components/spinner.mdx
+++ b/docs/components/spinner.mdx
@@ -12,12 +12,12 @@ Spinners indicate that content is loading or an action is in progress.
 
 <ComponentPreview auto json={`{"type":"Spinner","size":"default"}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import Spinner
 
 Spinner()
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "Spinner",
   "size": "default"
@@ -30,7 +30,7 @@ Spinner()
 
 <ComponentPreview auto json={`{"cssClass":"gap-4 items-center","type":"Row","children":[{"type":"Spinner","size":"sm"},{"type":"Spinner","size":"default"},{"type":"Spinner","size":"lg"}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import Row, Spinner
 
 with Row(gap=4, css_class="items-center"):
@@ -38,7 +38,7 @@ with Row(gap=4, css_class="items-center"):
     Spinner(size="default")
     Spinner(size="lg")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-4 items-center",
   "type": "Row",
@@ -67,7 +67,7 @@ Pair a spinner with text to communicate what's loading.
 
 <ComponentPreview auto json={`{"cssClass":"gap-2 items-center","type":"Row","children":[{"type":"Spinner","size":"sm"},{"type":"Text","content":"Computing the answer to life, the universe, and everything..."}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import Row, Spinner, Text
 
 with Row(gap=2, css_class="items-center"):
@@ -75,7 +75,7 @@ with Row(gap=2, css_class="items-center"):
     Text("Computing the answer to life, the "
          "universe, and everything...")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-2 items-center",
   "type": "Row",

--- a/docs/components/state.mdx
+++ b/docs/components/state.mdx
@@ -14,7 +14,7 @@ This is useful when you want to inject data into a subtree without polluting glo
 
 <ComponentPreview auto json={`{"type":"State","state":{"name":"Arthur Dent","role":"Reluctant Adventurer"},"children":[{"type":"Card","children":[{"type":"CardHeader","children":[{"type":"CardTitle","content":"{{ name }}"},{"type":"CardDescription","content":"{{ role }}"}]}]}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import (
     Card,
     CardDescription,
@@ -29,7 +29,7 @@ with State(name="Arthur Dent", role="Reluctant Adventurer"):
             CardTitle("{{ name }}")
             CardDescription("{{ role }}")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "State",
   "state": {
@@ -85,7 +85,7 @@ State components can nest. Inner values shadow outer ones for the same key, and 
 
 <ComponentPreview auto json={`{"cssClass":"gap-2","type":"Column","children":[{"type":"State","state":{"greeting":"Don't Panic","name":"Arthur"},"children":[{"type":"Text","content":"{{ greeting }}, {{ name }}"},{"type":"State","state":{"name":"Ford"},"children":[{"type":"Text","content":"{{ greeting }}, {{ name }}"}]}]}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import Column, State, Text
 
 with Column(gap=2):
@@ -94,7 +94,7 @@ with Column(gap=2):
         with State(name="Ford"):
             Text("{{ greeting }}, {{ name }}")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-2",
   "type": "Column",
@@ -138,7 +138,7 @@ State works well alongside [ForEach](/components/foreach) for providing extra co
 
 <ComponentPreview auto json={`{"_tree":{"type":"State","state":{"prefix":"Speaks"},"children":[{"cssClass":"gap-2 items-center","type":"Row","children":[{"type":"ForEach","key":"languages","children":[{"type":"Badge","label":"{{ prefix }}: {{ _item }}","variant":"secondary"}]}]}]},"languages":["Python","TypeScript","Rust"]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import Badge, ForEach, Row, State
 
 set_data(languages=["Python", "TypeScript", "Rust"])
@@ -151,7 +151,7 @@ with State(prefix="Speaks"):
                 variant="secondary",
             )
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "_tree": {
     "type": "State",

--- a/docs/components/switch.mdx
+++ b/docs/components/switch.mdx
@@ -12,12 +12,12 @@ Switches provide a visual toggle for binary states, offering an alternative to c
 
 <ComponentPreview auto json={`{"type":"Switch","label":"Enable notifications","checked":false,"size":"default","disabled":false,"required":false}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import Switch
 
 Switch(label="Enable notifications")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "Switch",
   "label": "Enable notifications",
@@ -34,12 +34,12 @@ Switch(label="Enable notifications")
 
 <ComponentPreview auto json={`{"type":"Switch","label":"Dark mode","checked":true,"size":"default","disabled":false,"required":false}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import Switch
 
 Switch(label="Dark mode", checked=True)
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "Switch",
   "label": "Dark mode",
@@ -58,7 +58,7 @@ Switches come in two sizes:
 
 <ComponentPreview auto json={`{"cssClass":"gap-4","type":"Column","children":[{"type":"Switch","label":"Default size","checked":true,"size":"default","disabled":false,"required":false},{"type":"Switch","label":"Small size","checked":true,"size":"sm","disabled":false,"required":false}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import (
     Column,
     Switch,
@@ -68,7 +68,7 @@ with Column(gap=4):
     Switch(label="Default size", checked=True)
     Switch(label="Small size", size="sm", checked=True)
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-4",
   "type": "Column",
@@ -99,7 +99,7 @@ with Column(gap=4):
 
 <ComponentPreview auto json={`{"cssClass":"gap-3","type":"Column","children":[{"type":"Switch","label":"Enabled switch","checked":false,"size":"default","disabled":false,"required":false},{"type":"Switch","label":"Disabled off","checked":false,"size":"default","disabled":true,"required":false},{"type":"Switch","label":"Disabled on","checked":true,"size":"default","disabled":true,"required":false}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import (
     Column,
     Switch,
@@ -110,7 +110,7 @@ with Column(gap=3):
     Switch(label="Disabled off", disabled=True)
     Switch(label="Disabled on", checked=True, disabled=True)
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-3",
   "type": "Column",

--- a/docs/components/table.mdx
+++ b/docs/components/table.mdx
@@ -12,7 +12,7 @@ Tables display structured data using HTML table semantics. They're composed from
 
 <ComponentPreview auto json={`{"type":"Table","children":[{"type":"TableCaption","content":"Recent invoices"},{"type":"TableHeader","children":[{"type":"TableRow","children":[{"type":"TableHead","content":"Invoice"},{"type":"TableHead","content":"Status"},{"type":"TableHead","content":"Method"},{"cssClass":"text-right","type":"TableHead","content":"Amount"}]}]},{"type":"TableBody","children":[{"type":"TableRow","children":[{"cssClass":"font-medium","type":"TableCell","content":"INV-001"},{"type":"TableCell","content":"Paid"},{"type":"TableCell","content":"Credit Card"},{"cssClass":"text-right","type":"TableCell","content":"$250.00"}]},{"type":"TableRow","children":[{"cssClass":"font-medium","type":"TableCell","content":"INV-002"},{"type":"TableCell","content":"Pending"},{"type":"TableCell","content":"PayPal"},{"cssClass":"text-right","type":"TableCell","content":"$150.00"}]},{"type":"TableRow","children":[{"cssClass":"font-medium","type":"TableCell","content":"INV-003"},{"type":"TableCell","content":"Paid"},{"type":"TableCell","content":"Bank Transfer"},{"cssClass":"text-right","type":"TableCell","content":"$350.00"}]}]}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import (
     Table,
     TableHeader,
@@ -48,7 +48,7 @@ with Table():
             TableCell("Bank Transfer")
             TableCell("$350.00", css_class="text-right")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "Table",
   "children": [
@@ -169,7 +169,7 @@ Table cells are containers — they can hold any component, not just text. This 
 
 <ComponentPreview auto json={`{"type":"Table","children":[{"type":"TableHeader","children":[{"type":"TableRow","children":[{"type":"TableHead","content":"Name"},{"type":"TableHead","content":"Status"},{"type":"TableHead","content":"Role"}]}]},{"type":"TableBody","children":[{"type":"TableRow","children":[{"type":"TableCell","content":"Alice Johnson"},{"type":"TableCell","children":[{"type":"Badge","label":"Active","variant":"success"}]},{"type":"TableCell","content":"Admin"}]},{"type":"TableRow","children":[{"type":"TableCell","content":"Bob Smith"},{"type":"TableCell","children":[{"type":"Badge","label":"Inactive","variant":"secondary"}]},{"type":"TableCell","content":"Viewer"}]}]}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import (
     Badge,
     Table,
@@ -198,7 +198,7 @@ with Table():
                 Badge("Inactive", variant="secondary")
             TableCell("Viewer")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "Table",
   "children": [

--- a/docs/components/tabs.mdx
+++ b/docs/components/tabs.mdx
@@ -12,7 +12,7 @@ Tabs organize content into panels that users switch between by clicking triggers
 
 <ComponentPreview auto json={`{"type":"Tabs","variant":"default","defaultValue":"account","children":[{"type":"Tab","title":"Account","value":"account","disabled":false,"children":[{"type":"Card","children":[{"type":"CardHeader","children":[{"type":"CardTitle","content":"Account"},{"type":"CardDescription","content":"Make changes to your account here."}]},{"type":"CardContent","children":[{"cssClass":"gap-3","type":"Column","children":[{"type":"Label","text":"Name"},{"type":"Input","inputType":"text","placeholder":"Your name","name":"accountName","disabled":false,"required":false}]}]}]}]},{"type":"Tab","title":"Password","value":"password","disabled":false,"children":[{"type":"Card","children":[{"type":"CardHeader","children":[{"type":"CardTitle","content":"Password"},{"type":"CardDescription","content":"Change your password here."}]},{"type":"CardContent","children":[{"cssClass":"gap-3","type":"Column","children":[{"type":"Label","text":"Current Password"},{"type":"Input","inputType":"password","name":"currentPw","disabled":false,"required":false},{"type":"Label","text":"New Password"},{"type":"Input","inputType":"password","name":"newPw","disabled":false,"required":false}]}]}]}]}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import (
     Card,
     CardContent,
@@ -48,7 +48,7 @@ with Tabs(default_value="account"):
                     Label("New Password")
                     Input(input_type="password", name="newPw")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "Tabs",
   "variant": "default",
@@ -174,7 +174,7 @@ The `variant` prop controls the visual style of the tab triggers. The default us
 
 <ComponentPreview auto json={`{"cssClass":"gap-6","type":"Column","children":[{"type":"Tabs","variant":"default","defaultValue":"one","children":[{"type":"Tab","title":"Mostly","value":"one","disabled":false,"children":[{"type":"Text","content":"Don't panic."}]},{"type":"Tab","title":"Harmless","value":"two","disabled":false,"children":[{"type":"Text","content":"It's a wholly remarkable book."}]}]},{"type":"Tabs","variant":"line","defaultValue":"one","children":[{"type":"Tab","title":"Mostly","value":"one","disabled":false,"children":[{"type":"Text","content":"Don't panic."}]},{"type":"Tab","title":"Harmless","value":"two","disabled":false,"children":[{"type":"Text","content":"It's a wholly remarkable book."}]}]}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import Column, Tab, Tabs, Text
 
 with Column(gap=6):
@@ -190,7 +190,7 @@ with Column(gap=6):
         with Tab("Harmless", value="two"):
             Text("It's a wholly remarkable book.")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-6",
   "type": "Column",

--- a/docs/components/textarea.mdx
+++ b/docs/components/textarea.mdx
@@ -12,12 +12,12 @@ Textareas provide multi-line text input for comments, descriptions, and other lo
 
 <ComponentPreview auto json={`{"type":"Textarea","placeholder":"Enter your message...","disabled":false,"required":false}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import Textarea
 
 Textarea(placeholder="Enter your message...")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "Textarea",
   "placeholder": "Enter your message...",
@@ -32,7 +32,7 @@ Textarea(placeholder="Enter your message...")
 
 <ComponentPreview auto json={`{"cssClass":"gap-2","type":"Column","children":[{"type":"Label","text":"Feedback"},{"type":"Textarea","placeholder":"Tell us what you think...","rows":5,"disabled":false,"required":false}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import (
     Column,
     Label,
@@ -46,7 +46,7 @@ with Column(gap=2):
         rows=5,
     )
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-2",
   "type": "Column",
@@ -72,7 +72,7 @@ with Column(gap=2):
 
 <ComponentPreview auto json={`{"type":"Textarea","value":"This is some initial content that can be edited.","rows":4,"disabled":false,"required":false}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import Textarea
 
 Textarea(
@@ -80,7 +80,7 @@ Textarea(
     rows=4,
 )
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "Textarea",
   "value": "This is some initial content that can be edited.",
@@ -96,12 +96,12 @@ Textarea(
 
 <ComponentPreview auto json={`{"type":"Textarea","placeholder":"This textarea is disabled","disabled":true,"required":false}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import Textarea
 
 Textarea(placeholder="This textarea is disabled", disabled=True)
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "Textarea",
   "placeholder": "This textarea is disabled",

--- a/docs/components/tooltip.mdx
+++ b/docs/components/tooltip.mdx
@@ -12,7 +12,7 @@ Tooltips show brief helper text when users hover over a component. Wrap any sing
 
 <ComponentPreview auto height="140px" json={`{"cssClass":"gap-4","type":"Row","children":[{"type":"Tooltip","content":"Save your current work","children":[{"type":"Button","label":"Save","variant":"default","size":"default","disabled":false}]},{"type":"Tooltip","content":"Discard unsaved changes","side":"bottom","children":[{"type":"Button","label":"Reset","variant":"outline","size":"default","disabled":false}]}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import Button, Row, Tooltip
 
 with Row(gap=4):
@@ -21,7 +21,7 @@ with Row(gap=4):
     with Tooltip("Discard unsaved changes", side="bottom"):
         Button("Reset", variant="outline")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-4",
   "type": "Row",
@@ -65,7 +65,7 @@ Control which side the tooltip appears on with the `side` parameter.
 
 <ComponentPreview auto height="140px" json={`{"cssClass":"gap-4","type":"Row","children":[{"type":"Tooltip","content":"Top","side":"top","children":[{"type":"Button","label":"Top","variant":"outline","size":"default","disabled":false}]},{"type":"Tooltip","content":"Right","side":"right","children":[{"type":"Button","label":"Right","variant":"outline","size":"default","disabled":false}]},{"type":"Tooltip","content":"Bottom","side":"bottom","children":[{"type":"Button","label":"Bottom","variant":"outline","size":"default","disabled":false}]},{"type":"Tooltip","content":"Left","side":"left","children":[{"type":"Button","label":"Left","variant":"outline","size":"default","disabled":false}]}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import Button, Row, Tooltip
 
 with Row(gap=4):
@@ -78,7 +78,7 @@ with Row(gap=4):
     with Tooltip("Left", side="left"):
         Button("Left", variant="outline")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-4",
   "type": "Row",

--- a/docs/components/typography.mdx
+++ b/docs/components/typography.mdx
@@ -12,7 +12,7 @@ Typography components give you semantic heading and body text styles that follow
 
 <ComponentPreview auto json={`{"cssClass":"gap-4","type":"Column","children":[{"content":"Dashboard","type":"H1"},{"content":"Monitor your application metrics and performance.","type":"Lead"},{"content":"Everything you need to manage your MCP server, organized in one place.","type":"P"},{"content":"Last updated 5 minutes ago","type":"Muted"}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import (
     H1,
     H2,
@@ -28,7 +28,7 @@ with Column(gap=4):
     P("Everything you need to manage your MCP server, organized in one place.")
     Muted("Last updated 5 minutes ago")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-4",
   "type": "Column",
@@ -61,7 +61,7 @@ Four heading levels with decreasing size and weight. H2 includes a subtle bottom
 
 <ComponentPreview auto json={`{"cssClass":"gap-4","type":"Column","children":[{"content":"H1 \\u2014 Page Title","type":"H1"},{"content":"H2 \\u2014 Section Heading","type":"H2"},{"content":"H3 \\u2014 Subsection","type":"H3"},{"content":"H4 \\u2014 Detail Heading","type":"H4"}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import (
     H1,
     H2,
@@ -76,7 +76,7 @@ with Column(gap=4):
     H3("H3 — Subsection")
     H4("H4 — Detail Heading")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-4",
   "type": "Column",
@@ -109,7 +109,7 @@ with Column(gap=4):
 
 <ComponentPreview auto json={`{"cssClass":"gap-4","type":"Column","children":[{"content":"A comprehensive guide to building MCP applications with FastMCP.","type":"Lead"},{"content":"FastMCP provides a complete toolkit for building and deploying MCP servers. Each component follows shadcn/ui conventions for consistent styling.","type":"P"},{"content":"Key Takeaway: Components compose naturally.","type":"Large"}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import (
     P,
     Lead,
@@ -122,7 +122,7 @@ with Column(gap=4):
     P("FastMCP provides a complete toolkit for building and deploying MCP servers. Each component follows shadcn/ui conventions for consistent styling.")
     Large("Key Takeaway: Components compose naturally.")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-4",
   "type": "Column",
@@ -151,7 +151,7 @@ with Column(gap=4):
 
 <ComponentPreview auto json={`{"cssClass":"gap-3","type":"Column","children":[{"content":"Terms and conditions apply","type":"Small"},{"content":"Last updated 5 minutes ago","type":"Muted"}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import (
     Small,
     Muted,
@@ -162,7 +162,7 @@ with Column(gap=3):
     Small("Terms and conditions apply")
     Muted("Last updated 5 minutes ago")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-3",
   "type": "Column",
@@ -185,12 +185,12 @@ with Column(gap=3):
 
 <ComponentPreview auto json={`{"content":"The best way to predict the future is to invent it.","type":"BlockQuote"}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import BlockQuote
 
 BlockQuote("The best way to predict the future is to invent it.")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "content": "The best way to predict the future is to invent it.",
   "type": "BlockQuote"
@@ -205,7 +205,7 @@ Renders text with a monospace font and subtle background, ideal for referencing 
 
 <ComponentPreview auto json={`{"cssClass":"gap-2 items-center","type":"Row","children":[{"content":"Run","type":"P"},{"content":"pip install prefab-ui","type":"InlineCode"},{"content":"to get started.","type":"P"}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import (
     InlineCode,
     P,
@@ -217,7 +217,7 @@ with Row(gap=2, css_class="items-center"):
     InlineCode("pip install prefab-ui")
     P("to get started.")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-2 items-center",
   "type": "Row",
@@ -264,7 +264,7 @@ All text components accept `bold` and `italic` props for quick emphasis without 
 
 <ComponentPreview auto json={`{"cssClass":"gap-2","type":"Column","children":[{"content":"Regular paragraph text.","type":"P"},{"content":"This is bold.","bold":true,"type":"P"},{"content":"This is italic.","italic":true,"type":"P"},{"type":"Text","content":"Bold and italic combined.","bold":true,"italic":true}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import (
     P,
     Text,
@@ -277,7 +277,7 @@ with Column(gap=2):
     P("This is italic.", italic=True)
     Text("Bold and italic combined.", bold=True, italic=True)
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-2",
   "type": "Column",

--- a/docs/overview.mdx
+++ b/docs/overview.mdx
@@ -68,7 +68,7 @@ You can reference state values in actions and component props using `{{ key }}` 
 
 <ComponentPreview auto json={`{"cssClass":"gap-3","type":"Column","children":[{"type":"Input","inputType":"text","placeholder":"Enter a city...","name":"city","disabled":false,"required":false},{"type":"Button","label":"Get Weather","variant":"default","size":"default","disabled":false,"onClick":{"action":"toolCall","tool":"get_weather","arguments":{"location":"{{ city }}"}}}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import Button, Column, Input
 from prefab_ui import ToolCall
 
@@ -79,7 +79,7 @@ with Column(gap=3):
         arguments={"location": "{{ city }}"},
     ))
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-3",
   "type": "Column",
@@ -139,7 +139,7 @@ Pass a list to compose multiple actions from a single interaction:
 
 <ComponentPreview auto json={`{"type":"Button","label":"Save","variant":"default","size":"default","disabled":false,"onClick":[{"action":"setState","key":"saving","value":true},{"action":"toolCall","tool":"save_data","arguments":{"item":"{{ item }}"}},{"action":"setState","key":"saving","value":false}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import Button
 from prefab_ui import SetState, ToolCall
 
@@ -149,7 +149,7 @@ Button("Save", on_click=[
     SetState("saving", False),
 ])
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "Button",
   "label": "Save",
@@ -188,7 +188,7 @@ FastMCP includes 30+ components spanning layout, form controls, data display, an
 
 <ComponentPreview auto json={`{"type":"Card","children":[{"type":"CardContent","children":[{"cssClass":"gap-3","type":"Column","children":[{"type":"Input","inputType":"text","placeholder":"you@example.com","name":"email","disabled":false,"required":false},{"type":"Button","label":"Subscribe","variant":"default","size":"default","disabled":false}]}]}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import Button, Card, CardContent, Column, Input
 
 with Card() as view:
@@ -197,7 +197,7 @@ with Card() as view:
             Input(name="email", placeholder="you@example.com")
             Button("Subscribe")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "Card",
   "children": [

--- a/docs/patterns/confirmation.mdx
+++ b/docs/patterns/confirmation.mdx
@@ -14,7 +14,7 @@ Wrap a destructive trigger in a Dialog so users must confirm before the action f
 
 <ComponentPreview auto height="420px" json={`{"type":"Dialog","title":"Delete Item","description":"This action cannot be undone.","children":[{"type":"Button","label":"Delete","variant":"destructive","size":"default","disabled":false},{"type":"Text","content":"Are you sure you want to permanently delete this item?"},{"cssClass":"gap-2 justify-end","type":"Row","children":[{"type":"Button","label":"Cancel","variant":"outline","size":"default","disabled":false},{"type":"Button","label":"Confirm Delete","variant":"destructive","size":"default","disabled":false,"onClick":{"action":"toolCall","tool":"delete_item","arguments":{"id":"{{ item_id }}"}}}]}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import Button, Dialog, Row, Text
 from prefab_ui import ToolCall
 
@@ -29,7 +29,7 @@ with Dialog(title="Delete Item", description="This action cannot be undone."):
             on_click=ToolCall("delete_item", arguments={"id": "{{ item_id }}"}),
         )
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "Dialog",
   "title": "Delete Item",
@@ -124,7 +124,7 @@ The `on_success` and `on_error` callbacks on `ToolCall` fire after the server to
 
 <ComponentPreview auto json={`{"type":"Button","label":"Save","variant":"default","size":"default","disabled":false,"onClick":{"onSuccess":{"action":"showToast","message":"Saved successfully!","variant":"success"},"onError":{"action":"showToast","message":"{{ $error }}","variant":"error"},"action":"toolCall","tool":"save_item","arguments":{"data":"{{ item }}"}}}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import Button
 from prefab_ui import ToolCall, ShowToast
 
@@ -138,7 +138,7 @@ Button(
     ),
 )
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "Button",
   "label": "Save",
@@ -175,7 +175,7 @@ For lighter-weight confirmations that do not need a full modal overlay, use a Po
 
 <ComponentPreview auto json={`{"type":"Popover","children":[{"type":"Button","label":"Archive","variant":"outline","size":"default","disabled":false},{"cssClass":"gap-2","type":"Column","children":[{"type":"Text","content":"Archive this item?"},{"type":"Button","label":"Confirm","variant":"default","size":"default","disabled":false,"onClick":{"action":"toolCall","tool":"archive_item","arguments":{"id":"{{ item_id }}"}}}]}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import Button, Column, Popover, Text
 from prefab_ui import ToolCall
 
@@ -188,7 +188,7 @@ with Popover():
             on_click=ToolCall("archive_item", arguments={"id": "{{ item_id }}"}),
         )
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "Popover",
   "children": [

--- a/docs/patterns/data-display.mdx
+++ b/docs/patterns/data-display.mdx
@@ -14,7 +14,7 @@ When you have rows-and-columns data, DataTable handles sorting, search, and pagi
 
 <ComponentPreview auto json={`{"type":"DataTable","columns":[{"key":"name","header":"Name","sortable":true},{"key":"status","header":"Status","sortable":false},{"key":"updated","header":"Updated","sortable":true}],"rows":[{"name":"Auth service","status":"Healthy","updated":"2 min ago"},{"name":"API gateway","status":"Degraded","updated":"30 sec ago"},{"name":"Database","status":"Healthy","updated":"5 min ago"}],"searchable":true,"paginated":true,"pageSize":10}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import DataTable, DataTableColumn
 
 DataTable(
@@ -33,7 +33,7 @@ DataTable(
     page_size=10,
 )
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "DataTable",
   "columns": [
@@ -99,7 +99,7 @@ ForEach renders its children once per item in a data list. Each item's fields be
 
 <ComponentPreview auto json={`{"type":"ForEach","key":"users","children":[{"type":"Card","children":[{"type":"CardHeader","children":[{"cssClass":"gap-2 items-center","type":"Row","children":[{"type":"CardTitle","content":"{{ name }}"},{"type":"Badge","label":"{{ role }}","variant":"secondary"}]},{"type":"CardDescription","content":"{{ email }}"}]}]}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import (
     Badge,
     Card,
@@ -118,7 +118,7 @@ with ForEach("users"):
                 Badge("{{ role }}", variant="secondary")
             CardDescription("{{ email }}")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "ForEach",
   "key": "users",
@@ -174,7 +174,7 @@ Tabs organize related data into switchable panels. Users click a tab trigger to 
 
 <ComponentPreview auto json={`{"type":"Tabs","variant":"default","defaultValue":"active","children":[{"type":"Tab","title":"Active","value":"active","disabled":false,"children":[{"type":"Text","content":"Active items go here"}]},{"type":"Tab","title":"Archived","value":"archived","disabled":false,"children":[{"type":"Text","content":"Archived items go here"}]}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import Tab, Tabs, Text
 
 with Tabs(default_value="active"):
@@ -183,7 +183,7 @@ with Tabs(default_value="active"):
     with Tab("Archived", value="archived"):
         Text("Archived items go here")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "Tabs",
   "variant": "default",
@@ -225,7 +225,7 @@ Accordions work well when you have many items that benefit from progressive disc
 
 <ComponentPreview auto json={`{"type":"Accordion","multiple":false,"collapsible":true,"children":[{"type":"AccordionItem","title":"Section 1","value":"s1","children":[{"type":"Text","content":"Content for section 1"}]},{"type":"AccordionItem","title":"Section 2","value":"s2","children":[{"type":"Text","content":"Content for section 2"}]}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import Accordion, AccordionItem, Text
 
 with Accordion():
@@ -234,7 +234,7 @@ with Accordion():
     with AccordionItem("Section 2", value="s2"):
         Text("Content for section 2")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "Accordion",
   "multiple": false,
@@ -276,7 +276,7 @@ Pages provides a multi-page layout where only the active page renders. Combined 
 
 <ComponentPreview auto json={`{"cssClass":"gap-4","type":"Column","children":[{"type":"Pages","defaultValue":"setup","name":"step","children":[{"type":"Page","title":"Setup","value":"setup","children":[{"type":"Text","content":"Configure your settings"},{"type":"Button","label":"Next","variant":"default","size":"default","disabled":false,"onClick":{"action":"setState","key":"step","value":"review"}}]},{"type":"Page","title":"Review","value":"review","children":[{"type":"Text","content":"Review your choices"},{"type":"Button","label":"Next","variant":"default","size":"default","disabled":false,"onClick":{"action":"setState","key":"step","value":"complete"}}]},{"type":"Page","title":"Complete","value":"complete","children":[{"type":"Text","content":"All done!"}]}]}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import Button, Column, Page, Pages, Row, Text
 from prefab_ui.actions import SetState
 
@@ -291,7 +291,7 @@ with Column(gap=4):
         with Page("Complete", value="complete"):
             Text("All done!")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-4",
   "type": "Column",
@@ -372,14 +372,14 @@ Progress bars show completion or loading status. The `value` prop supports inter
 
 <ComponentPreview auto json={`{"cssClass":"gap-2","type":"Column","children":[{"type":"Text","content":"Processing: {{ progress }}%"},{"type":"Progress","value":"{{ progress }}","max":100}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import Column, Progress, Text
 
 with Column(gap=2):
     Text("Processing: {{ progress }}%")
     Progress(value="{{ progress }}")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-2",
   "type": "Column",

--- a/docs/patterns/forms.mdx
+++ b/docs/patterns/forms.mdx
@@ -14,7 +14,7 @@ Combine `Input`, `Label`, and `Button` components to create a form with full con
 
 <ComponentPreview auto json={`{"cssClass":"gap-3","type":"Column","children":[{"type":"Label","text":"Name"},{"type":"Input","inputType":"text","placeholder":"Your name","name":"name","disabled":false,"required":false},{"type":"Label","text":"Email"},{"type":"Input","inputType":"email","placeholder":"you@example.com","name":"email","disabled":false,"required":false},{"type":"Button","label":"Submit","variant":"default","size":"default","disabled":false,"onClick":{"action":"toolCall","tool":"create_user","arguments":{"name":"{{ name }}","email":"{{ email }}"}}}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import Button, Column, Input, Label
 from prefab_ui import ToolCall
 
@@ -28,7 +28,7 @@ with Column(gap=3):
         arguments={"name": "{{ name }}", "email": "{{ email }}"},
     ))
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-3",
   "type": "Column",
@@ -86,7 +86,7 @@ This approach gives you complete control, but it requires wiring up every label,
 
 <ComponentPreview auto json={`{"cssClass":"gap-4","type":"Form","onSubmit":{"onError":{"action":"showToast","message":"{{ $error }}","variant":"error"},"action":"toolCall","tool":"submit_contact","arguments":{"data":{"name":"{{ name }}","email":"{{ email }}","message":"{{ message }}"}}},"children":[{"cssClass":"gap-2","type":"Column","children":[{"type":"Label","text":"Full Name"},{"type":"Input","inputType":"text","placeholder":"Full Name","name":"name","disabled":false,"required":true,"minLength":1}]},{"cssClass":"gap-2","type":"Column","children":[{"type":"Label","text":"Email"},{"type":"Input","inputType":"email","placeholder":"Email","name":"email","disabled":false,"required":true}]},{"cssClass":"gap-2","type":"Column","children":[{"type":"Label","text":"Message"},{"type":"Textarea","placeholder":"Your message","name":"message","rows":4,"disabled":false,"required":true}]},{"type":"Button","label":"Submit","variant":"default","size":"default","disabled":false,"onClick":{"onError":{"action":"showToast","message":"{{ $error }}","variant":"error"},"action":"toolCall","tool":"submit_contact","arguments":{"data":{"name":"{{ name }}","email":"{{ email }}","message":"{{ message }}"}}}}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from pydantic import BaseModel, Field
 from prefab_ui.components import Form
 from prefab_ui import ToolCall
@@ -101,7 +101,7 @@ class ContactInfo(BaseModel):
 
 Form.from_model(ContactInfo, on_submit=ToolCall("submit_contact"))
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-4",
   "type": "Form",

--- a/docs/patterns/interactivity.mdx
+++ b/docs/patterns/interactivity.mdx
@@ -12,14 +12,14 @@ Every named form control automatically syncs its value to client state, and `{{ 
 
 <ComponentPreview auto json={`{"cssClass":"gap-3","type":"Column","children":[{"type":"Input","inputType":"text","placeholder":"Type your name...","name":"name","disabled":false,"required":false},{"type":"Text","content":"Hello, {{ name }}!"}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import Column, Input, Text
 
 with Column(gap=3):
     Input(name="name", placeholder="Type your name...")
     Text("Hello, {{ name }}!")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-3",
   "type": "Column",
@@ -50,7 +50,7 @@ Every component has a `visible_when` prop that controls whether it renders based
 
 <ComponentPreview auto json={`{"cssClass":"gap-2","type":"Column","children":[{"type":"Button","label":"Toggle Details","variant":"outline","size":"default","disabled":false,"onClick":{"action":"toggleState","key":"showDetails"}},{"visibleWhen":"showDetails","type":"Alert","variant":"default","children":[{"type":"AlertTitle","content":"Here are the hidden details!"}]}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import Alert, AlertTitle, Button, Column
 from prefab_ui import ToggleState
 
@@ -59,7 +59,7 @@ with Column(gap=2):
     with Alert(visible_when="showDetails"):
         AlertTitle("Here are the hidden details!")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-2",
   "type": "Column",
@@ -100,7 +100,7 @@ Clicking the button flips `showDetails` between `True` and `False`. When `False`
 
 <ComponentPreview auto json={`{"cssClass":"gap-3","type":"Column","children":[{"type":"Input","inputType":"text","placeholder":"Search users...","name":"search","disabled":false,"required":false},{"type":"Button","label":"Search","variant":"default","size":"default","disabled":false,"onClick":{"action":"toolCall","tool":"find_users","arguments":{"query":"{{ search }}"},"resultKey":"results"}},{"type":"DataTable","columns":[{"key":"name","header":"Name","sortable":true},{"key":"email","header":"Email","sortable":false}],"rows":"{{ results }}","searchable":true,"paginated":false,"pageSize":10}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import Button, Column, DataTable, DataTableColumn, Input
 from prefab_ui import ToolCall
 
@@ -120,7 +120,7 @@ with Column(gap=3):
         searchable=True,
     )
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-3",
   "type": "Column",
@@ -181,7 +181,7 @@ The same pattern works with `ForEach` for custom result layouts. Each item in th
 
 <ComponentPreview auto json={`{"cssClass":"gap-3","type":"Column","children":[{"type":"Input","inputType":"text","placeholder":"Search products...","name":"q","disabled":false,"required":false},{"type":"Button","label":"Search","variant":"default","size":"default","disabled":false,"onClick":{"action":"toolCall","tool":"search_products","arguments":{"query":"{{ q }}"},"resultKey":"products"}},{"type":"ForEach","key":"products","children":[{"type":"Card","children":[{"type":"CardHeader","children":[{"type":"CardTitle","content":"{{ name }}"},{"type":"CardDescription","content":"{{ description }}"}]}]}]}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import (
     Button,
     Card,
@@ -207,7 +207,7 @@ with Column(gap=3):
                 CardTitle("{{ name }}")
                 CardDescription("{{ description }}")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "cssClass": "gap-3",
   "type": "Column",
@@ -273,7 +273,7 @@ Pass a list of actions to compose richer interactions. Actions execute in sequen
 
 <ComponentPreview auto json={`{"type":"Button","label":"Process","variant":"default","size":"default","disabled":false,"onClick":[{"action":"setState","key":"processing","value":true},{"onSuccess":{"action":"showToast","message":"Analysis complete!","variant":"success"},"onError":{"action":"showToast","message":"{{ $error }}","variant":"error"},"action":"toolCall","tool":"run_analysis","arguments":{"data":"{{ dataset }}"}},{"action":"setState","key":"processing","value":false}]}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import Button
 from prefab_ui import ToolCall, SetState, ShowToast
 
@@ -288,7 +288,7 @@ Button("Process", on_click=[
     SetState("processing", False),
 ])
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "Button",
   "label": "Process",
@@ -337,7 +337,7 @@ When a `ToolCall` action fails, the error message is available as `$error` insid
 
 <ComponentPreview auto json={`{"type":"Button","label":"Delete","variant":"destructive","size":"default","disabled":false,"onClick":{"onError":{"action":"showToast","message":"{{ $error }}","variant":"error"},"action":"toolCall","tool":"delete_item","arguments":{"id":"{{ item_id }}"}}}`}>
 <CodeGroup>
-```python Python
+```python Python icon="python"
 from prefab_ui.components import Button
 from prefab_ui import ToolCall, ShowToast
 
@@ -347,7 +347,7 @@ Button("Delete", variant="destructive", on_click=ToolCall(
     on_error=ShowToast("{{ $error }}", variant="error"),
 ))
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "type": "Button",
   "label": "Delete",

--- a/docs/snippets/component-preview.mdx
+++ b/docs/snippets/component-preview.mdx
@@ -1,9 +1,15 @@
 export const ComponentPreview = ({ json, height, children }) => {
   const hostRef = React.useRef(null);
   const handleRef = React.useRef(null);
+  const cardRef = React.useRef(null);
 
   React.useEffect(() => {
-    const host = hostRef.current;
+    if (cardRef.current) {
+      var card = cardRef.current.closest(".group");
+      if (card) card.classList.remove("group");
+    }
+
+    var host = hostRef.current;
     if (!host || !window.__prefab) return;
 
     var dark = document.documentElement.classList.contains("dark");
@@ -29,6 +35,7 @@ export const ComponentPreview = ({ json, height, children }) => {
 
   return (
     <Card>
+      <div ref={cardRef} />
       <div ref={hostRef} />
       <div style={{ marginBottom: "-2rem" }}>{children}</div>
     </Card>

--- a/docs/welcome.mdx
+++ b/docs/welcome.mdx
@@ -33,7 +33,7 @@ with Card():
                 Badge("{{ name }}", variant="default")
                 Badge("Prefab", variant="secondary")
 ```
-```json Protocol
+```json Protocol icon="brackets-curly"
 {
   "_tree": {
     "type": "Card",

--- a/renderer/src/playground/examples.json
+++ b/renderer/src/playground/examples.json
@@ -1,11 +1,11 @@
 [
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Actions",
     "code": "from prefab_ui.components import Button\nfrom prefab_ui import ToolCall\n\nButton(\"Refresh Data\", on_click=ToolCall(\"get_latest_data\"))"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Actions",
     "code": "from prefab_ui.components import Input, Button, Column\nfrom prefab_ui import ToolCall\n\nwith Column(gap=3):\n    Input(name=\"city\", placeholder=\"Enter a city...\")\n    Button(\"Get Weather\", on_click=ToolCall(\n        \"get_weather\",\n        arguments={\"location\": \"{{ city }}\"},\n    ))"
   },
@@ -15,57 +15,57 @@
     "code": "from prefab_ui.components import Button\nfrom prefab_ui import ToolCall, SetState\n\nButton(\"Analyze\", on_click=[\n    SetState(\"status\", \"analyzing...\"),\n    ToolCall(\"run_analysis\", arguments={\"data\": \"{{ dataset }}\"}),\n])"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Actions",
     "code": "from prefab_ui.components import Button\nfrom prefab_ui import OpenLink\n\nButton(\"View Documentation\", variant=\"link\",\n       on_click=OpenLink(\"https://prefab-ui.dev\"))"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Actions",
     "code": "from prefab_ui.components import Button, Row\nfrom prefab_ui import OpenLink\n\nwith Row(gap=4):\n    Button(\"GitHub\", variant=\"link\",\n           on_click=OpenLink(\"https://github.com/prefecthq/prefab\"))\n    Button(\"PyPI\", variant=\"link\",\n           on_click=OpenLink(\"https://pypi.org/project/prefab-ui\"))"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Actions",
     "code": "from prefab_ui.components import Input, Button, Column\nfrom prefab_ui import OpenLink\n\nwith Column(gap=3):\n    Input(name=\"repo\", placeholder=\"owner/repo\")\n    Button(\"Open on GitHub\", on_click=OpenLink(\n        \"https://github.com/{{ repo }}\"\n    ))"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Actions",
     "code": "from prefab_ui.components import Button\nfrom prefab_ui import SendMessage\n\nButton(\"Summarize\", on_click=SendMessage(\"Please summarize the data above.\"))"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Actions",
     "code": "from prefab_ui.components import Button, Row, H3, Column\nfrom prefab_ui import SendMessage\n\nwith Column(gap=3):\n    H3(\"Quick Actions\")\n    with Row(gap=2):\n        Button(\"Summarize\", variant=\"outline\",\n               on_click=SendMessage(\"Summarize these results.\"))\n        Button(\"Explain Further\", variant=\"outline\",\n               on_click=SendMessage(\"Explain these results in more detail.\"))\n        Button(\"Compare Options\", variant=\"outline\",\n               on_click=SendMessage(\"Compare the top options and recommend one.\"))"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Actions",
     "code": "from prefab_ui.components import Input, Button, Column\nfrom prefab_ui import SendMessage\n\nwith Column(gap=3):\n    Input(name=\"question\", placeholder=\"Ask a follow-up question...\")\n    Button(\"Ask\", on_click=SendMessage(\"{{ question }}\"))"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Actions",
     "code": "from prefab_ui.components import Slider, Muted, Column\nfrom prefab_ui import SetState\n\nset_initial_state(brightness=50)\n\nwith Column(gap=3):\n    Slider(name=\"brightness\", min=0, max=100,\n           on_change=SetState(\"brightness\"))\n    Muted(\"Brightness: {{ brightness }}%\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Actions",
     "code": "from prefab_ui.components import Button, Div, Row, Column\nfrom prefab_ui import SetState\n\nset_initial_state(color=\"bg-blue-500\")\n\nwith Column(gap=3):\n    with Row(gap=2):\n        Button(\"Blue\", css_class=\"bg-blue-500 text-white\",\n               on_click=SetState(\"color\", \"bg-blue-500\"))\n        Button(\"Emerald\", css_class=\"bg-emerald-500 text-white\",\n               on_click=SetState(\"color\", \"bg-emerald-500\"))\n        Button(\"Rose\", css_class=\"bg-rose-500 text-white\",\n               on_click=SetState(\"color\", \"bg-rose-500\"))\n        Button(\"Amber\", css_class=\"bg-amber-500 text-white\",\n               on_click=SetState(\"color\", \"bg-amber-500\"))\n    Div(css_class=\"{{ color }} h-10 rounded-md\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Actions",
     "code": "from prefab_ui.components import Button, Slider, Muted, Column\nfrom prefab_ui import SetState\n\nset_initial_state(volume=75)\n\nwith Column(gap=3):\n    Slider(name=\"volume\", min=0, max=100,\n           on_change=SetState(\"volume\"))\n    Muted(\"Volume: {{ volume }}\")\n    Button(\"Reset to 50\", variant=\"outline\",\n           on_click=SetState(\"volume\", 50))"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Actions",
     "code": "from prefab_ui.components import Button, Alert, AlertTitle, Column\nfrom prefab_ui import ToggleState\n\nwith Column(gap=2):\n    Button(\"Toggle Details\", variant=\"outline\",\n           on_click=ToggleState(\"showDetails\"))\n    with Alert(visible_when=\"showDetails\"):\n        AlertTitle(\"Here are the details!\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Actions",
     "code": "from prefab_ui.components import Button, P, Row, Column\nfrom prefab_ui import ToggleState\n\nwith Column(gap=3):\n    with Row(gap=2):\n        Button(\"Section A\", variant=\"outline\",\n               on_click=ToggleState(\"showA\"))\n        Button(\"Section B\", variant=\"outline\",\n               on_click=ToggleState(\"showB\"))\n        Button(\"Section C\", variant=\"outline\",\n               on_click=ToggleState(\"showC\"))\n    P(\"Content for section A\", visible_when=\"showA\")\n    P(\"Content for section B\", visible_when=\"showB\")\n    P(\"Content for section C\", visible_when=\"showC\")"
   },
@@ -80,12 +80,12 @@
     "code": "from prefab_ui import AppResult\n\n@mcp.tool()\nasync def settings() -> AppResult:\n    return AppResult(\n        view=...,\n        state={\"volume\": 75, \"muted\": False},\n    )"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Actions",
     "code": "from prefab_ui.components import Button\nfrom prefab_ui import UpdateContext\n\nButton(\"Use Advanced Mode\", on_click=UpdateContext(\n    content=\"User has selected advanced mode. Provide detailed technical responses.\"\n))"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Actions",
     "code": "from prefab_ui.components import Button, Select, SelectOption, Column\nfrom prefab_ui import UpdateContext\n\nwith Column(gap=3):\n    with Select(name=\"thinking\", placeholder=\"Thinking level...\"):\n        SelectOption(value=\"low\", label=\"Low\")\n        SelectOption(value=\"medium\", label=\"Medium\")\n        SelectOption(value=\"high\", label=\"High\")\n    Button(\"Set Preference\", on_click=UpdateContext(\n        structured_content={\"preference\": {\"thinking\": \"{{ thinking }}\"}},\n    ))"
   },
@@ -105,12 +105,12 @@
     "code": "from prefab_ui import SetState, ToolCall\n\nButton(\"Submit\", on_click=[\n    SetState(\"status\", \"analyzing...\"),\n    ToolCall(\"process\", arguments={\"query\": \"{{ query }}\"}),\n])"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import Accordion, AccordionItem, Text\n\nwith Accordion():\n    with AccordionItem(\"What is the Answer?\"):\n        Text(\n            \"Forty-two. The Answer to the Ultimate \"\n            \"Question of Life, the Universe, and \"\n            \"Everything.\"\n        )\n    with AccordionItem(\"What is the Heart of Gold?\"):\n        Text(\n            \"A starship powered by the Infinite \"\n            \"Improbability Drive. It can pass through \"\n            \"every conceivable point in every \"\n            \"conceivable universe almost simultaneously.\"\n        )\n    with AccordionItem(\"What is Deep Thought?\"):\n        Text(\n            \"A supercomputer designed to find the \"\n            \"Answer to the Ultimate Question. It took \"\n            \"7.5 million years to compute: 42.\"\n        )"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import Accordion, AccordionItem, Text\n\nwith Accordion(default_open_items=0):\n    with AccordionItem(\"What is the Answer?\"):\n        Text(\n            \"Forty-two. The Answer to the Ultimate \"\n            \"Question of Life, the Universe, and \"\n            \"Everything.\"\n        )\n    with AccordionItem(\"What is the Heart of Gold?\"):\n        Text(\n            \"A starship powered by the Infinite \"\n            \"Improbability Drive. It can pass through \"\n            \"every conceivable point in every \"\n            \"conceivable universe almost simultaneously.\"\n        )\n    with AccordionItem(\"What is Deep Thought?\"):\n        Text(\n            \"A supercomputer designed to find the \"\n            \"Answer to the Ultimate Question. It took \"\n            \"7.5 million years to compute: 42.\"\n        )"
   },
@@ -120,212 +120,212 @@
     "code": "with Accordion(default_open_items=\"faq\"):\n    with AccordionItem(\"FAQ\", value=\"faq\"):\n        Text(\"Frequently asked questions...\")\n    with AccordionItem(\"Contact\"):\n        Text(\"Get in touch...\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import Accordion, AccordionItem, Text\n\nwith Accordion(\n    multiple=True,\n    default_open_items=[0, 1]\n):\n    with AccordionItem(\"Who is Arthur Dent?\"):\n        Text(\n            \"An ordinary human from Earth, unexpectedly \"\n            \"swept into the cosmos when his planet is \"\n            \"demolished to make way for a hyperspace \"\n            \"bypass.\"\n        )\n    with AccordionItem(\"Who is Ford Prefect?\"):\n        Text(\n            \"A researcher for the Hitchhiker's Guide \"\n            \"to the Galaxy, and Arthur's best friend. \"\n            \"He's from a small planet somewhere in the \"\n            \"vicinity of Betelgeuse.\"\n        )\n    with AccordionItem(\"What is the Guide?\"):\n        Text(\n            \"A digital reference with the words \"\n            \"'Don't Panic' written in large, friendly \"\n            \"letters on the cover.\"\n        )"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import (\n    Alert,\n    AlertTitle,\n    AlertDescription,\n)\n\nwith Alert():\n    AlertTitle(\"Heads up!\")\n    AlertDescription(\"You can add components to your app using the CLI.\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import (\n    Alert,\n    AlertDescription,\n    AlertTitle,\n    Column,\n)\n\nwith Column(gap=4):\n    with Alert(icon=\"circle-alert\"):\n        AlertTitle(\"Heads up!\")\n        AlertDescription(\n            \"You can add components to your app \"\n            \"using the CLI.\"\n        )\n\n    with Alert(variant=\"destructive\", icon=\"circle-x\"):\n        AlertTitle(\"Error\")\n        AlertDescription(\n            \"Your session has expired. Please log \"\n            \"in again.\"\n        )\n\n    with Alert(variant=\"success\", icon=\"circle-check\"):\n        AlertTitle(\"Success\")\n        AlertDescription(\n            \"Your changes have been saved \"\n            \"successfully.\"\n        )"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import (\n    Alert,\n    AlertDescription,\n    AlertTitle,\n    Column,\n)\n\nwith Column(gap=4):\n    with Alert():\n        AlertTitle(\"Default\")\n        AlertDescription(\"A neutral informational message.\")\n\n    with Alert(variant=\"destructive\"):\n        AlertTitle(\"Error\")\n        AlertDescription(\"Your session has expired. Please log in again.\")\n\n    with Alert(variant=\"success\"):\n        AlertTitle(\"Success\")\n        AlertDescription(\"Your changes have been saved successfully.\")\n\n    with Alert(variant=\"warning\"):\n        AlertTitle(\"Warning\")\n        AlertDescription(\"Your trial expires in 3 days.\")\n\n    with Alert(variant=\"info\"):\n        AlertTitle(\"Info\")\n        AlertDescription(\"A new version is available for download.\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import (\n    Alert,\n    AlertDescription,\n)\n\nwith Alert():\n    AlertDescription(\"Your changes have been saved.\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import (\n    Card,\n    CardHeader,\n    CardTitle,\n    CardContent,\n    Alert,\n    AlertTitle,\n    AlertDescription,\n    Column,\n)\n\nwith Card():\n    with CardHeader():\n        CardTitle(\"Deployment\")\n    with CardContent():\n        with Column(gap=4):\n            with Alert():\n                AlertTitle(\"Maintenance Window\")\n                AlertDescription(\"Deployments are paused from 2:00–4:00 AM UTC.\")\n            with Alert():\n                AlertTitle(\"Latest Deploy\")\n                AlertDescription(\"v2.1.0 deployed successfully 3 hours ago.\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import AreaChart, ChartSeries\n\ndata = [\n    {\"month\": \"Jan\", \"desktop\": 186, \"mobile\": 80},\n    {\"month\": \"Feb\", \"desktop\": 305, \"mobile\": 200},\n    {\"month\": \"Mar\", \"desktop\": 237, \"mobile\": 120},\n    {\"month\": \"Apr\", \"desktop\": 73, \"mobile\": 190},\n    {\"month\": \"May\", \"desktop\": 209, \"mobile\": 130},\n    {\"month\": \"Jun\", \"desktop\": 214, \"mobile\": 140},\n]\n\nAreaChart(\n    data=data,\n    series=[\n        ChartSeries(data_key=\"desktop\", label=\"Desktop\"),\n        ChartSeries(data_key=\"mobile\", label=\"Mobile\"),\n    ],\n    x_axis=\"month\",\n    show_legend=True,\n)"
   },
   {
-    "title": "Python {8}",
+    "title": "Python {8} icon=\"python\"",
     "category": "Components",
     "code": "AreaChart(\n    data=data,\n    series=[\n        ChartSeries(data_key=\"desktop\", label=\"Desktop\"),\n        ChartSeries(data_key=\"mobile\", label=\"Mobile\"),\n    ],\n    x_axis=\"month\",\n    stacked=True,\n    show_legend=True,\n)"
   },
   {
-    "title": "Python {5}",
+    "title": "Python {5} icon=\"python\"",
     "category": "Components",
     "code": "AreaChart(\n    data=data,\n    series=[ChartSeries(data_key=\"value\", label=\"Requests\")],\n    x_axis=\"month\",\n    show_grid=False,\n)"
   },
   {
-    "title": "Python {8}",
+    "title": "Python {8} icon=\"python\"",
     "category": "Components",
     "code": "AreaChart(\n    data=data,\n    series=[\n        ChartSeries(data_key=\"desktop\", label=\"Desktop\"),\n        ChartSeries(data_key=\"mobile\", label=\"Mobile\"),\n    ],\n    x_axis=\"month\",\n    curve=\"smooth\",\n    show_legend=True,\n)"
   },
   {
-    "title": "Python {8}",
+    "title": "Python {8} icon=\"python\"",
     "category": "Components",
     "code": "AreaChart(\n    data=data,\n    series=[\n        ChartSeries(data_key=\"desktop\", label=\"Desktop\"),\n        ChartSeries(data_key=\"mobile\", label=\"Mobile\"),\n    ],\n    x_axis=\"month\",\n    curve=\"step\",\n    show_legend=True,\n)"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import Badge\n\nBadge(\"Mostly Harmless\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import Badge, Grid\n\nwith Grid(gap=8, columns=4, css_class=\"place-items-center\"):\n    Badge(\"Default\")\n    Badge(\"Secondary\", variant=\"secondary\")\n    Badge(\"Destructive\", variant=\"destructive\")\n    Badge(\"Outline\", variant=\"outline\")\n    Badge(\"Ghost\", variant=\"ghost\")\n    Badge(\"Success\", variant=\"success\")\n    Badge(\"Warning\", variant=\"warning\")\n    Badge(\"Info\", variant=\"info\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import (\n    Badge,\n    Card,\n    CardDescription,\n    CardHeader,\n    CardTitle,\n    Column,\n    Row,\n)\n\nwith Column(gap=3):\n    with Card():\n        with CardHeader():\n            with Row(gap=2, css_class=\"items-center\"):\n                CardTitle(\"Heart of Gold\")\n                Badge(\"Online\", variant=\"success\")\n            CardDescription(\"Infinite Improbability Drive engaged\")\n    with Card():\n        with CardHeader():\n            with Row(gap=2, css_class=\"items-center\"):\n                CardTitle(\"Vogon Fleet\")\n                Badge(\"Approaching\", variant=\"warning\")\n            CardDescription(\"Demolition order filed with local planning authority\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import BarChart, ChartSeries\n\ndata = [\n    {\"month\": \"Jan\", \"desktop\": 186, \"mobile\": 80},\n    {\"month\": \"Feb\", \"desktop\": 305, \"mobile\": 200},\n    {\"month\": \"Mar\", \"desktop\": 237, \"mobile\": 120},\n    {\"month\": \"Apr\", \"desktop\": 73, \"mobile\": 190},\n    {\"month\": \"May\", \"desktop\": 209, \"mobile\": 130},\n    {\"month\": \"Jun\", \"desktop\": 214, \"mobile\": 140},\n]\n\nBarChart(\n    data=data,\n    series=[\n        ChartSeries(data_key=\"desktop\", label=\"Desktop\"),\n        ChartSeries(data_key=\"mobile\", label=\"Mobile\"),\n    ],\n    x_axis=\"month\",\n    show_legend=True,\n)"
   },
   {
-    "title": "Python {8}",
+    "title": "Python {8} icon=\"python\"",
     "category": "Components",
     "code": "BarChart(\n    data=data,\n    series=[\n        ChartSeries(data_key=\"desktop\", label=\"Desktop\"),\n        ChartSeries(data_key=\"mobile\", label=\"Mobile\"),\n    ],\n    x_axis=\"month\",\n    stacked=True,\n    show_legend=True,\n)"
   },
   {
-    "title": "Python {5}",
+    "title": "Python {5} icon=\"python\"",
     "category": "Components",
     "code": "BarChart(\n    data=data,\n    series=[ChartSeries(data_key=\"revenue\", label=\"Revenue\")],\n    x_axis=\"month\",\n    show_grid=False,\n)"
   },
   {
-    "title": "Python {8}",
+    "title": "Python {8} icon=\"python\"",
     "category": "Components",
     "code": "BarChart(\n    data=data,\n    series=[\n        ChartSeries(data_key=\"desktop\", label=\"Desktop\"),\n        ChartSeries(data_key=\"mobile\", label=\"Mobile\"),\n    ],\n    x_axis=\"month\",\n    horizontal=True,\n    show_legend=True,\n)"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import Button, ButtonGroup\n\nwith ButtonGroup():\n    Button(\"Save\")\n    Button(\"Cancel\", variant=\"outline\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import Button, ButtonGroup\n\nwith ButtonGroup(orientation=\"vertical\"):\n    Button(\"Top\")\n    Button(\"Middle\", variant=\"outline\")\n    Button(\"Bottom\", variant=\"outline\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import Button, ButtonGroup\n\nwith ButtonGroup():\n    Button(\"Previous\", variant=\"outline\")\n    Button(\"1\")\n    Button(\"2\", variant=\"outline\")\n    Button(\"3\", variant=\"outline\")\n    Button(\"Next\", variant=\"outline\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import Button\n\nButton(\"Save Changes\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import (\n    Button,\n    Grid,\n)\n\nwith Grid(columns=3, gap=8):\n    Button(\"Default\", variant=\"default\")\n    Button(\"Destructive\", variant=\"destructive\")\n    Button(\"Outline\", variant=\"outline\")\n    Button(\"Secondary\", variant=\"secondary\")\n    Button(\"Ghost\", variant=\"ghost\")\n    Button(\"Link\", variant=\"link\")\n    Button(\"Success\", variant=\"success\")\n    Button(\"Warning\", variant=\"warning\")\n    Button(\"Info\", variant=\"info\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import (\n    Button,\n    Row,\n)\n\nwith Row(gap=3, css_class=\"items-center\"):\n    Button(\"Tiny\", size=\"xs\")\n    Button(\"Small\", size=\"sm\")\n    Button(\"Default\", size=\"default\")\n    Button(\"Large\", size=\"lg\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import Button, Row\n\nwith Row(gap=3, css_class=\"items-center\"):\n    Button(\"Download\", icon=\"download\")\n    Button(\"Settings\", icon=\"settings\", variant=\"outline\")\n    Button(\"Delete\", icon=\"trash-2\", variant=\"destructive\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import Button, Row\n\nwith Row(gap=3, css_class=\"items-center\"):\n    Button(\"\", icon=\"plus\", size=\"icon-xs\")\n    Button(\"\", icon=\"plus\", size=\"icon-sm\")\n    Button(\"\", icon=\"plus\", size=\"icon\")\n    Button(\"\", icon=\"plus\", size=\"icon-lg\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import Button\n\nButton(\"Unavailable\", disabled=True)"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import (\n    Button,\n    Column,\n)\n\nwith Column(gap=3, css_class=\"items-start w-full\"):\n    Button(\"Full Width Emerald\", css_class=\"w-full bg-emerald-500\")\n    Button(\"Pill Shape Rose\", css_class=\"rounded-full bg-rose-500\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import Calendar\n\nCalendar(name=\"selectedDate\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "import json\nfrom prefab_ui.components import Calendar\n\nset_initial_state(\n    dateRange=json.dumps({\n        \"from\": \"2025-06-10T12:00:00.000Z\",\n        \"to\": \"2025-06-20T12:00:00.000Z\",\n    })\n)\n\nCalendar(mode=\"range\", name=\"dateRange\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "import json\nfrom prefab_ui.components import Calendar\n\nset_initial_state(\n    selectedDates=json.dumps([\n        \"2025-06-10T12:00:00.000Z\",\n        \"2025-06-15T12:00:00.000Z\",\n        \"2025-06-22T12:00:00.000Z\",\n    ])\n)\n\nCalendar(mode=\"multiple\", name=\"selectedDates\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import (\n    Calendar,\n    Column,\n    Muted,\n    Row,\n    Text,\n)\n\nset_initial_state(selectedDate=\"2025-06-15T12:00:00.000Z\")\n\nwith Row(gap=6):\n    Calendar(name=\"selectedDate\")\n    with Column(gap=2):\n        Text(\"Selected date:\")\n        Text(\"{{ selectedDate | date:long }}\", bold=True)\n        Muted(\"Raw: {{ selectedDate }}\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import (\n    Card,\n    CardHeader,\n    CardTitle,\n    CardDescription,\n    CardContent,\n    CardFooter,\n    Button,\n    P,\n)\n\nwith Card():\n    with CardHeader():\n        CardTitle(\"Create project\")\n        CardDescription(\"Deploy your new project in one-click.\")\n    with CardContent():\n        P(\"Your project will be created with default settings.\")\n    with CardFooter():\n        Button(\"Cancel\", variant=\"outline\")\n        Button(\"Deploy\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import (\n    Card,\n    CardHeader,\n    CardTitle,\n    CardDescription,\n    CardContent,\n    CardFooter,\n    Button,\n    P,\n    Muted,\n)\n\nwith Card():\n    with CardHeader():\n        CardTitle(\"Account Settings\")\n        CardDescription(\"Manage your account preferences and security.\")\n    with CardContent():\n        P(\"Update your display name, email, and notification preferences from this panel.\")\n        Muted(\"Changes take effect immediately.\")\n    with CardFooter():\n        Button(\"Save changes\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import (\n    Card,\n    H3,\n    P,\n)\n\nwith Card(css_class=\"p-6\"):\n    H3(\"Quick Stats\")\n    P(\"42 active connections, 3 pending requests.\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import (\n    Card,\n    CardHeader,\n    CardTitle,\n    CardDescription,\n    Grid,\n)\n\nwith Grid(columns=3, gap=4):\n    for title, desc in [\n        (\"Revenue\", \"$12,450\"),\n        (\"Users\", \"1,234\"),\n        (\"Uptime\", \"99.9%\"),\n    ]:\n        with Card():\n            with CardHeader():\n                CardDescription(title)\n                CardTitle(desc)"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import Checkbox\n\nCheckbox(label=\"Accept terms and conditions\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import Checkbox\n\nCheckbox(label=\"Subscribe to newsletter\", checked=True)"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import (\n    Checkbox,\n    Column,\n)\n\nwith Column(gap=3, css_class=\"w-fit mx-auto\"):\n    Checkbox(label=\"Email notifications\", checked=True)\n    Checkbox(label=\"SMS notifications\")\n    Checkbox(label=\"Push notifications\", checked=True)"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import (\n    Checkbox,\n    Column,\n)\n\nwith Column(gap=3, css_class=\"w-fit mx-auto\"):\n    Checkbox(label=\"Enabled option\")\n    Checkbox(label=\"Disabled option\", disabled=True)\n    Checkbox(label=\"Disabled & checked\", checked=True, disabled=True)"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import Code\n\nCode(\"\"\"\ndef answer() -> int:\n    \\\"\\\"\\\"Return the Answer to the Ultimate Question\n    of Life, the Universe, and Everything.\\\"\\\"\\\"\n    return 42\n\"\"\".strip(), language=\"python\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import Code, Column\n\nwith Column(gap=3):\n    Code(\"pip install prefab-ui\", language=\"bash\")\n    Code(\n        \"SELECT name, designation\\n\"\n        \"FROM crew\\n\"\n        \"WHERE ship = 'Heart of Gold';\",\n        language=\"sql\",\n    )\n    Code('{ \"ship\": \"Heart of Gold\", \"drive\": \"Infinite Improbability\" }', language=\"json\")"
   },
@@ -335,82 +335,82 @@
     "code": "Code(\"{{ query_result }}\", language=\"sql\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import (\n    Column,\n    Div,\n)\n\nwith Column(gap=4):\n    Div(css_class=\"bg-emerald-500 rounded-md h-10\")\n    Div(css_class=\"bg-emerald-500 rounded-md h-10\")\n    Div(css_class=\"bg-emerald-500 rounded-md h-10\")"
   },
   {
-    "title": "Python highlight={3}",
+    "title": "Python highlight={3} icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import Column, Div\n\nwith Column(gap=4, css_class=\"p-3 border-3 border-dashed\"):\n    Div(css_class=\"bg-emerald-500 rounded-md h-10\")\n    Div(css_class=\"bg-emerald-500 rounded-md h-10\")\n    Div(css_class=\"bg-emerald-500 rounded-md h-10\")"
   },
   {
-    "title": "Python highlight={3}",
+    "title": "Python highlight={3} icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import Column, Div\n\nwith Column(gap=8, css_class=\"p-3 border-3 border-dashed\"):\n    Div(css_class=\"bg-emerald-500 rounded-md h-10\")\n    Div(css_class=\"bg-emerald-500 rounded-md h-10\")\n    Div(css_class=\"bg-emerald-500 rounded-md h-10\")"
   },
   {
-    "title": "Python highlight={3}",
+    "title": "Python highlight={3} icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import Column, Div\n\nwith Column(gap=12, css_class=\"p-3 border-3 border-dashed\"):\n    Div(css_class=\"bg-emerald-500 rounded-md h-10\")\n    Div(css_class=\"bg-emerald-500 rounded-md h-10\")\n    Div(css_class=\"bg-emerald-500 rounded-md h-10\")"
   },
   {
-    "title": "Python highlight={3}",
+    "title": "Python highlight={3} icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import Column, Div\n\nwith Column(gap=4, align=\"start\", css_class=\"p-3 border-3 border-dashed\"):\n    Div(css_class=\"bg-emerald-500 rounded-md h-10 w-full\")\n    Div(css_class=\"bg-emerald-500 rounded-md h-10 w-3/4\")\n    Div(css_class=\"bg-emerald-500 rounded-md h-10 w-1/2\")"
   },
   {
-    "title": "Python highlight={3}",
+    "title": "Python highlight={3} icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import Column, Div\n\nwith Column(gap=4, align=\"center\", css_class=\"p-3 border-3 border-dashed\"):\n    Div(css_class=\"bg-emerald-500 rounded-md h-10 w-full\")\n    Div(css_class=\"bg-emerald-500 rounded-md h-10 w-3/4\")\n    Div(css_class=\"bg-emerald-500 rounded-md h-10 w-1/2\")"
   },
   {
-    "title": "Python highlight={3}",
+    "title": "Python highlight={3} icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import Column, Div\n\nwith Column(gap=4, align=\"end\", css_class=\"p-3 border-3 border-dashed\"):\n    Div(css_class=\"bg-emerald-500 rounded-md h-10 w-full\")\n    Div(css_class=\"bg-emerald-500 rounded-md h-10 w-3/4\")\n    Div(css_class=\"bg-emerald-500 rounded-md h-10 w-1/2\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import Combobox, ComboboxOption\n\nwith Combobox(\n    placeholder=\"Select a framework...\",\n    name=\"framework\",\n):\n    ComboboxOption(\"Next.js\", value=\"nextjs\")\n    ComboboxOption(\"Remix\", value=\"remix\")\n    ComboboxOption(\"Astro\", value=\"astro\")\n    ComboboxOption(\"SvelteKit\", value=\"sveltekit\")\n    ComboboxOption(\"Nuxt\", value=\"nuxt\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import (\n    Column,\n    Combobox,\n    ComboboxOption,\n    Text,\n)\n\nwith Column(gap=3):\n    with Combobox(\n        placeholder=\"Select a planet...\",\n        name=\"planet\",\n    ):\n        ComboboxOption(\"Magrathea\", value=\"magrathea\")\n        ComboboxOption(\"Betelgeuse\", value=\"betelgeuse\")\n        ComboboxOption(\"Vogsphere\", value=\"vogsphere\")\n\n    Text(\"Selected: {{ planet }}\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import Combobox, ComboboxOption\n\nwith Combobox(\n    placeholder=\"Pick a language...\",\n    search_placeholder=\"Filter languages...\",\n    name=\"language\",\n):\n    ComboboxOption(\"Python\", value=\"python\")\n    ComboboxOption(\"TypeScript\", value=\"typescript\")\n    ComboboxOption(\"Rust\", value=\"rust\")\n    ComboboxOption(\"Go\", value=\"go\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import Combobox, ComboboxOption\n\nwith Combobox(\n    placeholder=\"Select a planet...\",\n    name=\"planet\",\n):\n    ComboboxOption(\"Magrathea\", value=\"magrathea\")\n    ComboboxOption(\n        \"Earth\",\n        value=\"earth\",\n        disabled=True,\n    )\n    ComboboxOption(\"Betelgeuse\", value=\"betelgeuse\")\n    ComboboxOption(\"Vogsphere\", value=\"vogsphere\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import DataTable, DataTableColumn\n\nDataTable(\n    columns=[\n        DataTableColumn(key=\"name\", header=\"Name\", sortable=True),\n        DataTableColumn(key=\"email\", header=\"Email\"),\n        DataTableColumn(key=\"role\", header=\"Role\", sortable=True),\n    ],\n    rows=[\n        {\"name\": \"Alice Johnson\", \"email\": \"alice@example.com\", \"role\": \"Admin\"},\n        {\"name\": \"Bob Smith\", \"email\": \"bob@example.com\", \"role\": \"Editor\"},\n        {\"name\": \"Carol White\", \"email\": \"carol@example.com\", \"role\": \"Viewer\"},\n    ],\n    searchable=True,\n)"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import DataTable, DataTableColumn\n\nDataTable(\n    columns=[\n        DataTableColumn(key=\"id\", header=\"ID\"),\n        DataTableColumn(key=\"task\", header=\"Task\", sortable=True),\n        DataTableColumn(key=\"status\", header=\"Status\"),\n    ],\n    rows=[\n        {\"id\": \"T-001\", \"task\": \"Design system\", \"status\": \"Complete\"},\n        {\"id\": \"T-002\", \"task\": \"API integration\", \"status\": \"In Progress\"},\n        {\"id\": \"T-003\", \"task\": \"Testing\", \"status\": \"Pending\"},\n        {\"id\": \"T-004\", \"task\": \"Documentation\", \"status\": \"In Progress\"},\n        {\"id\": \"T-005\", \"task\": \"Deployment\", \"status\": \"Pending\"},\n    ],\n    paginated=True,\n    page_size=3,\n    caption=\"Sprint tasks\",\n)"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import DatePicker\n\nDatePicker(placeholder=\"Select deadline\", name=\"deadline\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import (\n    Column,\n    DatePicker,\n    Row,\n    Text,\n)\n\nset_initial_state(deadline=\"2025-06-15T12:00:00.000Z\")\n\nwith Column(gap=3):\n    with Row(gap=4, css_class=\"items-center\"):\n        DatePicker(placeholder=\"Select deadline\", name=\"deadline\")\n        Text(\"{{ deadline | date:long }}\", bold=True)"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import (\n    Button,\n    Card,\n    CardContent,\n    CardFooter,\n    CardHeader,\n    CardTitle,\n    Column,\n    DatePicker,\n    Input,\n    Label,\n)\n\nwith Card():\n    with CardHeader():\n        CardTitle(\"New Event\")\n    with CardContent():\n        with Column(gap=3):\n            Label(\"Event Name\")\n            Input(name=\"eventName\", placeholder=\"Team standup\")\n            Label(\"Date\")\n            DatePicker(placeholder=\"Pick a date\", name=\"eventDate\")\n    with CardFooter():\n        Button(\"Create Event\")"
   },
@@ -435,97 +435,97 @@
     "code": "from prefab_ui.components import (\n    Card, CardHeader, CardTitle, CardDescription,\n    Column, ForEach, Heading,\n)\n\nwith Define(\"project-card\") as project_card:\n    with Card():\n        with CardHeader():\n            CardTitle(\"{{ name }}\")\n            CardDescription(\"{{ description }}\")\n\nwith Column(gap=4) as view:\n    Heading(\"Featured\")\n    Use(\"project-card\", name=\"Prefab\", description=\"The agentic frontend framework\")\n\n    Heading(\"All Projects\")\n    with ForEach(\"projects\"):\n        Use(\"project-card\")\n\nUIResponse(\n    view=view,\n    defs=[project_card],\n    data={\"projects\": [\n        {\"name\": \"Alpha\", \"description\": \"First project\"},\n        {\"name\": \"Beta\", \"description\": \"Second project\"},\n    ]},\n)"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import (\n    Button,\n    Column,\n    Dialog,\n    Input,\n    Label,\n    Row,\n)\n\nwith Dialog(\n    title=\"Crew Profile\",\n    description=\"Update your details for the Heart of Gold crew manifest.\",\n):\n    Button(\"Edit Profile\", variant=\"outline\")\n    with Column(gap=3):\n        Label(\"Name\")\n        Input(name=\"crewName\", placeholder=\"Arthur Dent\")\n        Label(\"Designation\")\n        Input(name=\"crewDesignation\", placeholder=\"Sandwich Maker\")\n    with Row(gap=2, css_class=\"justify-end\"):\n        Button(\"Save changes\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import Button, Dialog, Row, Text\n\nwith Dialog(\n    title=\"Activate Improbability Drive\",\n    description=\"This action cannot be undone.\",\n):\n    Button(\"Engage Drive\", variant=\"destructive\")\n    Text(\n        \"Are you sure? The last time this was engaged, \"\n        \"a sperm whale and a bowl of petunias materialized in mid-air.\"\n    )\n    with Row(gap=2, css_class=\"justify-end\"):\n        Button(\"Cancel\", variant=\"outline\")\n        Button(\"Engage\", variant=\"destructive\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import (\n    Div,\n    P,\n)\n\nwith Div(css_class=\"flex items-center gap-3 rounded-lg border p-4\"):\n    Div(css_class=\"bg-emerald-500 rounded-md h-8 w-8\")\n    P(\"Custom layout with Div\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import (\n    P,\n    Row,\n    Span,\n)\n\nwith Row(gap=2, align=\"baseline\"):\n    P(\"Status:\")\n    Span(\"Online\", css_class=\"text-sm text-success font-medium\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import Column, Field, Switch\n\nwith Column(gap=4):\n    with Field(\n        title=\"Marketing emails\",\n        description=\"Receive emails about new products \"\n        \"and features.\",\n    ):\n        Switch()\n\n    with Field(\n        title=\"Security emails\",\n        description=\"Receive emails about your account \"\n        \"activity.\",\n    ):\n        Switch(checked=True)"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import Checkbox, Column, Field\n\nwith Column(gap=4):\n    with Field(\n        title=\"Accept terms\",\n        description=\"You agree to our Terms of Service \"\n        \"and Privacy Policy.\",\n    ):\n        Checkbox()\n\n    with Field(\n        title=\"Subscribe to newsletter\",\n        description=\"Get weekly updates on new features.\",\n    ):\n        Checkbox(checked=True)"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import Column, Field, Switch\n\nwith Column(gap=4):\n    with Field(\n        title=\"Enabled option\",\n        description=\"You can toggle this.\",\n    ):\n        Switch(checked=True)\n\n    with Field(\n        title=\"Disabled option\",\n        description=\"This cannot be changed.\",\n        disabled=True,\n    ):\n        Switch(disabled=True)"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import (\n    ForEach,\n    Card,\n    CardHeader,\n    CardTitle,\n    CardDescription,\n    Badge,\n    Column,\n    Row,\n)\n\nset_data(crew=[\n    {\"name\": \"Arthur Dent\", \"designation\": \"Sandwich Maker\", \"email\": \"arthur@heart-of-gold.ship\"},\n    {\"name\": \"Ford Prefect\", \"designation\": \"Researcher\", \"email\": \"ford@megadodo.pub\"},\n    {\"name\": \"Trillian\", \"designation\": \"Astrophysicist\", \"email\": \"trillian@heart-of-gold.ship\"},\n])\n\nwith Column(gap=2):\n    with ForEach(\"crew\"):\n        with Card():\n            with CardHeader():\n                with Row(gap=2, align=\"center\"):\n                    CardTitle(\"{{ name }}\")\n                    Badge(\"{{ designation }}\", variant=\"secondary\")\n                CardDescription(\"{{ email }}\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import (\n    ForEach,\n    Badge,\n    Row,\n)\n\nset_data(tags=[\"earth\", \"magrathea\", \"vogon poetry\", \"42\"])\n\nwith Row(gap=2):\n    with ForEach(\"tags\"):\n        Badge(\"{{ _item }}\", variant=\"secondary\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import (\n    ForEach,\n    Card,\n    CardHeader,\n    CardTitle,\n    CardDescription,\n    Column,\n)\n\nset_data(projects=[\n    {\"name\": \"Heart of Gold\", \"owner\": {\"name\": \"Zaphod Beeblebrox\"}},\n    {\"name\": \"Hitchhiker's Guide\", \"owner\": {\"name\": \"Ford Prefect\"}},\n])\n\nwith Column(gap=2):\n    with ForEach(\"projects\"):\n        with Card():\n            with CardHeader():\n                CardTitle(\"{{ name }}\")\n                CardDescription(\"Owner: {{ owner.name }}\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import (\n    Div,\n    Grid,\n)\n\nwith Grid(columns=3, gap=4):\n    for _ in range(6):\n        Div(css_class=\"bg-emerald-500 rounded-md h-10\")"
   },
   {
-    "title": "Python highlight={3}",
+    "title": "Python highlight={3} icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import Div, Grid\n\nwith Grid(columns=2, gap=4, css_class=\"p-3 border-3 border-dashed\"):\n    for _ in range(6):\n        Div(css_class=\"bg-emerald-500 rounded-md h-10\")"
   },
   {
-    "title": "Python highlight={3}",
+    "title": "Python highlight={3} icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import Div, Grid\n\nwith Grid(columns=3, gap=4, css_class=\"p-3 border-3 border-dashed\"):\n    for _ in range(6):\n        Div(css_class=\"bg-emerald-500 rounded-md h-10\")"
   },
   {
-    "title": "Python highlight={3}",
+    "title": "Python highlight={3} icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import Div, Grid\n\nwith Grid(columns=4, gap=4, css_class=\"p-3 border-3 border-dashed\"):\n    for _ in range(6):\n        Div(css_class=\"bg-emerald-500 rounded-md h-10\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import (\n    Column,\n    Grid,\n    H3,\n    P,\n)\n\nwith Grid(columns=2, gap=6, css_class=\"p-3 border-3 border-dashed\"):\n    with Column(css_class=\"p-3 border-3 border-dashed\"):\n        H3(\"Left Panel\")\n        P(\"Primary content goes here.\")\n    with Column(css_class=\"p-3 border-3 border-dashed\"):\n        H3(\"Right Panel\")\n        P(\"Secondary content goes here.\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import Icon\n\nIcon(\"rocket\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import Icon, Row\n\nwith Row(gap=4, css_class=\"items-center\"):\n    Icon(\"heart\", size=\"sm\")\n    Icon(\"heart\", size=\"default\")\n    Icon(\"heart\", size=\"lg\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import (\n    Column,\n    Icon,\n    Row,\n    Text,\n)\n\nwith Column(gap=3):\n    with Row(gap=2, css_class=\"items-center\"):\n        Icon(\"check\", size=\"sm\")\n        Text(\"Task completed\")\n    with Row(gap=2, css_class=\"items-center\"):\n        Icon(\"clock\", size=\"sm\")\n        Text(\"Waiting for approval\")\n    with Row(gap=2, css_class=\"items-center\"):\n        Icon(\"circle-x\", size=\"sm\")\n        Text(\"Build failed\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import Image\n\nImage(src=\"https://picsum.photos/400/300\", alt=\"Example image\", width=\"400px\")"
   },
@@ -535,107 +535,107 @@
     "code": "from prefab_ui.components import (\n    Card,\n    CardContent,\n    CardHeader,\n    CardTitle,\n    Image,\n    P,\n)\n\nwith Card():\n    with CardHeader():\n        CardTitle(\"{{ name }}\")\n    with CardContent():\n        Image(src=\"{{ photo_url }}\", alt=\"{{ name }}\", width=\"100%\")\n        P(\"{{ bio }}\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import Input\n\nInput(placeholder=\"Enter your email...\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import (\n    Input,\n    Column,\n)\n\nwith Column(gap=4):\n    Input(input_type=\"email\", placeholder=\"Email\")\n    Input(input_type=\"password\", placeholder=\"Password\")\n    Input(input_type=\"number\", placeholder=\"Age\")\n    Input(input_type=\"tel\", placeholder=\"Phone\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import (\n    Column,\n    Input,\n    Label,\n)\n\nwith Column(gap=2):\n    Label(\"Email address\")\n    Input(input_type=\"email\", placeholder=\"you@example.com\", required=True)"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import (\n    Column,\n    Input,\n    Label,\n    Row,\n)\n\nwith Row(gap=4):\n    with Column(gap=2, css_class=\"flex-1\"):\n        Label(\"Date\")\n        Input(input_type=\"date\", name=\"date\")\n    with Column(gap=2, css_class=\"flex-1\"):\n        Label(\"Time\")\n        Input(input_type=\"time\", name=\"time\")\n    with Column(gap=2, css_class=\"flex-1\"):\n        Label(\"Date & Time\")\n        Input(input_type=\"datetime-local\", name=\"datetime\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import Input\n\nInput(placeholder=\"Disabled input\", disabled=True)"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import Label\n\nLabel(\"Email address\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import (\n    Column,\n    Input,\n    Label,\n)\n\nwith Column(gap=2):\n    Label(\"Username\", for_id=\"username\")\n    Input(placeholder=\"Enter username\", name=\"username\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import LineChart, ChartSeries\n\ndata = [\n    {\"month\": \"Jan\", \"desktop\": 186, \"mobile\": 80},\n    {\"month\": \"Feb\", \"desktop\": 305, \"mobile\": 200},\n    {\"month\": \"Mar\", \"desktop\": 237, \"mobile\": 120},\n    {\"month\": \"Apr\", \"desktop\": 73, \"mobile\": 190},\n    {\"month\": \"May\", \"desktop\": 209, \"mobile\": 130},\n    {\"month\": \"Jun\", \"desktop\": 214, \"mobile\": 140},\n]\n\nLineChart(\n    data=data,\n    series=[\n        ChartSeries(data_key=\"desktop\", label=\"Desktop\"),\n        ChartSeries(data_key=\"mobile\", label=\"Mobile\"),\n    ],\n    x_axis=\"month\",\n    show_legend=True,\n)"
   },
   {
-    "title": "Python {5}",
+    "title": "Python {5} icon=\"python\"",
     "category": "Components",
     "code": "LineChart(\n    data=data,\n    series=[ChartSeries(data_key=\"value\", label=\"Requests\")],\n    x_axis=\"month\",\n    show_grid=False,\n)"
   },
   {
-    "title": "Python {8}",
+    "title": "Python {8} icon=\"python\"",
     "category": "Components",
     "code": "LineChart(\n    data=data,\n    series=[\n        ChartSeries(data_key=\"desktop\", label=\"Desktop\"),\n        ChartSeries(data_key=\"mobile\", label=\"Mobile\"),\n    ],\n    x_axis=\"month\",\n    curve=\"smooth\",\n    show_legend=True,\n)"
   },
   {
-    "title": "Python {8}",
+    "title": "Python {8} icon=\"python\"",
     "category": "Components",
     "code": "LineChart(\n    data=data,\n    series=[\n        ChartSeries(data_key=\"desktop\", label=\"Desktop\"),\n        ChartSeries(data_key=\"mobile\", label=\"Mobile\"),\n    ],\n    x_axis=\"month\",\n    curve=\"step\",\n    show_legend=True,\n)"
   },
   {
-    "title": "Python {8}",
+    "title": "Python {8} icon=\"python\"",
     "category": "Components",
     "code": "LineChart(\n    data=data,\n    series=[\n        ChartSeries(data_key=\"desktop\", label=\"Desktop\"),\n        ChartSeries(data_key=\"mobile\", label=\"Mobile\"),\n    ],\n    x_axis=\"month\",\n    show_dots=True,\n    show_legend=True,\n)"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import Markdown\n\nMarkdown(\"\"\"\n# Release Notes\n\nVersion **2.5.0** brings several improvements:\n\n## New Features\n\n- **Dark mode** with automatic system detection\n- Keyboard shortcuts for *all* actions\n- Inline `code` formatting support\n\n## Migration Guide\n\n> Update your config file before upgrading.\n\n| Setting | Old | New |\n|---------|-----|-----|\n| theme | `light` | `auto` |\n| timeout | `30s` | `60s` |\n\"\"\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import (\n    Button,\n    Card,\n    CardDescription,\n    CardHeader,\n    CardTitle,\n    Column,\n    Page,\n    Pages,\n    Row,\n)\nfrom prefab_ui.actions import SetState\n\nwith Column(gap=4):\n    with Row(gap=2):\n        Button(\"Earth\", on_click=SetState(\"entry\", \"earth\"))\n        Button(\"Magrathea\", variant=\"outline\", on_click=SetState(\"entry\", \"magrathea\"))\n        Button(\"Milliways\", variant=\"outline\", on_click=SetState(\"entry\", \"milliways\"))\n\n    with Pages(name=\"entry\", default_value=\"earth\"):\n        with Page(\"Earth\", value=\"earth\"):\n            with Card():\n                with CardHeader():\n                    CardTitle(\"Earth\")\n                    CardDescription(\"Mostly harmless.\")\n        with Page(\"Magrathea\", value=\"magrathea\"):\n            with Card():\n                with CardHeader():\n                    CardTitle(\"Magrathea\")\n                    CardDescription(\n                        \"Ancient planet-building civilization. \"\n                        \"Custom-built luxury planets for the ultra-rich.\"\n                    )\n        with Page(\"Milliways\", value=\"milliways\"):\n            with Card():\n                with CardHeader():\n                    CardTitle(\"Milliways\")\n                    CardDescription(\n                        \"The Restaurant at the End of the Universe. \"\n                        \"Reservations recommended.\"\n                    )"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import Button, Column, Page, Pages, Row, Text\nfrom prefab_ui.actions import SetState\n\nwith Column(gap=4):\n    with Pages(name=\"step\", default_value=\"setup\"):\n        with Page(\"Setup\", value=\"setup\"):\n            with Column(gap=4):\n                Text(\"Configure your settings.\")\n                with Row():\n                    Button(\"Next\", on_click=SetState(\"step\", \"review\"))\n        with Page(\"Review\", value=\"review\"):\n            with Column(gap=4):\n                Text(\"Review your choices.\")\n                with Row(gap=2):\n                    Button(\"Back\", variant=\"outline\", on_click=SetState(\"step\", \"setup\"))\n                    Button(\"Next\", on_click=SetState(\"step\", \"complete\"))\n        with Page(\"Complete\", value=\"complete\"):\n            Text(\"All done!\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import PieChart\n\ndata = [\n    {\"browser\": \"Chrome\", \"visitors\": 275},\n    {\"browser\": \"Safari\", \"visitors\": 200},\n    {\"browser\": \"Firefox\", \"visitors\": 187},\n    {\"browser\": \"Edge\", \"visitors\": 173},\n    {\"browser\": \"Other\", \"visitors\": 90},\n]\n\nPieChart(\n    data=data,\n    data_key=\"visitors\",\n    name_key=\"browser\",\n    show_legend=True,\n)"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "PieChart(\n    data=[\n        {\"browser\": \"Chrome\", \"visitors\": 275},\n        {\"browser\": \"Safari\", \"visitors\": 200},\n        {\"browser\": \"Firefox\", \"visitors\": 187},\n        {\"browser\": \"Edge\", \"visitors\": 173},\n        {\"browser\": \"Other\", \"visitors\": 90},\n    ],\n    data_key=\"visitors\",\n    name_key=\"browser\",\n    inner_radius=60,\n    show_legend=True,\n)"
   },
   {
-    "title": "Python {5}",
+    "title": "Python {5} icon=\"python\"",
     "category": "Components",
     "code": "PieChart(\n    data=data,\n    data_key=\"visitors\",\n    name_key=\"browser\",\n    show_label=True,\n    show_legend=True,\n)"
   },
   {
-    "title": "Python {6}",
+    "title": "Python {6} icon=\"python\"",
     "category": "Components",
     "code": "PieChart(\n    data=data,\n    data_key=\"visitors\",\n    name_key=\"browser\",\n    inner_radius=60,\n    padding_angle=5,\n    show_legend=True,\n)"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import (\n    Button,\n    Column,\n    Input,\n    Label,\n    Popover,\n)\n\nwith Popover(title=\"Babel Fish Settings\", description=\"Configure your universal translator.\"):\n    Button(\"Open popover\", variant=\"outline\")\n    with Column(gap=3):\n        Label(\"Source Language\")\n        Input(name=\"sourceLang\", placeholder=\"Vogon\")\n        Label(\"Target Language\")\n        Input(name=\"targetLang\", placeholder=\"Galactic Standard\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import (\n    Button,\n    Column,\n    Label,\n    Popover,\n    Slider,\n)\n\nwith Popover():\n    Button(\"Settings\", variant=\"outline\")\n    with Column(gap=3):\n        Label(\"Improbability Factor\")\n        Slider(min=0, max=100, value=42, name=\"improbability\")"
   },
@@ -645,217 +645,217 @@
     "code": "with Popover(title=\"Guide Entry\", side=\"right\"):\n    Button(\"Hover for info\", variant=\"outline\")\n    Text(\"A towel is about the most massively useful thing an interstellar hitchhiker can have.\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import Progress\n\nProgress(value=60)"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import Column, Label, Progress\n\nwith Column(gap=4):\n    with Column(gap=2):\n        Label(\"3 of 5 steps\")\n        Progress(value=3, max=5)\n    with Column(gap=2):\n        Label(\"75%\")\n        Progress(value=75)"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import Column, Label, Progress\n\nwith Column(gap=4):\n    with Column(gap=2):\n        Label(\"Storage Used\")\n        Progress(value=85, indicator_class=\"bg-red-500\")\n    with Column(gap=2):\n        Label(\"Upload Progress\")\n        Progress(value=45, indicator_class=\"bg-blue-500\")\n    with Column(gap=2):\n        Label(\"Tasks Complete\")\n        Progress(value=100, indicator_class=\"bg-green-500\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import (\n    Column,\n    Progress,\n    Row,\n    Slider,\n    Text,\n)\n\nset_initial_state(progress=0.65)\n\nwith Column(gap=3):\n    with Row(css_class=\"justify-between items-center\"):\n        Text(\"Upload progress\")\n        Text(\"{{ progress | percent }}\", bold=True)\n    Progress(value=\"{{ progress }}\", max=1)\n    Slider(name=\"progress\", min=0, max=1, step=0.01, value=0.65)"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import RadarChart, ChartSeries\n\ndata = [\n    {\"subject\": \"Math\", \"alice\": 120, \"bob\": 98},\n    {\"subject\": \"English\", \"alice\": 98, \"bob\": 130},\n    {\"subject\": \"Science\", \"alice\": 86, \"bob\": 110},\n    {\"subject\": \"History\", \"alice\": 99, \"bob\": 95},\n    {\"subject\": \"Art\", \"alice\": 85, \"bob\": 90},\n]\n\nRadarChart(\n    data=data,\n    series=[\n        ChartSeries(data_key=\"alice\", label=\"Alice\"),\n        ChartSeries(data_key=\"bob\", label=\"Bob\"),\n    ],\n    axis_key=\"subject\",\n    show_legend=True,\n)"
   },
   {
-    "title": "Python {5}",
+    "title": "Python {5} icon=\"python\"",
     "category": "Components",
     "code": "RadarChart(\n    data=data,\n    series=[ChartSeries(data_key=\"score\", label=\"Score\")],\n    axis_key=\"subject\",\n    show_grid=False,\n)"
   },
   {
-    "title": "Python {8}",
+    "title": "Python {8} icon=\"python\"",
     "category": "Components",
     "code": "RadarChart(\n    data=data,\n    series=[\n        ChartSeries(data_key=\"alice\", label=\"Alice\"),\n        ChartSeries(data_key=\"bob\", label=\"Bob\"),\n    ],\n    axis_key=\"subject\",\n    filled=False,\n    show_legend=True,\n)"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import RadialChart\n\ndata = [\n    {\"browser\": \"Chrome\", \"visitors\": 275},\n    {\"browser\": \"Safari\", \"visitors\": 200},\n    {\"browser\": \"Firefox\", \"visitors\": 187},\n    {\"browser\": \"Edge\", \"visitors\": 173},\n    {\"browser\": \"Other\", \"visitors\": 90},\n]\n\nRadialChart(\n    data=data,\n    data_key=\"visitors\",\n    name_key=\"browser\",\n    show_legend=True,\n)"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "RadialChart(\n    data=[\n        {\"browser\": \"Chrome\", \"visitors\": 275},\n        {\"browser\": \"Safari\", \"visitors\": 200},\n        {\"browser\": \"Firefox\", \"visitors\": 187},\n        {\"browser\": \"Edge\", \"visitors\": 173},\n        {\"browser\": \"Other\", \"visitors\": 90},\n    ],\n    inner_radius=80,\n    data_key=\"visitors\",\n    name_key=\"browser\",\n    show_legend=True,\n)"
   },
   {
-    "title": "Python {5-6}",
+    "title": "Python {5-6} icon=\"python\"",
     "category": "Components",
     "code": "RadialChart(\n    data=data,\n    data_key=\"visitors\",\n    name_key=\"browser\",\n    start_angle=90,\n    end_angle=-270,\n    show_legend=True,\n)"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import (\n    Radio,\n    RadioGroup,\n)\n\nwith RadioGroup(name=\"size\"):\n    Radio(value=\"sm\", label=\"Small\")\n    Radio(value=\"md\", label=\"Medium\", checked=True)\n    Radio(value=\"lg\", label=\"Large\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import (\n    Column,\n    Radio,\n)\n\nwith Column(gap=3):\n    Radio(value=\"yes\", label=\"Yes\", name=\"answer\")\n    Radio(value=\"no\", label=\"No\", name=\"answer\", checked=True)"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import (\n    Radio,\n    RadioGroup,\n)\n\nwith RadioGroup(name=\"plan\"):\n    Radio(value=\"free\", label=\"Free\", checked=True)\n    Radio(value=\"pro\", label=\"Pro\")\n    Radio(value=\"enterprise\", label=\"Enterprise\", disabled=True)"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import (\n    Div,\n    Row,\n)\n\nwith Row(gap=4):\n    Div(css_class=\"bg-emerald-500 rounded-md h-10 w-20\")\n    Div(css_class=\"bg-emerald-500 rounded-md h-10 w-20\")\n    Div(css_class=\"bg-emerald-500 rounded-md h-10 w-20\")"
   },
   {
-    "title": "Python highlight={3}",
+    "title": "Python highlight={3} icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import Div, Row\n\nwith Row(gap=4, css_class=\"p-3 border-3 border-dashed\"):\n    Div(css_class=\"bg-emerald-500 rounded-md h-10 w-20\")\n    Div(css_class=\"bg-emerald-500 rounded-md h-10 w-20\")\n    Div(css_class=\"bg-emerald-500 rounded-md h-10 w-20\")"
   },
   {
-    "title": "Python highlight={3}",
+    "title": "Python highlight={3} icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import Div, Row\n\nwith Row(gap=8, css_class=\"p-3 border-3 border-dashed\"):\n    Div(css_class=\"bg-emerald-500 rounded-md h-10 w-20\")\n    Div(css_class=\"bg-emerald-500 rounded-md h-10 w-20\")\n    Div(css_class=\"bg-emerald-500 rounded-md h-10 w-20\")"
   },
   {
-    "title": "Python highlight={3}",
+    "title": "Python highlight={3} icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import Div, Row\n\nwith Row(gap=12, css_class=\"p-3 border-3 border-dashed\"):\n    Div(css_class=\"bg-emerald-500 rounded-md h-10 w-20\")\n    Div(css_class=\"bg-emerald-500 rounded-md h-10 w-20\")\n    Div(css_class=\"bg-emerald-500 rounded-md h-10 w-20\")"
   },
   {
-    "title": "Python highlight={3}",
+    "title": "Python highlight={3} icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import Div, Row\n\nwith Row(gap=4, align=\"start\", css_class=\"p-3 border-3 border-dashed\"):\n    Div(css_class=\"bg-emerald-500 rounded-md h-8 w-20\")\n    Div(css_class=\"bg-emerald-500 rounded-md h-16 w-20\")\n    Div(css_class=\"bg-emerald-500 rounded-md h-10 w-20\")"
   },
   {
-    "title": "Python highlight={3}",
+    "title": "Python highlight={3} icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import Div, Row\n\nwith Row(gap=4, align=\"center\", css_class=\"p-3 border-3 border-dashed\"):\n    Div(css_class=\"bg-emerald-500 rounded-md h-8 w-20\")\n    Div(css_class=\"bg-emerald-500 rounded-md h-16 w-20\")\n    Div(css_class=\"bg-emerald-500 rounded-md h-10 w-20\")"
   },
   {
-    "title": "Python highlight={3}",
+    "title": "Python highlight={3} icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import Div, Row\n\nwith Row(gap=4, align=\"end\", css_class=\"p-3 border-3 border-dashed\"):\n    Div(css_class=\"bg-emerald-500 rounded-md h-8 w-20\")\n    Div(css_class=\"bg-emerald-500 rounded-md h-16 w-20\")\n    Div(css_class=\"bg-emerald-500 rounded-md h-10 w-20\")"
   },
   {
-    "title": "Python highlight={3}",
+    "title": "Python highlight={3} icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import Row, Span\n\nwith Row(gap=4, align=\"baseline\", css_class=\"p-3 border-3 border-dashed\"):\n    Span(\n        \"Small\",\n        css_class=\"bg-emerald-500 rounded-md \"\n        \"px-3 py-1 text-white text-sm\",\n    )\n    Span(\n        \"Large\",\n        css_class=\"bg-emerald-500 rounded-md \"\n        \"px-3 py-2 text-white text-2xl\",\n    )\n    Span(\n        \"Medium\",\n        css_class=\"bg-emerald-500 rounded-md \"\n        \"px-3 py-1 text-white text-base\",\n    )"
   },
   {
-    "title": "Python highlight={3}",
+    "title": "Python highlight={3} icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import Div, Row\n\nwith Row(gap=1, justify=\"start\", css_class=\"w-full p-3 border-3 border-dashed\"):\n    Div(css_class=\"bg-emerald-500 rounded-md h-10 w-20\")\n    Div(css_class=\"bg-emerald-500 rounded-md h-10 w-20\")\n    Div(css_class=\"bg-emerald-500 rounded-md h-10 w-20\")"
   },
   {
-    "title": "Python highlight={3}",
+    "title": "Python highlight={3} icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import Div, Row\n\nwith Row(gap=1, justify=\"center\", css_class=\"w-full p-3 border-3 border-dashed\"):\n    Div(css_class=\"bg-emerald-500 rounded-md h-10 w-20\")\n    Div(css_class=\"bg-emerald-500 rounded-md h-10 w-20\")\n    Div(css_class=\"bg-emerald-500 rounded-md h-10 w-20\")"
   },
   {
-    "title": "Python highlight={3}",
+    "title": "Python highlight={3} icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import Div, Row\n\nwith Row(gap=1, justify=\"end\", css_class=\"w-full p-3 border-3 border-dashed\"):\n    Div(css_class=\"bg-emerald-500 rounded-md h-10 w-20\")\n    Div(css_class=\"bg-emerald-500 rounded-md h-10 w-20\")\n    Div(css_class=\"bg-emerald-500 rounded-md h-10 w-20\")"
   },
   {
-    "title": "Python highlight={3}",
+    "title": "Python highlight={3} icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import Div, Row\n\nwith Row(gap=1, justify=\"between\", css_class=\"w-full p-3 border-3 border-dashed\"):\n    Div(css_class=\"bg-emerald-500 rounded-md h-10 w-20\")\n    Div(css_class=\"bg-emerald-500 rounded-md h-10 w-20\")\n    Div(css_class=\"bg-emerald-500 rounded-md h-10 w-20\")"
   },
   {
-    "title": "Python highlight={3}",
+    "title": "Python highlight={3} icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import Div, Row\n\nwith Row(gap=1, justify=\"around\", css_class=\"w-full p-3 border-3 border-dashed\"):\n    Div(css_class=\"bg-emerald-500 rounded-md h-10 w-20\")\n    Div(css_class=\"bg-emerald-500 rounded-md h-10 w-20\")\n    Div(css_class=\"bg-emerald-500 rounded-md h-10 w-20\")"
   },
   {
-    "title": "Python highlight={3}",
+    "title": "Python highlight={3} icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import Div, Row\n\nwith Row(gap=1, justify=\"evenly\", css_class=\"w-full p-3 border-3 border-dashed\"):\n    Div(css_class=\"bg-emerald-500 rounded-md h-10 w-20\")\n    Div(css_class=\"bg-emerald-500 rounded-md h-10 w-20\")\n    Div(css_class=\"bg-emerald-500 rounded-md h-10 w-20\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import (\n    Select,\n    SelectOption,\n)\n\nwith Select(placeholder=\"Choose size...\"):\n    SelectOption(value=\"sm\", label=\"Small\")\n    SelectOption(value=\"md\", label=\"Medium\")\n    SelectOption(value=\"lg\", label=\"Large\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import (\n    Select,\n    SelectOption,\n)\n\nwith Select(placeholder=\"Select country\"):\n    SelectOption(value=\"us\", label=\"United States\")\n    SelectOption(value=\"uk\", label=\"United Kingdom\", selected=True)\n    SelectOption(value=\"ca\", label=\"Canada\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import (\n    Column,\n    Select,\n    SelectOption,\n)\n\nwith Column(gap=4):\n    with Select(placeholder=\"Default size\"):\n        SelectOption(value=\"1\", label=\"Option 1\")\n        SelectOption(value=\"2\", label=\"Option 2\")\n\n    with Select(placeholder=\"Small size\", size=\"sm\"):\n        SelectOption(value=\"1\", label=\"Option 1\")\n        SelectOption(value=\"2\", label=\"Option 2\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import (\n    Column,\n    Label,\n    Select,\n    SelectOption,\n)\n\nwith Column(gap=2):\n    Label(\"Preferred language\")\n    with Select(placeholder=\"Choose language\"):\n        SelectOption(value=\"en\", label=\"English\")\n        SelectOption(value=\"es\", label=\"Spanish\")\n        SelectOption(value=\"fr\", label=\"French\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import (\n    Column,\n    P,\n    Separator,\n)\n\nwith Column():\n    P(\"Content above the separator\")\n    Separator(css_class=\"my-4\")\n    P(\"Content below the separator\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import (\n    Row,\n    Separator,\n    Span,\n)\n\nwith Row(gap=4, css_class=\"items-center\"):\n    Span(\"Left\")\n    Separator(orientation=\"vertical\", css_class=\"h-4\")\n    Span(\"Middle\")\n    Separator(orientation=\"vertical\", css_class=\"h-4\")\n    Span(\"Right\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import (\n    Card,\n    CardContent,\n    P,\n    Separator,\n)\n\nwith Card():\n    with CardContent():\n        P(\"First section\")\n        Separator(css_class=\"my-4\")\n        P(\"Second section\")\n        Separator(css_class=\"my-4\")\n        P(\"Third section\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import Slider\n\nSlider(min=0, max=100, value=50)"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import Slider\n\nSlider(min=0, max=10, step=0.5, value=5)"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import (\n    Column,\n    Label,\n    Slider,\n)\n\nwith Column(gap=4):\n    with Column(gap=2):\n        Label(\"Volume (0-100)\")\n        Slider(min=0, max=100, value=75)\n\n    with Column(gap=2):\n        Label(\"Temperature (0-10)\")\n        Slider(min=0, max=10, value=7)"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import (\n    Column,\n    Label,\n    Progress,\n    Row,\n    Slider,\n    Text,\n)\n\nset_initial_state(volume=75)\n\nwith Column(gap=4):\n    with Column(gap=2):\n        with Row(css_class=\"justify-between\"):\n            Label(\"Volume\")\n            Text(\"{{ volume | number }}%\", bold=True)\n        Slider(name=\"volume\", min=0, max=100, value=75)\n    Progress(value=\"{{ volume }}\", max=100)"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import Slider\n\nSlider(min=0, max=100, value=30, disabled=True)"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import Spinner\n\nSpinner()"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import Row, Spinner\n\nwith Row(gap=4, css_class=\"items-center\"):\n    Spinner(size=\"sm\")\n    Spinner(size=\"default\")\n    Spinner(size=\"lg\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import Row, Spinner, Text\n\nwith Row(gap=2, css_class=\"items-center\"):\n    Spinner(size=\"sm\")\n    Text(\"Computing the answer to life, the \"\n         \"universe, and everything...\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import (\n    Card,\n    CardDescription,\n    CardHeader,\n    CardTitle,\n    State,\n)\n\nwith State(name=\"Arthur Dent\", role=\"Reluctant Adventurer\"):\n    with Card():\n        with CardHeader():\n            CardTitle(\"{{ name }}\")\n            CardDescription(\"{{ role }}\")"
   },
@@ -865,52 +865,52 @@
     "code": "from prefab_ui.components import State, Text\n\n# Kwargs style\nwith State(name=\"Ford\", role=\"Researcher\"):\n    Text(\"{{ name }} is a {{ role }}\")\n\n# Dict style\nwith State({\"name\": \"Ford\", \"role\": \"Researcher\"}):\n    Text(\"{{ name }} is a {{ role }}\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import Column, State, Text\n\nwith Column(gap=2):\n    with State(greeting=\"Don't Panic\", name=\"Arthur\"):\n        Text(\"{{ greeting }}, {{ name }}\")\n        with State(name=\"Ford\"):\n            Text(\"{{ greeting }}, {{ name }}\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import Badge, ForEach, Row, State\n\nset_data(languages=[\"Python\", \"TypeScript\", \"Rust\"])\n\nwith State(prefix=\"Speaks\"):\n    with Row(gap=2, align=\"center\"):\n        with ForEach(\"languages\"):\n            Badge(\n                \"{{ prefix }}: {{ _item }}\",\n                variant=\"secondary\",\n            )"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import Switch\n\nSwitch(label=\"Enable notifications\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import Switch\n\nSwitch(label=\"Dark mode\", checked=True)"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import (\n    Column,\n    Switch,\n)\n\nwith Column(gap=4):\n    Switch(label=\"Default size\", checked=True)\n    Switch(label=\"Small size\", size=\"sm\", checked=True)"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import (\n    Column,\n    Switch,\n)\n\nwith Column(gap=3):\n    Switch(label=\"Enabled switch\")\n    Switch(label=\"Disabled off\", disabled=True)\n    Switch(label=\"Disabled on\", checked=True, disabled=True)"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import (\n    Table,\n    TableHeader,\n    TableBody,\n    TableRow,\n    TableHead,\n    TableCell,\n    TableCaption,\n)\n\nwith Table():\n    TableCaption(\"Recent invoices\")\n    with TableHeader():\n        with TableRow():\n            TableHead(\"Invoice\")\n            TableHead(\"Status\")\n            TableHead(\"Method\")\n            TableHead(\"Amount\", css_class=\"text-right\")\n    with TableBody():\n        with TableRow():\n            TableCell(\"INV-001\", css_class=\"font-medium\")\n            TableCell(\"Paid\")\n            TableCell(\"Credit Card\")\n            TableCell(\"$250.00\", css_class=\"text-right\")\n        with TableRow():\n            TableCell(\"INV-002\", css_class=\"font-medium\")\n            TableCell(\"Pending\")\n            TableCell(\"PayPal\")\n            TableCell(\"$150.00\", css_class=\"text-right\")\n        with TableRow():\n            TableCell(\"INV-003\", css_class=\"font-medium\")\n            TableCell(\"Paid\")\n            TableCell(\"Bank Transfer\")\n            TableCell(\"$350.00\", css_class=\"text-right\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import (\n    Badge,\n    Table,\n    TableBody,\n    TableHead,\n    TableHeader,\n    TableRow,\n    TableCell,\n)\n\nwith Table():\n    with TableHeader():\n        with TableRow():\n            TableHead(\"Name\")\n            TableHead(\"Status\")\n            TableHead(\"Role\")\n    with TableBody():\n        with TableRow():\n            TableCell(\"Alice Johnson\")\n            with TableCell():\n                Badge(\"Active\", variant=\"success\")\n            TableCell(\"Admin\")\n        with TableRow():\n            TableCell(\"Bob Smith\")\n            with TableCell():\n                Badge(\"Inactive\", variant=\"secondary\")\n            TableCell(\"Viewer\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import (\n    Card,\n    CardContent,\n    CardDescription,\n    CardHeader,\n    CardTitle,\n    Column,\n    Input,\n    Label,\n    Tab,\n    Tabs,\n)\n\nwith Tabs(default_value=\"account\"):\n    with Tab(\"Account\", value=\"account\"):\n        with Card():\n            with CardHeader():\n                CardTitle(\"Account\")\n                CardDescription(\"Make changes to your account here.\")\n            with CardContent():\n                with Column(gap=3):\n                    Label(\"Name\")\n                    Input(name=\"accountName\", placeholder=\"Your name\")\n    with Tab(\"Password\", value=\"password\"):\n        with Card():\n            with CardHeader():\n                CardTitle(\"Password\")\n                CardDescription(\"Change your password here.\")\n            with CardContent():\n                with Column(gap=3):\n                    Label(\"Current Password\")\n                    Input(input_type=\"password\", name=\"currentPw\")\n                    Label(\"New Password\")\n                    Input(input_type=\"password\", name=\"newPw\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import Column, Tab, Tabs, Text\n\nwith Column(gap=6):\n    with Tabs(default_value=\"one\"):\n        with Tab(\"Mostly\", value=\"one\"):\n            Text(\"Don't panic.\")\n        with Tab(\"Harmless\", value=\"two\"):\n            Text(\"It's a wholly remarkable book.\")\n\n    with Tabs(variant=\"line\", default_value=\"one\"):\n        with Tab(\"Mostly\", value=\"one\"):\n            Text(\"Don't panic.\")\n        with Tab(\"Harmless\", value=\"two\"):\n            Text(\"It's a wholly remarkable book.\")"
   },
@@ -920,62 +920,62 @@
     "code": "from prefab_ui.components import Button, Column, Row, Tab, Tabs, Text\nfrom prefab_ui.actions import SetState\n\nwith Column(gap=4):\n    with Tabs(name=\"activeTab\", default_value=\"general\"):\n        with Tab(\"General\", value=\"general\"):\n            Text(\"General settings here.\")\n        with Tab(\"Advanced\", value=\"advanced\"):\n            Text(\"Advanced settings here.\")\n\n    with Row(gap=2):\n        Button(\"Go to General\", on_click=SetState(\"activeTab\", \"general\"))\n        Button(\"Go to Advanced\", on_click=SetState(\"activeTab\", \"advanced\"))"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import Textarea\n\nTextarea(placeholder=\"Enter your message...\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import (\n    Column,\n    Label,\n    Textarea,\n)\n\nwith Column(gap=2):\n    Label(\"Feedback\")\n    Textarea(\n        placeholder=\"Tell us what you think...\",\n        rows=5,\n    )"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import Textarea\n\nTextarea(\n    value=\"This is some initial content that can be edited.\",\n    rows=4,\n)"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import Textarea\n\nTextarea(placeholder=\"This textarea is disabled\", disabled=True)"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import Button, Row, Tooltip\n\nwith Row(gap=4):\n    with Tooltip(\"Save your current work\"):\n        Button(\"Save\")\n    with Tooltip(\"Discard unsaved changes\", side=\"bottom\"):\n        Button(\"Reset\", variant=\"outline\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import Button, Row, Tooltip\n\nwith Row(gap=4):\n    with Tooltip(\"Top\", side=\"top\"):\n        Button(\"Top\", variant=\"outline\")\n    with Tooltip(\"Right\", side=\"right\"):\n        Button(\"Right\", variant=\"outline\")\n    with Tooltip(\"Bottom\", side=\"bottom\"):\n        Button(\"Bottom\", variant=\"outline\")\n    with Tooltip(\"Left\", side=\"left\"):\n        Button(\"Left\", variant=\"outline\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import (\n    H1,\n    H2,\n    P,\n    Lead,\n    Muted,\n    Column,\n)\n\nwith Column(gap=4):\n    H1(\"Dashboard\")\n    Lead(\"Monitor your application metrics and performance.\")\n    P(\"Everything you need to manage your MCP server, organized in one place.\")\n    Muted(\"Last updated 5 minutes ago\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import (\n    H1,\n    H2,\n    H3,\n    H4,\n    Column,\n)\n\nwith Column(gap=4):\n    H1(\"H1 — Page Title\")\n    H2(\"H2 — Section Heading\")\n    H3(\"H3 — Subsection\")\n    H4(\"H4 — Detail Heading\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import (\n    P,\n    Lead,\n    Large,\n    Column,\n)\n\nwith Column(gap=4):\n    Lead(\"A comprehensive guide to building MCP applications with FastMCP.\")\n    P(\"FastMCP provides a complete toolkit for building and deploying MCP servers. Each component follows shadcn/ui conventions for consistent styling.\")\n    Large(\"Key Takeaway: Components compose naturally.\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import (\n    Small,\n    Muted,\n    Column,\n)\n\nwith Column(gap=3):\n    Small(\"Terms and conditions apply\")\n    Muted(\"Last updated 5 minutes ago\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import BlockQuote\n\nBlockQuote(\"The best way to predict the future is to invent it.\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import (\n    InlineCode,\n    P,\n    Row,\n)\n\nwith Row(gap=2, css_class=\"items-center\"):\n    P(\"Run\")\n    InlineCode(\"pip install prefab-ui\")\n    P(\"to get started.\")"
   },
@@ -985,7 +985,7 @@
     "code": "from prefab_ui.components import (\n    Text,\n    Markdown,\n    Heading,\n)\n\nText(\"Plain paragraph with no default styling.\")\nHeading(\"Section Title\", level=2)\nMarkdown(\"**Bold** and *italic* text with [links](https://example.com).\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Components",
     "code": "from prefab_ui.components import (\n    P,\n    Text,\n    Column,\n)\n\nwith Column(gap=2):\n    P(\"Regular paragraph text.\")\n    P(\"This is bold.\", bold=True)\n    P(\"This is italic.\", italic=True)\n    Text(\"Bold and italic combined.\", bold=True, italic=True)"
   },
@@ -1000,22 +1000,22 @@
     "code": "from prefab_ui import AppResult, ToolCall\nfrom prefab_ui.components import Button, Column, Input, Text\n\nmcp = FastMCP(\"Demo\")\n\n@mcp.tool(ui=True)\nasync def search(query: str = \"\") -> AppResult:\n    results = find_items(query) if query else []\n    with Column(gap=3) as view:\n        Input(name=\"q\", placeholder=\"Search...\")\n        Button(\"Search\", on_click=ToolCall(\"search\", arguments={\"query\": \"{{ q }}\"}))\n        for r in results:\n            Text(r[\"title\"])\n    return AppResult(view=view, state={\"results\": results})"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "General",
     "code": "from prefab_ui.components import Button, Column, Input\nfrom prefab_ui import ToolCall\n\nwith Column(gap=3):\n    Input(name=\"city\", placeholder=\"Enter a city...\")\n    Button(\"Get Weather\", on_click=ToolCall(\n        \"get_weather\",\n        arguments={\"location\": \"{{ city }}\"},\n    ))"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "General",
     "code": "from prefab_ui.components import Button\nfrom prefab_ui import SetState, ToolCall\n\nButton(\"Save\", on_click=[\n    SetState(\"saving\", True),\n    ToolCall(\"save_data\", arguments={\"item\": \"{{ item }}\"}),\n    SetState(\"saving\", False),\n])"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "General",
     "code": "from prefab_ui.components import Button, Card, CardContent, Column, Input\n\nwith Card() as view:\n    with CardContent():\n        with Column(gap=3):\n            Input(name=\"email\", placeholder=\"you@example.com\")\n            Button(\"Subscribe\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Patterns",
     "code": "from prefab_ui.components import Button, Dialog, Row, Text\nfrom prefab_ui import ToolCall\n\nwith Dialog(title=\"Delete Item\", description=\"This action cannot be undone.\"):\n    Button(\"Delete\", variant=\"destructive\")\n    Text(\"Are you sure you want to permanently delete this item?\")\n    with Row(gap=2, css_class=\"justify-end\"):\n        Button(\"Cancel\", variant=\"outline\")\n        Button(\n            \"Confirm Delete\",\n            variant=\"destructive\",\n            on_click=ToolCall(\"delete_item\", arguments={\"id\": \"{{ item_id }}\"}),\n        )"
   },
@@ -1025,17 +1025,17 @@
     "code": "from prefab_ui.components import Button, Column, Dialog, Row, Text\nfrom prefab_ui import ToolCall, ShowToast\n\nwith Dialog(title=\"Remove User\", description=\"This will revoke all access.\"):\n    Button(\"Remove\", variant=\"destructive\")\n    Column(\n        gap=3,\n        children=[\n            Text(\"User {{ user_name }} will lose access to all projects.\"),\n            Row(\n                gap=2,\n                css_class=\"justify-end\",\n                children=[\n                    Button(\"Cancel\", variant=\"outline\"),\n                    Button(\n                        \"Remove User\",\n                        variant=\"destructive\",\n                        on_click=ToolCall(\n                            \"remove_user\",\n                            arguments={\"user_id\": \"{{ user_id }}\"},\n                            on_success=ShowToast(\"User removed\", variant=\"success\"),\n                            on_error=ShowToast(\"{{ $error }}\", variant=\"error\"),\n                        ),\n                    ),\n                ],\n            ),\n        ],\n    )"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Patterns",
     "code": "from prefab_ui.components import Button\nfrom prefab_ui import ToolCall, ShowToast\n\nButton(\n    \"Save\",\n    on_click=ToolCall(\n        \"save_item\",\n        arguments={\"data\": \"{{ item }}\"},\n        on_success=ShowToast(\"Saved successfully!\", variant=\"success\"),\n        on_error=ShowToast(\"{{ $error }}\", variant=\"error\"),\n    ),\n)"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Patterns",
     "code": "from prefab_ui.components import Button, Column, Popover, Text\nfrom prefab_ui import ToolCall\n\nwith Popover():\n    Button(\"Archive\", variant=\"outline\")\n    with Column(gap=2):\n        Text(\"Archive this item?\")\n        Button(\n            \"Confirm\",\n            on_click=ToolCall(\"archive_item\", arguments={\"id\": \"{{ item_id }}\"}),\n        )"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Patterns",
     "code": "from prefab_ui.components import DataTable, DataTableColumn\n\nDataTable(\n    columns=[\n        DataTableColumn(key=\"name\", header=\"Name\", sortable=True),\n        DataTableColumn(key=\"status\", header=\"Status\"),\n        DataTableColumn(key=\"updated\", header=\"Updated\", sortable=True),\n    ],\n    rows=[\n        {\"name\": \"Auth service\", \"status\": \"Healthy\", \"updated\": \"2 min ago\"},\n        {\"name\": \"API gateway\", \"status\": \"Degraded\", \"updated\": \"30 sec ago\"},\n        {\"name\": \"Database\", \"status\": \"Healthy\", \"updated\": \"5 min ago\"},\n    ],\n    searchable=True,\n    paginated=True,\n    page_size=10,\n)"
   },
@@ -1045,7 +1045,7 @@
     "code": "DataTable(\n    columns=[\n        DataTableColumn(key=\"name\", header=\"Name\", sortable=True),\n        DataTableColumn(key=\"status\", header=\"Status\"),\n    ],\n    rows=\"{{ items }}\",\n    searchable=True,\n)"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Patterns",
     "code": "from prefab_ui.components import (\n    Badge,\n    Card,\n    CardDescription,\n    CardHeader,\n    CardTitle,\n    ForEach,\n    Row,\n)\n\nwith ForEach(\"users\"):\n    with Card():\n        with CardHeader():\n            with Row(gap=2, css_class=\"items-center\"):\n                CardTitle(\"{{ name }}\")\n                Badge(\"{{ role }}\", variant=\"secondary\")\n            CardDescription(\"{{ email }}\")"
   },
@@ -1055,22 +1055,22 @@
     "code": "with Row(gap=2):\n    with ForEach(\"tags\"):\n        Badge(\"{{ _item }}\", variant=\"outline\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Patterns",
     "code": "from prefab_ui.components import Tab, Tabs, Text\n\nwith Tabs(default_value=\"active\"):\n    with Tab(\"Active\", value=\"active\"):\n        Text(\"Active items go here\")\n    with Tab(\"Archived\", value=\"archived\"):\n        Text(\"Archived items go here\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Patterns",
     "code": "from prefab_ui.components import Accordion, AccordionItem, Text\n\nwith Accordion():\n    with AccordionItem(\"Section 1\", value=\"s1\"):\n        Text(\"Content for section 1\")\n    with AccordionItem(\"Section 2\", value=\"s2\"):\n        Text(\"Content for section 2\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Patterns",
     "code": "from prefab_ui.components import Button, Column, Page, Pages, Row, Text\nfrom prefab_ui.actions import SetState\n\nwith Column(gap=4):\n    with Pages(name=\"step\", default_value=\"setup\"):\n        with Page(\"Setup\", value=\"setup\"):\n            Text(\"Configure your settings\")\n            Button(\"Next\", on_click=SetState(\"step\", \"review\"))\n        with Page(\"Review\", value=\"review\"):\n            Text(\"Review your choices\")\n            Button(\"Next\", on_click=SetState(\"step\", \"complete\"))\n        with Page(\"Complete\", value=\"complete\"):\n            Text(\"All done!\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Patterns",
     "code": "from prefab_ui.components import Column, Progress, Text\n\nwith Column(gap=2):\n    Text(\"Processing: {{ progress }}%\")\n    Progress(value=\"{{ progress }}\")"
   },
@@ -1190,12 +1190,12 @@
     "code": "Button(\"Share context\", on_click=UpdateContext(\n    \"The user selected {{ selectedItem }}.\"\n))"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Patterns",
     "code": "from prefab_ui.components import Button, Column, Input, Label\nfrom prefab_ui import ToolCall\n\nwith Column(gap=3):\n    Label(\"Name\")\n    Input(name=\"name\", placeholder=\"Your name\")\n    Label(\"Email\")\n    Input(name=\"email\", input_type=\"email\", placeholder=\"you@example.com\")\n    Button(\"Submit\", on_click=ToolCall(\n        \"create_user\",\n        arguments={\"name\": \"{{ name }}\", \"email\": \"{{ email }}\"},\n    ))"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Patterns",
     "code": "from pydantic import BaseModel, Field\nfrom prefab_ui.components import Form\nfrom prefab_ui import ToolCall\n\nclass ContactInfo(BaseModel):\n    name: str = Field(title=\"Full Name\", min_length=1)\n    email: str\n    message: str = Field(\n        description=\"Your message\",\n        json_schema_extra={\"ui\": {\"type\": \"textarea\", \"rows\": 4}},\n    )\n\nForm.from_model(ContactInfo, on_submit=ToolCall(\"submit_contact\"))"
   },
@@ -1220,32 +1220,32 @@
     "code": "from pydantic import BaseModel, Field\nfrom prefab_ui.components import Form\nfrom prefab_ui import ToolCall, ShowToast\n\nclass Contact(BaseModel):\n    name: str = Field(min_length=1)\n    email: str\n\nForm.from_model(\n    Contact,\n    on_submit=ToolCall(\n        \"create_contact\",\n        on_error=ShowToast(\"Could not save: {{ $error }}\", variant=\"error\"),\n    ),\n)"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Patterns",
     "code": "from prefab_ui.components import Column, Input, Text\n\nwith Column(gap=3):\n    Input(name=\"name\", placeholder=\"Type your name...\")\n    Text(\"Hello, {{ name }}!\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Patterns",
     "code": "from prefab_ui.components import Alert, AlertTitle, Button, Column\nfrom prefab_ui import ToggleState\n\nwith Column(gap=2):\n    Button(\"Toggle Details\", variant=\"outline\", on_click=ToggleState(\"showDetails\"))\n    with Alert(visible_when=\"showDetails\"):\n        AlertTitle(\"Here are the hidden details!\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Patterns",
     "code": "from prefab_ui.components import Button, Column, DataTable, DataTableColumn, Input\nfrom prefab_ui import ToolCall\n\nwith Column(gap=3):\n    Input(name=\"search\", placeholder=\"Search users...\")\n    Button(\"Search\", on_click=ToolCall(\n        \"find_users\",\n        arguments={\"query\": \"{{ search }}\"},\n        result_key=\"results\",\n    ))\n    DataTable(\n        columns=[\n            DataTableColumn(key=\"name\", header=\"Name\", sortable=True),\n            DataTableColumn(key=\"email\", header=\"Email\"),\n        ],\n        rows=\"{{ results }}\",\n        searchable=True,\n    )"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Patterns",
     "code": "from prefab_ui.components import (\n    Button,\n    Card,\n    CardDescription,\n    CardHeader,\n    CardTitle,\n    Column,\n    ForEach,\n    Input,\n)\nfrom prefab_ui import ToolCall\n\nwith Column(gap=3):\n    Input(name=\"q\", placeholder=\"Search products...\")\n    Button(\"Search\", on_click=ToolCall(\n        \"search_products\",\n        arguments={\"query\": \"{{ q }}\"},\n        result_key=\"products\",\n    ))\n    with ForEach(\"products\"):\n        with Card():\n            with CardHeader():\n                CardTitle(\"{{ name }}\")\n                CardDescription(\"{{ description }}\")"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Patterns",
     "code": "from prefab_ui.components import Button\nfrom prefab_ui import ToolCall, SetState, ShowToast\n\nButton(\"Process\", on_click=[\n    SetState(\"processing\", True),\n    ToolCall(\n        \"run_analysis\",\n        arguments={\"data\": \"{{ dataset }}\"},\n        on_success=ShowToast(\"Analysis complete!\", variant=\"success\"),\n        on_error=ShowToast(\"{{ $error }}\", variant=\"error\"),\n    ),\n    SetState(\"processing\", False),\n])"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "Patterns",
     "code": "from prefab_ui.components import Button\nfrom prefab_ui import ToolCall, ShowToast\n\nButton(\"Delete\", variant=\"destructive\", on_click=ToolCall(\n    \"delete_item\",\n    arguments={\"id\": \"{{ item_id }}\"},\n    on_error=ShowToast(\"{{ $error }}\", variant=\"error\"),\n))"
   },
@@ -1300,7 +1300,7 @@
     "code": "from prefab_ui import Define, Use, UIResponse\nfrom prefab_ui.components import (\n    Card, CardHeader, CardTitle, CardDescription,\n    Column, ForEach, Heading,\n)\n\nwith Define(\"project-card\") as project_card:\n    with Card():\n        with CardHeader():\n            CardTitle(\"{{ name }}\")\n            CardDescription(\"{{ description }}\")\n\nwith Column(gap=4) as view:\n    Heading(\"Featured\")\n    Use(\"project-card\", name=\"Prefab\", description=\"The agentic frontend framework\")\n\n    Heading(\"All Projects\")\n    with ForEach(\"projects\"):\n        Use(\"project-card\")\n\nUIResponse(\n    view=view,\n    defs=[project_card],\n    data={\"projects\": [\n        {\"name\": \"Alpha\", \"description\": \"First project\"},\n        {\"name\": \"Beta\", \"description\": \"Second project\"},\n    ]},\n)"
   },
   {
-    "title": "Python",
+    "title": "Python icon=\"python\"",
     "category": "General",
     "code": "from prefab_ui.components import Card, CardContent, Column, H3, Muted, Input, Badge, Row\n\nset_initial_state(name=\"world\")\n\nwith Card():\n    with CardContent():\n        with Column(gap=3):\n            H3(\"Hello, {{ name }}!\")\n            Muted(\"Type below and watch this update in real time.\")\n            Input(name=\"name\", placeholder=\"Your name...\")\n            with Row(gap=2):\n                Badge(\"{{ name }}\", variant=\"default\")\n                Badge(\"Prefab\", variant=\"secondary\")"
   }


### PR DESCRIPTION
The build pipeline now auto-injects `icon="python"` on Python code blocks and `icon="brackets-curly"` on Protocol blocks, so every ComponentPreview gets tab icons without authors needing to specify them.

Also fixes a hover issue where the Python/Protocol tab buttons showed their hover state when the mouse was anywhere over the preview card. The Mintlify `<Card>` component adds a Tailwind `group` class, which caused all `group-hover:` styles on descendant tabs to activate on any card hover. The ComponentPreview now strips that class on mount.