### PR TITLE
Add set_initial_state as a real public API

### DIFF
--- a/docs/_preview-build/render_previews.py
+++ b/docs/_preview-build/render_previews.py
@@ -77,14 +77,12 @@ def _execute_and_serialize(
         Component,
         ContainerComponent,
         _component_stack,
+        clear_initial_state,
+        get_initial_state,
     )
 
     _component_stack.set(None)
-
-    initial_state: dict[str, Any] = {}
-
-    def set_initial_state(**kwargs: Any) -> None:
-        initial_state.update(kwargs)
+    clear_initial_state()
 
     created: list[Component] = []
     original = Component.model_post_init
@@ -98,7 +96,6 @@ def _execute_and_serialize(
         ns: dict[str, object] = {}
         if shared_ns:
             ns.update(shared_ns)
-        ns["set_initial_state"] = set_initial_state
         exec(source, ns)  # noqa: S102
         if shared_ns is not None:
             for k, v in ns.items():
@@ -123,6 +120,7 @@ def _execute_and_serialize(
     tree = roots[0].to_json()
 
     envelope: dict[str, Any] = {"view": tree}
+    initial_state = get_initial_state()
     if initial_state:
         envelope["state"] = initial_state
 

--- a/src/prefab_ui/components/__init__.py
+++ b/src/prefab_ui/components/__init__.py
@@ -8,7 +8,13 @@ from this single package::
 
 from prefab_ui.components.alert import Alert, AlertDescription, AlertTitle
 from prefab_ui.components.badge import Badge
-from prefab_ui.components.base import Component, ContainerComponent
+from prefab_ui.components.base import (
+    Component,
+    ContainerComponent,
+    clear_initial_state,
+    get_initial_state,
+    set_initial_state,
+)
 from prefab_ui.components.button import Button
 from prefab_ui.components.calendar import Calendar
 from prefab_ui.components.chart import (
@@ -177,4 +183,7 @@ __all__ = [
     "Text",
     "Textarea",
     "Tooltip",
+    "clear_initial_state",
+    "get_initial_state",
+    "set_initial_state",
 ]

--- a/src/prefab_ui/components/base.py
+++ b/src/prefab_ui/components/base.py
@@ -14,6 +14,38 @@ _component_stack: ContextVar[list[ContainerComponent] | None] = ContextVar(
     "_component_stack", default=None
 )
 
+_initial_state: ContextVar[dict[str, Any] | None] = ContextVar(
+    "_initial_state", default=None
+)
+
+
+def set_initial_state(**kwargs: Any) -> None:
+    """Declare initial client-side state for the current app.
+
+    Called alongside component construction to define the starting
+    values that templates like ``{{ name }}`` resolve against::
+
+        set_initial_state(name="world")
+
+        with Card():
+            H3("Hello, {{ name }}!")
+    """
+    current = _initial_state.get()
+    if current is None:
+        current = {}
+        _initial_state.set(current)
+    current.update(kwargs)
+
+
+def get_initial_state() -> dict[str, Any] | None:
+    """Retrieve state set by :func:`set_initial_state`, or ``None``."""
+    return _initial_state.get()
+
+
+def clear_initial_state() -> None:
+    """Reset the initial-state accumulator."""
+    _initial_state.set(None)
+
 
 # ── Gap / Align / Justify ──────────────────────────────────────────────
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -8,6 +8,7 @@ import pytest
 
 from prefab_ui.app import PROTOCOL_VERSION, PrefabApp
 from prefab_ui.components import Column, Heading, Text
+from prefab_ui.components.base import clear_initial_state, set_initial_state
 
 
 class TestPrefabAppToJson:
@@ -139,6 +140,40 @@ class TestPrefabAppCsp:
         )
         csp = app.csp()
         assert "https://cdn.example.com" in csp["script_domains"]
+
+
+class TestSetInitialState:
+    def setup_method(self):
+        clear_initial_state()
+
+    def teardown_method(self):
+        clear_initial_state()
+
+    def test_consumed_by_prefab_app(self):
+        set_initial_state(name="world")
+        app = PrefabApp(view=Text(content="hi"))
+        assert app.state == {"name": "world"}
+
+    def test_cleared_after_consumption(self):
+        set_initial_state(name="world")
+        PrefabApp()
+        app2 = PrefabApp()
+        assert app2.state is None
+
+    def test_explicit_state_overrides(self):
+        set_initial_state(name="world", count=0)
+        app = PrefabApp(state={"name": "Alice"})
+        assert app.state == {"name": "Alice", "count": 0}
+
+    def test_accumulates_across_calls(self):
+        set_initial_state(name="world")
+        set_initial_state(count=0)
+        app = PrefabApp()
+        assert app.state == {"name": "world", "count": 0}
+
+    def test_no_initial_state_means_none(self):
+        app = PrefabApp()
+        assert app.state is None
 
 
 class TestPrefabAppWireFormatIsolation:


### PR DESCRIPTION
`set_initial_state()` was used across 17 doc pages but only existed as a local function inside the doc build script's `exec()` namespace. Anyone installing `prefab-ui` from PyPI and following the docs would get a `NameError`.

Now it's a real ContextVar-backed function exported from `prefab_ui.components`. `PrefabApp` consumes and clears accumulated state on construction — explicit `state=` overrides accumulated values, accumulated values fill in gaps.