### PR TITLE
Pass NODE_AUTH_TOKEN to npm publish step

### DIFF
--- a/.github/workflows/publish-renderer.yml
+++ b/.github/workflows/publish-renderer.yml
@@ -50,3 +50,5 @@ jobs:
 
       - run: npm publish --access public --tag latest
         working-directory: renderer
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
The `setup-node` action with `registry-url` configures npm to authenticate via `NODE_AUTH_TOKEN`, but the env var was never passed to the publish step, causing a 404/auth failure.