### PR TITLE
Remove unnecessary NODE_AUTH_TOKEN from npm publish

### DIFF
--- a/.github/workflows/publish-renderer.yml
+++ b/.github/workflows/publish-renderer.yml
@@ -50,5 +50,3 @@ jobs:
 
       - run: npm publish --access public --tag latest
         working-directory: renderer
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Reverts an erroneous addition from #92. npm publish uses OIDC via `id-token: write`, no secret needed.