### PR TITLE
Move Examples above Client Interactivity in docs nav

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -65,6 +65,13 @@
             ]
           },
           {
+            "group": "Examples",
+            "pages": [
+              "examples/todo",
+              "examples/file-upload"
+            ]
+          },
+          {
             "group": "Client Interactivity",
             "pages": [
               "expressions/overview",
@@ -72,13 +79,6 @@
               "expressions/operators",
               "expressions/pipes",
               "expressions/context"
-            ]
-          },
-          {
-            "group": "Examples",
-            "pages": [
-              "examples/todo",
-              "examples/file-upload"
             ]
           },
           {


### PR DESCRIPTION
Examples are more immediately useful for new users scanning the left-hand nav than the Client Interactivity (expressions) section. This reorders them so Examples appears first, right after Running Prefab.