### PR TITLE
Rebuild renderer entry with v0.3.0 CDN URL

### DIFF
--- a/docs/renderer.js
+++ b/docs/renderer.js
@@ -1,1 +1,1 @@
-(function(){var base=window.location.hostname==="localhost"?"/":"https://cdn.jsdelivr.net/npm/@prefecthq/prefab-ui@0.0.0/dist/";window.__prefabReady=import(base+"_chunks/embed-DVX88IE0.mjs");})();
+(function(){var base=window.location.hostname==="localhost"?"/":"https://cdn.jsdelivr.net/npm/@prefecthq/prefab-ui@0.3.0/dist/";window.__prefabReady=import(base+"_chunks/embed-DNN8TWNC.mjs");})();


### PR DESCRIPTION
The merged PR built `docs/renderer.js` before the v0.3.0 tag existed, so the CDN URL pointed to `@0.0.0`. This rebuild picks up the tag automatically via `git describe --tags` and points to `@0.3.0` where the chunks are published.