### PR TITLE
Fix playground rendering as raw HTML on deployed docs

### DIFF
--- a/docs/playground.mdx
+++ b/docs/playground.mdx
@@ -11,9 +11,13 @@ export const PlaygroundFrame = () => {
   const [src, setSrc] = React.useState(null);
   React.useEffect(function () {
     var isLocal = location.hostname === "localhost" || location.hostname === "127.0.0.1";
-    setSrc(isLocal
+    var url = isLocal
       ? "/playground.html"
-      : "https://cdn.jsdelivr.net/npm/@prefecthq/prefab-ui@0.3.0/dist/playground.html");
+      : "https://cdn.jsdelivr.net/npm/@prefecthq/prefab-ui@0.3.0/dist/playground.html";
+    fetch(url).then(function(r) { return r.text(); }).then(function(html) {
+      var blob = new Blob([html], { type: "text/html" });
+      setSrc(URL.createObjectURL(blob));
+    });
     if (ref.current) {
       ref.current.style.height = "calc(100vh - 60px)";
     }


### PR DESCRIPTION
`mode: frame` wraps the page in a Mintlify-controlled iframe, which prevents the nested CDN iframe from rendering — the playground HTML shows up as escaped text instead. Switch to `mode: wide` (which is what the playground used before PR #125) and bump CDN URL to v0.3.0.