### PR TITLE
Reorganize docs sidebar nav

### DIFF
--- a/docs/actions/overview.mdx
+++ b/docs/actions/overview.mdx
@@ -1,5 +1,5 @@
 ---
-title: Actions
+title: Overview
 description: Connect UI interactions to server tools, state changes, and navigation.
 icon: bolt
 ---

--- a/docs/building-uis.mdx
+++ b/docs/building-uis.mdx
@@ -7,7 +7,7 @@ icon: hammer
 
 import { ComponentPreview } from '/snippets/component-preview.mdx'
 
-Prefab UIs are declarative. You describe *what* to render — a tree of components with properties — and the renderer handles the rest. The Python DSL compiles `with` statements into that component tree, which serializes to JSON, which a React renderer paints as a live interface. Your Python code runs once at build time to produce the tree; all interactivity after that happens client-side through [expressions](/expressions/overview) and [actions](/actions).
+Prefab UIs are declarative. You describe *what* to render — a tree of components with properties — and the renderer handles the rest. The Python DSL compiles `with` statements into that component tree, which serializes to JSON, which a React renderer paints as a live interface. Your Python code runs once at build time to produce the tree; all interactivity after that happens client-side through [expressions](/expressions/overview) and [actions](/actions/overview).
 
 This distinction between build time and render time matters throughout this page.
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -91,17 +91,23 @@
                 "group": "Layout",
                 "expanded": false,
                 "pages": [
-                  "components/container",
-                  "components/row",
                   "components/column",
-                  "components/grid",
+                  "components/container",
                   "components/dashboard-grid",
                   "components/div-span",
+                  "components/grid",
+                  "components/pages",
+                  "components/row",
+                  "components/slot"
+                ]
+              },
+              {
+                "group": "Control Flow",
+                "expanded": false,
+                "pages": [
                   "components/conditional",
                   "components/define-use",
-                  "components/foreach",
-                  "components/pages",
-                  "components/slot"
+                  "components/foreach"
                 ]
               },
               {
@@ -149,9 +155,9 @@
                 "group": "Charts",
                 "expanded": false,
                 "pages": [
+                  "components/area-chart",
                   "components/bar-chart",
                   "components/line-chart",
-                  "components/area-chart",
                   "components/pie-chart",
                   "components/radar-chart",
                   "components/radial-chart"
@@ -161,16 +167,21 @@
                 "group": "Actions",
                 "expanded": false,
                 "pages": [
-                  "actions",
-                  "actions/set-state",
-                  "actions/show-toast",
+                  "actions/overview",
+                  "actions/fetch",
                   "actions/open-file-picker",
                   "actions/open-link",
-                  "actions/fetch",
-                  "actions/call-tool",
-                  "actions/send-message",
-                  "actions/update-context",
-                  "actions/set-interval"
+                  "actions/set-interval",
+                  "actions/set-state",
+                  "actions/show-toast",
+                  {
+                    "group": "MCP",
+                    "pages": [
+                      "actions/call-tool",
+                      "actions/send-message",
+                      "actions/update-context"
+                    ]
+                  }
                 ]
               }
             ]
@@ -192,15 +203,22 @@
             "pages": [
               "protocol/column",
               "protocol/container",
-              "protocol/condition",
+              "protocol/dashboard",
+              "protocol/dashboard-item",
               "protocol/div",
-              "protocol/for-each",
               "protocol/grid",
               "protocol/page",
               "protocol/pages",
               "protocol/row",
               "protocol/slot",
               "protocol/span"
+            ]
+          },
+          {
+            "group": "Control Flow",
+            "pages": [
+              "protocol/condition",
+              "protocol/for-each"
             ]
           },
           {
@@ -278,13 +296,13 @@
           {
             "group": "Charts",
             "pages": [
-              "protocol/bar-chart",
-              "protocol/line-chart",
               "protocol/area-chart",
+              "protocol/bar-chart",
+              "protocol/chart-series",
+              "protocol/line-chart",
               "protocol/pie-chart",
               "protocol/radar-chart",
-              "protocol/radial-chart",
-              "protocol/chart-series"
+              "protocol/radial-chart"
             ]
           },
           {

--- a/docs/expressions/overview.mdx
+++ b/docs/expressions/overview.mdx
@@ -8,7 +8,7 @@ import { ComponentPreview } from '/snippets/component-preview.mdx'
 
 Prefab UIs aren't static. When a user clicks a button, drags a slider, or types into an input, the interface can respond instantly — updating text, toggling visibility, reformatting values, computing totals — all without waiting for a server call.
 
-This client-side interactivity is powered by a small expression language that runs inside the renderer. Expressions evaluate against the current [state](/components/state), and the UI re-renders whenever that state changes. Combined with [actions](/actions) that modify state in response to user interaction, this covers the common cases for reactive UIs: counters, toggles, conditional displays, formatted output, and form-driven content.
+This client-side interactivity is powered by a small expression language that runs inside the renderer. Expressions evaluate against the current [state](/components/state), and the UI re-renders whenever that state changes. Combined with [actions](/actions/overview) that modify state in response to user interaction, this covers the common cases for reactive UIs: counters, toggles, conditional displays, formatted output, and form-driven content.
 
 Try clicking the buttons in this counter — it works entirely in the browser, with no server involved:
 
@@ -100,7 +100,7 @@ Prefab splits interactive behavior into three layers, each with a clear scope:
 | Layer | Scope | Examples |
 |------|---------|----------|
 | **Expressions** | Compute display values | Arithmetic, formatting, conditional text, comparisons |
-| **[Actions](/actions)** | Mutate client state | SetState, ToggleState, ShowToast |
+| **[Actions](/actions/overview)** | Mutate client state | SetState, ToggleState, ShowToast |
 | **[CallTool](/actions/call-tool)** | Run server logic | Data fetching, business logic, complex transformations |
 
 If you find yourself wanting to write application logic inside a `{{ }}` template, that computation belongs in a CallTool instead.

--- a/docs/welcome.mdx
+++ b/docs/welcome.mdx
@@ -1649,7 +1649,7 @@ Prefab requires Python 3.10+.
   <Card title="Components" icon="cube" href="/components/button">
     35+ components: layout, typography, forms, data display, and interactive elements. Nest them with Python context managers.
   </Card>
-  <Card title="Actions" icon="bolt" href="/actions">
+  <Card title="Actions" icon="bolt" href="/actions/overview">
     Declarative interactivity — state updates, server calls, navigation, and toast notifications. Chain them with lifecycle callbacks.
   </Card>
   <Card title="Expressions" icon="lightbulb" href="/expressions/overview">


### PR DESCRIPTION
Alphabetizes all nav groups and splits the overloaded "Layout" section into spatial layout components and control flow logic.

- **Layout** (alphabetical): Column, Container, Dashboard, Div & Span, Grid, Pages, Row, Slot
- **Control Flow** (new): Conditional, Define & Use, ForEach
- **Charts**: alphabetized
- **Actions**: alphabetized, with Call Tool / Send Message / Update Context grouped under an **MCP** subgroup
- Actions overview moved from `docs/actions.mdx` → `docs/actions/overview.mdx` so it shows as "Overview" instead of confusingly repeating the group name