### PR TITLE
Snap slider values to step increments on initialization

### DIFF
--- a/src/prefab_ui/components/slider.py
+++ b/src/prefab_ui/components/slider.py
@@ -111,6 +111,19 @@ class Slider(StatefulMixin, Component):
         description="Action(s) to execute when value changes",
     )
 
+    def model_post_init(self, __context: Any) -> None:
+        if self.step is not None and self.value is not None:
+            if isinstance(self.value, list):
+                self.value = [self._snap(v) for v in self.value]
+            else:
+                self.value = self._snap(self.value)
+        super().model_post_init(__context)
+
+    def _snap(self, v: float) -> float:
+        assert self.step is not None
+        snapped = round((v - self.min) / self.step) * self.step + self.min
+        return max(self.min, min(self.max, snapped))
+
     def to_json(self) -> dict[str, Any]:
         d = super().to_json()
         if not self.range:

--- a/tests/components/test_slider.py
+++ b/tests/components/test_slider.py
@@ -94,3 +94,23 @@ def test_slider_all_new_props():
     assert j["indicatorClass"] == "rounded"
     assert j["orientation"] == "vertical"
     assert j["handleStyle"] == "bar"
+
+
+def test_slider_snaps_off_step_initial_value():
+    s = Slider(min=0, max=10, step=1, value=1.2)
+    assert s.value == 1
+
+
+def test_slider_snaps_off_step_range_values():
+    s = Slider(min=0, max=100, step=10, value=[12, 87], range=True)
+    assert s.value == [10, 90]
+
+
+def test_slider_on_step_value_unchanged():
+    s = Slider(min=0, max=10, step=2, value=4)
+    assert s.value == 4
+
+
+def test_slider_snap_clamps_to_max():
+    s = Slider(min=0, max=10, step=3, value=10.5)
+    assert s.value == 10  # round(10.5/3)*3 = round(3.5)*3 = 4*3 = 12, clamped to max=10


### PR DESCRIPTION
## Summary
This PR adds automatic value snapping to the Slider component when a `step` is defined. Initial values that don't align with the step increment are now automatically rounded to the nearest valid step value.

## Key Changes
- Added `model_post_init` hook to snap initial slider values to step increments during component initialization
- Implemented `_snap()` helper method that:
  - Rounds values to the nearest multiple of the step size
  - Clamps the result to the min/max bounds
  - Handles both single values and range values (lists)
- Added comprehensive test coverage for snapping behavior:
  - Single values that need snapping
  - Range values (both elements snapped independently)
  - Values already aligned with step (unchanged)
  - Edge case where snapped value exceeds max (properly clamped)

## Implementation Details
The snapping algorithm uses the formula: `round((v - min) / step) * step + min`, which correctly handles arbitrary min/max/step combinations. The result is then clamped to ensure it stays within bounds, handling cases where rounding might push a value outside the valid range.

https://claude.ai/code/session_011kWGTNzFp2ZQVRtzhxubnf