### PR TITLE
Add workflow to auto-update release branch on publish

### DIFF
--- a/.github/workflows/update-release-branch.yml
+++ b/.github/workflows/update-release-branch.yml
@@ -1,0 +1,32 @@
+# Fast-forwards the `release` branch to the tagged commit on each release.
+#
+# Mintlify builds docs from `release`, so this keeps published docs in sync
+# with what's actually released. The renderer CDN (`@latest`) updates at the
+# same time via publish-renderer.yml.
+name: Update release branch
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  update-release-branch:
+    name: "Fast-forward release branch"
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Fast-forward release branch to tagged commit
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout release || git checkout -b release
+          git merge --ff-only "${{ github.ref_name }}"
+          git push origin release


### PR DESCRIPTION
## Summary
This PR adds a GitHub Actions workflow that automatically fast-forwards the `release` branch to match the tagged commit whenever a new release is published. This keeps the documentation source in sync with actual releases.

## Key Changes
- Added `.github/workflows/update-release-branch.yml` workflow that:
  - Triggers on release publication events
  - Checks out the repository with full history (`fetch-depth: 0`)
  - Creates or switches to the `release` branch
  - Fast-forwards the `release` branch to the tagged release commit
  - Pushes the updated branch to origin

## Implementation Details
- Uses `git merge --ff-only` to ensure only fast-forward merges (no merge commits)
- Configures git with the `github-actions[bot]` identity for commits
- Requires `contents: write` permission to push branch updates
- Completes within 2-minute timeout
- Keeps Mintlify documentation builds and renderer CDN (`@latest`) in sync with releases

https://claude.ai/code/session_01SZBPyicqY8NFua5fuEECeA

<!-- mintlify-editor-comments:start -->
Mintlify
---
0 threads from 0 users in Mintlify

- No unresolved comments
<!-- mintlify-editor-comments:end -->

<!-- mintlify-comment-->

<a href="https://dashboard.mintlify.com/prefect-bd373955/prefab/editor/claude%2Ffix-doc-rendering-JiTLT?source=pr_comment" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://d3gk2c5xim1je2.cloudfront.net/assets/open-mintlify-editor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://d3gk2c5xim1je2.cloudfront.net/assets/open-mintlify-editor-light.svg"><img src="https://d3gk2c5xim1je2.cloudfront.net/assets/open-mintlify-editor-light.svg" alt="Open in Mintlify Editor"></picture></a>

<!-- /mintlify-comment -->