### PR TITLE
Default slider step to (max - min) / 100

### DIFF
--- a/renderer/src/ui/slider.tsx
+++ b/renderer/src/ui/slider.tsx
@@ -29,6 +29,7 @@ function Slider({
   value,
   min = 0,
   max = 100,
+  step,
   variant,
   indicatorClassName,
   handleStyle,
@@ -38,6 +39,7 @@ function Slider({
     indicatorClassName?: string;
     handleStyle?: "circle" | "bar";
   }) {
+  const resolvedStep = step ?? (max - min) / 100
   const _values = React.useMemo(
     () =>
       Array.isArray(value)
@@ -55,6 +57,7 @@ function Slider({
       value={value}
       min={min}
       max={max}
+      step={resolvedStep}
       className={cn(
         "cn-slider relative flex w-full cursor-pointer touch-none items-center select-none data-disabled:cursor-not-allowed data-disabled:opacity-50 data-vertical:h-full data-vertical:w-auto data-vertical:flex-col",
         className


### PR DESCRIPTION
Radix UI's Slider defaults `step` to `1`, which means a slider with `min=0, max=1` only allows selecting 0 or 1. The renderer now computes `step = (max - min) / 100` when no explicit step is provided, giving 100 discrete positions regardless of range. This fixes the issue at the renderer level so it works for both Python-generated and hand-written JSON.