### PR TITLE
PyPI downloads example: total chart, direct line, in-memory cache

### DIFF
--- a/examples/pypi-downloads/api_server.py
+++ b/examples/pypi-downloads/api_server.py
@@ -1,14 +1,17 @@
 """FastAPI server for the PyPI downloads dashboard."""
 
-import csv
 import datetime
-import json
 
-from dashboard import downloads_chart, downloads_table, gainers_losers
-from data import load_data
+from dashboard import (
+    downloads_chart,
+    downloads_table,
+    gainers_losers,
+    total_downloads_chart,
+)
+from data import load_data, load_total_data
 from fastapi import FastAPI
 from fastapi.responses import HTMLResponse
-from query import CSV_PATH, META_PATH, run_query
+from query import run_query, run_total_query
 
 from prefab_ui.actions import Fetch, SetState, ShowToast
 from prefab_ui.app import PrefabApp
@@ -16,110 +19,151 @@ from prefab_ui.components import (
     Button,
     Card,
     CardContent,
+    Checkbox,
     Column,
     Form,
     Input,
     Row,
+    Separator,
     Slot,
     Text,
 )
+from prefab_ui.components.base import insert
 
 app = FastAPI()
 
+_cache: dict = {}
 
-def _dashboard_view(package_name: str, d: dict) -> dict:
-    """Build the dashboard content as a component tree.
 
-    Args:
-        package_name: The PyPI package name shown in the header.
-        d: Data dict as returned by ``load_data``, containing keys
-            ``chart_data``, ``packages``, ``prev_week``, ``latest_week``,
-            ``top_gainers``, ``top_losers``, and ``table_rows``.
-
-    Returns:
-        A JSON-serializable component tree for the Prefab renderer.
-    """
+def _dashboard_view(
+    package_name: str,
+    total_data: dict,
+    dep_data: dict,
+    show_direct: bool = True,
+) -> dict:
+    """Build the dashboard content as a component tree."""
     with Column(gap=4) as content:
-        downloads_chart(package_name, d["chart_data"], d["packages"])
-        Text(
-            f"Week over Week ({d['prev_week']} vs {d['latest_week']})",
-            css_class="text-lg font-semibold",
-        )
-        gainers_losers(d["top_gainers"], d["top_losers"])
-        downloads_table(d["table_rows"], d["latest_week"], d["prev_week"])
+        total_downloads_chart(package_name, total_data["chart_data"])
+        if dep_data["packages"]:
+            series = dep_data["packages"]
+            if not show_direct:
+                series = [p for p in series if p != "direct"]
+            downloads_chart(package_name, dep_data["chart_data"], series)
+            Text(
+                f"Week over Week ({dep_data['prev_week']} vs {dep_data['latest_week']})",
+                css_class="text-lg font-semibold",
+            )
+            gainers_losers(dep_data["top_gainers"], dep_data["top_losers"])
+            downloads_table(
+                dep_data["table_rows"], dep_data["latest_week"], dep_data["prev_week"]
+            )
     return content.to_json()
 
 
-@app.get("/api/data")
-def api_data():
-    """Return current dashboard data as JSON.
+def _render_from_cache(show_direct: bool = True) -> dict | None:
+    if not _cache.get("total_rows"):
+        return None
+    package_name = _cache["package_name"]
+    total_data = load_total_data(_cache["total_rows"])
+    dep_rows = _cache.get("dep_rows", [])
+    dep_data = (
+        load_data(dep_rows, total_rows=_cache["total_rows"])
+        if dep_rows
+        else _empty_dep_data()
+    )
+    return _dashboard_view(package_name, total_data, dep_data, show_direct=show_direct)
 
-    Reads the cached CSV and metadata from disk and returns a rendered
-    component tree without querying ClickHouse.
 
-    Returns:
-        A JSON-serializable component tree for the Prefab renderer.
-    """
-    with open(META_PATH) as f:
-        meta = json.load(f)
-    return _dashboard_view(meta["package_name"], load_data())
+def _default_dates() -> tuple[str, str]:
+    yesterday = datetime.date.today() - datetime.timedelta(days=1)
+    six_months_ago = yesterday - datetime.timedelta(weeks=26)
+    return six_months_ago.isoformat(), yesterday.isoformat()
 
 
 @app.post("/api/fetch")
 def api_fetch(body: dict):
-    """Fetch fresh data from ClickHouse and return updated dashboard data.
-
-    Args:
-        body: JSON request body with optional keys ``package_name``,
-            ``min_date``, and ``max_date``. Defaults to ``"fastmcp"``
-            and the last 8 weeks if not provided.
-
-    Returns:
-        A JSON-serializable component tree for the Prefab renderer.
-    """
+    """Fetch fresh data from ClickHouse and return updated dashboard."""
     package_name = (body.get("package_name") or "fastmcp").strip()
+    show_direct = body.get("show_direct", True)
     min_date = body.get("min_date") or ""
     max_date = body.get("max_date") or ""
 
-    yesterday = datetime.date.today() - datetime.timedelta(days=1)
-    eight_weeks_ago = yesterday - datetime.timedelta(weeks=8)
+    default_min, default_max = _default_dates()
 
-    rows = run_query(
+    total_rows = run_total_query(
         package_name=package_name,
-        min_date=min_date or eight_weeks_ago.isoformat(),
-        max_date=max_date or yesterday.isoformat(),
+        min_date=min_date or default_min,
+        max_date=max_date or default_max,
     )
-    if rows:
-        with open(CSV_PATH, "w", newline="") as f:
-            writer = csv.DictWriter(f, fieldnames=rows[0].keys())
-            writer.writeheader()
-            writer.writerows(rows)
 
-        with open(META_PATH, "w") as f:
-            json.dump({"package_name": package_name}, f)
+    if not total_rows:
+        _cache.clear()
+        return None
 
-    d = load_data(rows if rows else None)
-    return _dashboard_view(package_name, d)
+    dep_rows = run_query(
+        package_name=package_name,
+        min_date=min_date or default_min,
+        max_date=max_date or default_max,
+    )
+
+    _cache.update(
+        package_name=package_name,
+        total_rows=total_rows,
+        dep_rows=dep_rows,
+    )
+
+    total_data = load_total_data(total_rows)
+    dep_data = (
+        load_data(dep_rows, total_rows=total_rows) if dep_rows else _empty_dep_data()
+    )
+    return _dashboard_view(package_name, total_data, dep_data, show_direct=show_direct)
+
+
+@app.post("/api/render")
+def api_render(body: dict):
+    """Re-render dashboard from cache (no ClickHouse query)."""
+    show_direct = body.get("show_direct", True)
+    return _render_from_cache(show_direct=show_direct)
+
+
+def _empty_dep_data() -> dict:
+    return {
+        "chart_data": [],
+        "packages": [],
+        "table_rows": [],
+        "latest_week": "",
+        "prev_week": None,
+        "top_gainers": [],
+        "top_losers": [],
+    }
 
 
 @app.get("/", response_class=HTMLResponse)
 def page():
-    """Serve the full HTML page for the PyPI downloads dashboard.
+    """Serve the full HTML page for the PyPI downloads dashboard."""
+    package_name = _cache.get("package_name", "fastmcp")
+    dashboard_content = _render_from_cache()
 
-    Loads cached data, builds the search form and dashboard layout,
-    and returns a complete ``PrefabApp`` HTML response.
-
-    Returns:
-        An HTMLResponse containing the rendered single-page application.
-    """
-    with open(META_PATH) as f:
-        meta = json.load(f)
-    package_name = meta["package_name"]
-
-    d = load_data()
-    dashboard_content = _dashboard_view(package_name, d)
+    pkg_input = Input(
+        name="package_name",
+        value=package_name,
+        placeholder="e.g. fastmcp",
+        on_change=SetState("package_name", "{{ $event }}"),
+        defer=True,
+    )
 
     with Column(gap=4, css_class="p-6") as view:
+        with Column(gap=1):
+            Text(
+                f"PyPI Downloads: {pkg_input.rx}",
+                css_class="text-3xl font-bold tracking-tight",
+            )
+            Text(
+                f"Total downloads and top dependents for {pkg_input.rx},"
+                " powered by ClickHouse.",
+                css_class="text-muted-foreground",
+            )
+        Separator()
         with Card():
             with CardContent():
                 with Form(
@@ -127,6 +171,7 @@ def page():
                         "/api/fetch",
                         body={
                             "package_name": "{{ package_name }}",
+                            "show_direct": "{{ show_direct }}",
                             "min_date": "{{ min_date }}",
                             "max_date": "{{ max_date }}",
                         },
@@ -141,12 +186,7 @@ def page():
                     with Row(gap=4, align="end"):
                         with Column(gap=1, css_class="flex-[3]"):
                             Text("Package", css_class="text-sm font-medium")
-                            Input(
-                                name="package_name",
-                                value=package_name,
-                                placeholder="e.g. fastmcp",
-                                on_change=SetState("package_name", "{{ $event }}"),
-                            )
+                            insert(pkg_input)
                         with Column(gap=1):
                             Text("Start date", css_class="text-sm font-medium")
                             Input(
@@ -164,6 +204,19 @@ def page():
                                 on_change=SetState("max_date", "{{ $event }}"),
                             )
                         Button("Fetch")
+                    Checkbox(
+                        name="show_direct",
+                        label="Show direct downloads",
+                        checked=True,
+                        on_change=[
+                            SetState("show_direct", "{{ $event }}"),
+                            Fetch.post(
+                                "/api/render",
+                                body={"show_direct": "{{ $event }}"},
+                                result_key="dashboard_content",
+                            ),
+                        ],
+                    )
         Slot("dashboard_content")
 
     return HTMLResponse(
@@ -174,6 +227,7 @@ def page():
                 "package_name": package_name,
                 "min_date": "",
                 "max_date": "",
+                "show_direct": True,
                 "dashboard_content": dashboard_content,
             },
         ).html()

--- a/examples/pypi-downloads/dashboard.py
+++ b/examples/pypi-downloads/dashboard.py
@@ -15,6 +15,32 @@ from prefab_ui.components import (
 from prefab_ui.components.charts import ChartSeries, LineChart
 
 
+def total_downloads_chart(package_name: str, chart_data: list[dict]):
+    """Render a line chart of the package's own weekly downloads.
+
+    Args:
+        package_name: The PyPI package name.
+        chart_data: List of dicts with ``"week"`` and ``"downloads"`` keys.
+
+    Returns:
+        A ``Card`` component containing the rendered line chart.
+    """
+    with Card() as card:
+        with CardHeader():
+            CardTitle(f"{package_name} - Weekly Downloads")
+        with CardContent():
+            LineChart(
+                data=chart_data,
+                series=[ChartSeries(data_key="downloads", label=package_name)],
+                x_axis="week",
+                height=300,
+                curve="smooth",
+                show_tooltip=True,
+                show_grid=True,
+            )
+    return card
+
+
 def downloads_chart(package_name: str, chart_data, series_keys, **line_chart_kwargs):
     """Render a line chart of weekly downloads for a package's dependents.
 

--- a/examples/pypi-downloads/pyproject.toml
+++ b/examples/pypi-downloads/pyproject.toml
@@ -4,9 +4,4 @@ version = "0.1.0"
 description = "Dashboard tracking weekly PyPI downloads for the top dependents of a given package"
 readme = "README.md"
 requires-python = ">=3.12"
-dependencies = [
-    "fastapi[standard]",
-    "fastmcp>=3.0.0",
-    "prefab-ui @ git+https://github.com/prefecthq/prefab.git@main",
-    "requests",
-]
+dependencies = ["fastapi[standard]", "fastmcp>=3.0.0", "prefab-ui", "requests"]

--- a/examples/pypi-downloads/query.py
+++ b/examples/pypi-downloads/query.py
@@ -1,15 +1,8 @@
-# /// script
-# requires-python = ">=3.10"
-# dependencies = ["requests"]
-# ///
-"""Run a query against the ClickHouse SQL Playground (sql.clickhouse.com)."""
+"""Run queries against the ClickHouse SQL Playground (sql.clickhouse.com)."""
 
 import csv
-import datetime
 import io
-import json
 import os
-import sys
 
 import requests
 
@@ -17,32 +10,18 @@ CLICKHOUSE_URL = "https://sql-clickhouse.clickhouse.com"
 CLICKHOUSE_USER = "demo"
 CLICKHOUSE_PASSWORD = ""
 
-QUERY_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "query.sql")
+_DIR = os.path.dirname(os.path.abspath(__file__))
+QUERY_PATH = os.path.join(_DIR, "query.sql")
+QUERY_TOTAL_PATH = os.path.join(_DIR, "query_total.sql")
 
 
-def run_query(package_name="fastmcp", min_date="2026-01-01", max_date="2026-02-21"):
-    """Run a parameterized query against the ClickHouse SQL Playground.
-
-    Reads the SQL from query.sql and executes it with the given parameters,
-    returning the results as a list of dictionaries.
-
-    Args:
-        package_name: PyPI package name to find dependents for.
-        min_date: Start date for the query range (inclusive), ISO format.
-        max_date: End date for the query range (exclusive), ISO format.
-
-    Returns:
-        A list of dicts with keys 'week', 'package', and 'downloads'.
-
-    Raises:
-        requests.HTTPError: If the ClickHouse API returns an error response.
-    """
+def _run(sql_path: str, package_name: str, min_date: str, max_date: str) -> list[dict]:
     params = {
         "param_package_name": package_name,
         "param_min_date": min_date,
         "param_max_date": max_date,
     }
-    with open(QUERY_PATH) as f:
+    with open(sql_path) as f:
         query = f.read()
 
     response = requests.post(
@@ -55,45 +34,20 @@ def run_query(package_name="fastmcp", min_date="2026-01-01", max_date="2026-02-2
     response.raise_for_status()
 
     reader = csv.DictReader(io.StringIO(response.text))
-    rows = list(reader)
-    return rows
+    return list(reader)
 
 
-_DIR = os.path.dirname(os.path.abspath(__file__))
-CSV_PATH = os.path.join(_DIR, "downloads", "downloads.csv")
-META_PATH = os.path.join(_DIR, "downloads", "downloads.meta.json")
+def run_query(package_name: str, min_date: str, max_date: str) -> list[dict]:
+    """Query weekly downloads for the top dependents of a package.
 
-
-def main():
-    """Run the query and write results to downloads.csv.
-
-    Args can be passed via the command line:
-        argv[1]: Package name (default: 'fastmcp').
-        argv[2]: Min date, ISO format (default: 8 weeks ago).
-        argv[3]: Max date, ISO format (default: yesterday).
+    Returns a list of dicts with keys 'week', 'package', and 'downloads'.
     """
-    package_name = sys.argv[1] if len(sys.argv) > 1 else "fastmcp"
-    yesterday = datetime.date.today() - datetime.timedelta(days=1)
-    eight_weeks_ago = yesterday - datetime.timedelta(weeks=8)
-    min_date = sys.argv[2] if len(sys.argv) > 2 else eight_weeks_ago.isoformat()
-    max_date = sys.argv[3] if len(sys.argv) > 3 else yesterday.isoformat()
-
-    rows = run_query(package_name, min_date, max_date)
-
-    if not rows:
-        print("No results.")
-        return
-
-    with open(CSV_PATH, "w", newline="") as f:
-        writer = csv.DictWriter(f, fieldnames=rows[0].keys())
-        writer.writeheader()
-        writer.writerows(rows)
-
-    with open(META_PATH, "w") as f:
-        json.dump({"package_name": package_name}, f)
-
-    print(f"{len(rows)} rows written to {CSV_PATH}")
+    return _run(QUERY_PATH, package_name, min_date, max_date)
 
 
-if __name__ == "__main__":
-    main()
+def run_total_query(package_name: str, min_date: str, max_date: str) -> list[dict]:
+    """Query weekly total downloads for a package itself.
+
+    Returns a list of dicts with keys 'week' and 'downloads'.
+    """
+    return _run(QUERY_TOTAL_PATH, package_name, min_date, max_date)

--- a/examples/pypi-downloads/query_total.sql
+++ b/examples/pypi-downloads/query_total.sql
@@ -1,0 +1,9 @@
+SELECT
+    {max_date:String}::Date32 - toIntervalDay(dateDiff('day', date, {max_date:String}::Date32) DIV 7 * 7 + 7) AS week,
+    sum(count) AS downloads
+FROM pypi.pypi_downloads_per_day
+WHERE project = {package_name:String}
+    AND date >= {min_date:String}::Date32
+    AND date < {max_date:String}::Date32
+GROUP BY week
+ORDER BY week


### PR DESCRIPTION
The PyPI downloads example previously required pre-fetching data to CSV before the server could start, and only showed dependent package downloads. This rework makes the example self-contained and more informative.

The dashboard now shows the package's own total weekly downloads in a chart above the dependents chart. A "direct" line in the dependents chart estimates downloads not attributable to any tracked dependent (total minus sum of top-20 dependents). A checkbox toggles the direct line instantly via a lightweight `/api/render` endpoint that re-renders from an in-memory cache without re-querying ClickHouse.

The page header is reactive — it updates as you type in the package name field, using the `defer`/`insert` pattern:

```python
pkg_input = Input(name="package_name", value="fastmcp", defer=True)

with Column():
    Text(f"PyPI Downloads: {pkg_input.rx}")  # reactive header
    with Form(...):
        insert(pkg_input)  # render the input here
```

All file-based caching (CSV, meta JSON) is replaced with a simple in-memory dict, so the server starts clean and fetches data on demand.