### PR TITLE
Fix playground link redirect to use /docs/playground in production

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,4 +116,4 @@ Button("Save", on_click=[
 
 ## Documentation
 
-Full documentation at [prefab.prefect.io](https://prefab.prefect.io), including an interactive [playground](https://prefab.prefect.io/playground) where you can try components live.
+Full documentation at [prefab.prefect.io](https://prefab.prefect.io), including an interactive [playground](https://prefab.prefect.io/docs/playground) where you can try components live.

--- a/docs/snippets/component-preview.mdx
+++ b/docs/snippets/component-preview.mdx
@@ -9,7 +9,9 @@ export const ComponentPreview = ({ json, height, resizable, bare, hideJson, play
 
   React.useEffect(function () {
     if (!playground) return;
-    var url = new URL("../playground", window.location.href);
+    var isLocal = location.hostname === "localhost" || location.hostname === "127.0.0.1";
+    var path = isLocal ? "/playground" : "/docs/playground";
+    var url = new URL(path, window.location.href);
     url.hash = "code=" + playground;
     setPlaygroundHref(url.href);
   }, [playground]);

--- a/renderer/README.md
+++ b/renderer/README.md
@@ -6,7 +6,7 @@ This package contains the bundled React renderer that turns Prefab's JSON wire f
 
 ## Documentation
 
-Full documentation at [prefab.prefect.io](https://prefab.prefect.io), including an interactive [playground](https://prefab.prefect.io/playground).
+Full documentation at [prefab.prefect.io](https://prefab.prefect.io), including an interactive [playground](https://prefab.prefect.io/docs/playground).
 
 ## License
 


### PR DESCRIPTION
The "Run in Playground" link on component preview cards was resolving to `prefab.prefect.io/playground` instead of `prefab.prefect.io/docs/playground`. This happened because the relative path `../playground` doesn't work correctly for pages at different depths in the docs hierarchy.

The fix detects local vs production environments and uses the appropriate absolute path—`/playground` locally, `/docs/playground` in production. Also fixed the same incorrect URL in the README files.

Closes https://prefecthq.slack.com/archives/C0AH6V5417E/p1772166460619149

🤖 Generated with Claude Code

https://claude.ai/code/session_01X2frBax1JLrYVzgTUVD2k2