### PR TITLE
Bump pydantic floor to >=2.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "prefab-ui"
 dynamic = ["version"]
 description = "The agentic frontend framework that even humans can use."
 authors = [{ name = "Jeremiah Lowin" }]
-dependencies = ["pydantic>=2.10", "cyclopts>=4", "rich>=13"]
+dependencies = ["pydantic>=2.11", "cyclopts>=4", "rich>=13"]
 requires-python = ">=3.10"
 license = "Apache-2.0"
 readme = "README.md"

--- a/src/prefab_ui/components/base.py
+++ b/src/prefab_ui/components/base.py
@@ -300,11 +300,6 @@ class Component(BaseModel):
             _defer_next_component.set(False)
             return
 
-        # Skip auto-attach when defer=True was passed
-        if _defer_next_component.get():
-            _defer_next_component.set(False)
-            return
-
         stack = _component_stack.get() or []
         if stack:
             stack[-1].children.append(self)

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "cyclopts", specifier = ">=4" },
-    { name = "pydantic", specifier = ">=2.10" },
+    { name = "pydantic", specifier = ">=2.11" },
     { name = "rich", specifier = ">=13" },
 ]
 


### PR DESCRIPTION
Pydantic 2.10 doesn't resolve `Any` from stringified annotations (via `from __future__ import annotations`) when they're inherited from a parent class in a different module. This breaks `Popover`, `Metric`, `RadioGroup`, `Ring`, and `OpenFilePicker` — any subclass whose module doesn't independently import `Any`.

2.11 fixes the namespace resolution. FastMCP already requires `>=2.11` for the same reason.

Also removes a duplicate `_defer_next_component` check in `Component.model_post_init`.