### PR TITLE
Make SetState and AppendState value required

### DIFF
--- a/docs/actions/update-state.mdx
+++ b/docs/actions/update-state.mdx
@@ -63,9 +63,7 @@ async def settings() -> AppResult:
 
 ## SetState
 
-`SetState` explicitly sets a state key to a value. When you wire it to a form control's `on_change`, the default value is `{{ $event }}` — the current value of that control (slider position, input text, checkbox state, etc.). This means `SetState("key")` with no second argument captures whatever the user entered.
-
-For non-form elements like buttons, pass an explicit value as the second argument:
+`SetState` explicitly sets a state key to a value. Both arguments are required — the key and the value to write:
 
 <ComponentPreview json={{"view":{"cssClass":"gap-3","type":"Column","children":[{"cssClass":"gap-2","type":"Row","children":[{"type":"Button","label":"Improbability","variant":"outline","size":"default","disabled":false,"onClick":{"action":"setState","key":"drive","value":"improbability"}},{"type":"Button","label":"Conventional","variant":"outline","size":"default","disabled":false,"onClick":{"action":"setState","key":"drive","value":"conventional"}},{"type":"Button","label":"Bistromath","variant":"outline","size":"default","disabled":false,"onClick":{"action":"setState","key":"drive","value":"bistromath"}}]},{"type":"Badge","label":"Active drive: {{ drive }}","variant":"default"}]},"state":{"drive":"improbability"}}} playground="ZnJvbSBwcmVmYWJfdWkuYXBwIGltcG9ydCBzZXRfaW5pdGlhbF9zdGF0ZQpmcm9tIHByZWZhYl91aS5jb21wb25lbnRzIGltcG9ydCBCYWRnZSwgQnV0dG9uLCBDb2x1bW4sIFJvdwpmcm9tIHByZWZhYl91aS5hY3Rpb25zIGltcG9ydCBTZXRTdGF0ZQoKc3RhdGUgPSBzZXRfaW5pdGlhbF9zdGF0ZShkcml2ZT0iaW1wcm9iYWJpbGl0eSIpCgp3aXRoIENvbHVtbihnYXA9Myk6CiAgICB3aXRoIFJvdyhnYXA9Mik6CiAgICAgICAgQnV0dG9uKCJJbXByb2JhYmlsaXR5IiwgdmFyaWFudD0ib3V0bGluZSIsCiAgICAgICAgICAgICAgIG9uX2NsaWNrPVNldFN0YXRlKCJkcml2ZSIsICJpbXByb2JhYmlsaXR5IikpCiAgICAgICAgQnV0dG9uKCJDb252ZW50aW9uYWwiLCB2YXJpYW50PSJvdXRsaW5lIiwKICAgICAgICAgICAgICAgb25fY2xpY2s9U2V0U3RhdGUoImRyaXZlIiwgImNvbnZlbnRpb25hbCIpKQogICAgICAgIEJ1dHRvbigiQmlzdHJvbWF0aCIsIHZhcmlhbnQ9Im91dGxpbmUiLAogICAgICAgICAgICAgICBvbl9jbGljaz1TZXRTdGF0ZSgiZHJpdmUiLCAiYmlzdHJvbWF0aCIpKQogICAgQmFkZ2UoZiJBY3RpdmUgZHJpdmU6IHtzdGF0ZS5kcml2ZX0iKQo=">
 <CodeGroup>

--- a/docs/concepts/expression-reference.mdx
+++ b/docs/concepts/expression-reference.mdx
@@ -442,7 +442,7 @@ Available inside action handlers. Contains the value emitted by the interaction:
 | RadioGroup | Selected value (string) |
 | Button | `undefined` |
 
-`SetState("key")` with no second argument defaults to `"{{ $event }}"`.
+To capture `$event` explicitly, pass `EVENT` as the value: `SetState("last_volume", EVENT)`. Form controls update their own state key automatically, so this is mainly useful when writing the event value to a different key.
 
 #### `$error`
 

--- a/docs/expressions/context.mdx
+++ b/docs/expressions/context.mdx
@@ -127,7 +127,7 @@ Available inside action handlers. It contains the value from the interaction tha
 | RadioGroup | Selected value (string) |
 | Button | `undefined` |
 
-This is why [SetState](/actions/update-state) can be so concise: when you write `SetState("volume")` without a second argument, it defaults to `"{{ $event }}"`, which automatically captures whatever the component emitted. On a slider, that's the position; on an input, that's the text.
+When you need to capture the event value explicitly — for example, to store it under a different key or transform it — pass `EVENT` as the value: `SetState("last_volume", EVENT)`. For form controls like Slider and Input, the component's own state key updates automatically, so a separate `SetState` is only needed when you want to write the value somewhere else.
 
 ### `$error`
 

--- a/schemas/fixtures/actions/appendState.json
+++ b/schemas/fixtures/actions/appendState.json
@@ -1,5 +1,5 @@
 {
   "action": "appendState",
   "key": "test_key",
-  "value": "{{ $event }}"
+  "value": "test_value"
 }

--- a/schemas/fixtures/actions/setState.json
+++ b/schemas/fixtures/actions/setState.json
@@ -1,5 +1,5 @@
 {
   "action": "setState",
   "key": "test_key",
-  "value": "{{ $event }}"
+  "value": "test_value"
 }

--- a/scripts/generate_schemas.py
+++ b/scripts/generate_schemas.py
@@ -66,6 +66,8 @@ _WIRE_ONLY_FIXTURES: dict[str, dict[str, Any]] = {
 def _minimal_value(field_info: FieldInfo, field_name: str) -> Any:
     """Produce a minimal valid value for a required Pydantic field."""
     annotation = field_info.annotation
+    if annotation is Any:
+        return f"test_{field_name}"
     if annotation is None:
         return None
 

--- a/src/prefab_ui/actions/state.py
+++ b/src/prefab_ui/actions/state.py
@@ -38,9 +38,6 @@ def _validate_path(path: str) -> str:
 class SetState(Action):
     """Set a client-side state variable. No server round-trip.
 
-    The default ``value`` of ``{{ $event }}`` captures the event value
-    (slider position, input text, checkbox state, etc.).
-
     The ``key`` supports dot-paths for nested updates::
 
         SetState("todos.0.done", True)   # deep-update into a list
@@ -48,19 +45,14 @@ class SetState(Action):
 
     action: Literal["setState"] = "setState"
     key: str = Field(description="State key or dot-path to set")
-    value: Any = Field(
-        default="{{ $event }}",
-        description="Value to set. Use '{{ $event }}' for the event value.",
-    )
+    value: Any = Field(description="Value to set.")
 
     @field_validator("key")
     @classmethod
     def _validate_key(cls, v: str) -> str:
         return _validate_path(v)
 
-    def __init__(
-        self, key: str | Rx, value: Any = "{{ $event }}", **kwargs: Any
-    ) -> None:
+    def __init__(self, key: str | Rx, value: Any, **kwargs: Any) -> None:
         kwargs["key"] = key.key if isinstance(key, Rx) else key
         kwargs["value"] = value
         super().__init__(**kwargs)
@@ -93,10 +85,7 @@ class AppendState(Action):
 
     action: Literal["appendState"] = "appendState"
     key: str = Field(description="State key or dot-path to the array")
-    value: Any = Field(
-        default="{{ $event }}",
-        description="Value to append.",
-    )
+    value: Any = Field(description="Value to append.")
     index: int | str | None = Field(
         default=None,
         description="Insert position (int or template string). None to append at end.",
@@ -110,7 +99,7 @@ class AppendState(Action):
     def __init__(
         self,
         key: str | Rx,
-        value: Any = "{{ $event }}",
+        value: Any,
         *,
         index: int | str | Rx | None = None,
         **kwargs: Any,

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -18,7 +18,7 @@ from prefab_ui.actions import (
 )
 from prefab_ui.actions.mcp import CallTool, SendMessage, UpdateContext
 from prefab_ui.components import Button, Checkbox, DropZone, Input, Slider
-from prefab_ui.rx import STATE, Rx
+from prefab_ui.rx import EVENT, STATE, Rx
 
 
 class TestActionSerialization:
@@ -40,17 +40,21 @@ class TestActionSerialization:
         assert d["action"] == "sendMessage"
         assert d["content"] == "Summarize this"
 
-    def test_set_state_default_event(self):
-        a = SetState("brightness")
-        d = a.model_dump()
-        assert d["action"] == "setState"
-        assert d["key"] == "brightness"
-        assert d["value"] == "{{ $event }}"
+    def test_set_state_requires_value(self):
+        with pytest.raises(TypeError):
+            SetState("brightness")
 
     def test_set_state_explicit_value(self):
         a = SetState("loading", True)
         d = a.model_dump()
         assert d["value"] is True
+
+    def test_set_state_event_value(self):
+        a = SetState("brightness", EVENT)
+        d = a.model_dump()
+        assert d["action"] == "setState"
+        assert d["key"] == "brightness"
+        assert d["value"] == "{{ $event }}"
 
     def test_toggle_state(self):
         a = ToggleState("showDetails")
@@ -120,13 +124,13 @@ class TestActionOnComponents:
         assert j["onClick"][1]["action"] == "toolCall"
 
     def test_slider_on_change(self):
-        s = Slider(min=0, max=100, on_change=SetState("volume"))
+        s = Slider(min=0, max=100, on_change=SetState("volume", EVENT))
         j = s.to_json()
         assert j["onChange"]["action"] == "setState"
         assert j["onChange"]["key"] == "volume"
 
     def test_input_on_change(self):
-        i = Input(placeholder="Name", on_change=SetState("name"))
+        i = Input(placeholder="Name", on_change=SetState("name", EVENT))
         j = i.to_json()
         assert j["onChange"]["action"] == "setState"
 
@@ -189,9 +193,9 @@ class TestActionCallbacks:
             SendMessage("m"),
             UpdateContext(content="c"),
             OpenLink("http://example.com"),
-            SetState("k"),
+            SetState("k", 0),
             ToggleState("k"),
-            AppendState("k"),
+            AppendState("k", 0),
             PopState("k", 0),
             ShowToast("m"),
             CloseOverlay(),
@@ -349,10 +353,9 @@ class TestAppendStateSerialization:
         assert d["value"] == "new_item"
         assert "index" not in d
 
-    def test_default_event_value(self):
-        a = AppendState("items")
-        d = a.model_dump(by_alias=True, exclude_none=True)
-        assert d["value"] == "{{ $event }}"
+    def test_requires_value(self):
+        with pytest.raises(TypeError):
+            AppendState("items")
 
     def test_with_index(self):
         a = AppendState("items", "new_item", index=0)
@@ -590,12 +593,10 @@ class TestRxAsKey:
         assert d["key"] == "brightness"
         assert d["value"] == 50
 
-    def test_set_state_rx_default_event(self):
+    def test_set_state_rx_requires_value(self):
         rx = Rx("volume")
-        a = SetState(rx)
-        d = a.model_dump(by_alias=True, exclude_none=True)
-        assert d["key"] == "volume"
-        assert d["value"] == "{{ $event }}"
+        with pytest.raises(TypeError):
+            SetState(rx)
 
     def test_set_state_rx_with_dot_path(self):
         rx = Rx("user")
@@ -671,12 +672,10 @@ class TestRxAsKey:
         assert d["key"] == "todos"
         assert d["index"] == 0
 
-    def test_append_state_rx_default_event(self):
+    def test_append_state_rx_requires_value(self):
         rx = Rx("log")
-        a = AppendState(rx)
-        d = a.model_dump(by_alias=True, exclude_none=True)
-        assert d["key"] == "log"
-        assert d["value"] == "{{ $event }}"
+        with pytest.raises(TypeError):
+            AppendState(rx)
 
     def test_append_state_string_key_unchanged(self):
         a = AppendState("items", "val")
@@ -711,7 +710,7 @@ class TestRxAsKey:
         assert j["onClick"]["key"] == "active_tab"
 
     def test_rx_key_on_slider_change(self):
-        s = Slider(min=0, max=100, on_change=SetState(Rx("volume")), defer=True)
+        s = Slider(min=0, max=100, on_change=SetState(Rx("volume"), EVENT), defer=True)
         j = s.to_json()
         assert j["onChange"]["key"] == "volume"
 

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -71,6 +71,8 @@ def _minimal_value(field_info: FieldInfo, field_name: str) -> Any:
     from typing import Literal, Union, get_args, get_origin
 
     annotation = field_info.annotation
+    if annotation is Any:
+        return f"test_{field_name}"
     if annotation is None:
         return None
 


### PR DESCRIPTION
`SetState("key")` silently defaulted `value` to `"{{ $event }}"`, which captured the triggering event's value. This was convenient for `on_change` handlers but completely non-obvious — there's no way to know this from reading the code. Worse, form controls already auto-update their own state key, so the default was usually redundant.

Both `SetState` and `AppendState` now require an explicit value. When you actually want the event value, pass `EVENT`:

```python
from prefab_ui.rx import EVENT

# Before (implicit magic)
Slider(on_change=SetState("volume"))

# After (explicit)
Slider(on_change=SetState("volume", EVENT))
```

Closes #187