### PR TITLE
Fix infinite iteration on Rx objects

### DIFF
--- a/src/prefab_ui/components/charts/__init__.py
+++ b/src/prefab_ui/components/charts/__init__.py
@@ -26,6 +26,7 @@ from typing import Any, Literal
 from pydantic import BaseModel, Field
 
 from prefab_ui.components.base import Component
+from prefab_ui.rx import RxStr
 
 
 class ChartSeries(BaseModel):
@@ -54,7 +55,7 @@ class BarChart(Component):
     """
 
     type: Literal["BarChart"] = "BarChart"
-    data: list[dict[str, Any]] | str = Field(
+    data: list[dict[str, Any]] | RxStr = Field(
         description="Row data or {{ interpolation }} reference"
     )
     series: list[ChartSeries] = Field(description="Series to render as bars")
@@ -101,7 +102,7 @@ class LineChart(Component):
     """
 
     type: Literal["LineChart"] = "LineChart"
-    data: list[dict[str, Any]] | str = Field(
+    data: list[dict[str, Any]] | RxStr = Field(
         description="Row data or {{ interpolation }} reference"
     )
     series: list[ChartSeries] = Field(description="Series to render as lines")
@@ -148,7 +149,7 @@ class AreaChart(Component):
     """
 
     type: Literal["AreaChart"] = "AreaChart"
-    data: list[dict[str, Any]] | str = Field(
+    data: list[dict[str, Any]] | RxStr = Field(
         description="Row data or {{ interpolation }} reference"
     )
     series: list[ChartSeries] = Field(description="Series to render as areas")
@@ -199,7 +200,7 @@ class PieChart(Component):
     """
 
     type: Literal["PieChart"] = "PieChart"
-    data: list[dict[str, Any]] | str = Field(
+    data: list[dict[str, Any]] | RxStr = Field(
         description="Row data or {{ interpolation }} reference"
     )
     data_key: str = Field(alias="dataKey", description="Numeric value field")
@@ -243,7 +244,7 @@ class ScatterChart(Component):
     """
 
     type: Literal["ScatterChart"] = "ScatterChart"
-    data: list[dict[str, Any]] | str = Field(
+    data: list[dict[str, Any]] | RxStr = Field(
         description="Row data or {{ interpolation }} reference"
     )
     series: list[ChartSeries] = Field(description="Series to render as scatter groups")
@@ -282,7 +283,7 @@ class RadarChart(Component):
     """
 
     type: Literal["RadarChart"] = "RadarChart"
-    data: list[dict[str, Any]] | str = Field(
+    data: list[dict[str, Any]] | RxStr = Field(
         description="Row data or {{ interpolation }} reference"
     )
     series: list[ChartSeries] = Field(description="Series to render as radar areas")
@@ -323,7 +324,7 @@ class RadialChart(Component):
     """
 
     type: Literal["RadialChart"] = "RadialChart"
-    data: list[dict[str, Any]] | str = Field(
+    data: list[dict[str, Any]] | RxStr = Field(
         description="Row data or {{ interpolation }} reference"
     )
     data_key: str = Field(alias="dataKey", description="Numeric value field")

--- a/src/prefab_ui/rx.py
+++ b/src/prefab_ui/rx.py
@@ -335,6 +335,13 @@ class Rx:
             f"Rx indices must be int, str, or Rx, not {type(index).__name__}"
         )
 
+    def __iter__(self):
+        raise TypeError(
+            f"Rx({self.key!r}) is not iterable. "
+            "Use str(rx) to get the template string, "
+            "or rx[i] for index access."
+        )
+
     # ── Arithmetic ───────────────────────────────────────────────────
 
     def __add__(self, other: object) -> Rx:

--- a/tests/test_rx.py
+++ b/tests/test_rx.py
@@ -604,3 +604,12 @@ class TestGetItem:
     def test_str_produces_template_wrapping(self) -> None:
         result = STATE.groups[Rx("gi")].name
         assert str(result) == "{{ groups.{{ gi }}.name }}"
+
+    def test_rx_not_iterable(self) -> None:
+        with pytest.raises(TypeError, match="not iterable"):
+            list(Rx("items"))
+
+    def test_rx_not_iterable_in_for_loop(self) -> None:
+        with pytest.raises(TypeError, match="not iterable"):
+            for _ in Rx("items"):
+                pass  # pragma: no cover


### PR DESCRIPTION
Adding `Rx.__getitem__` (PR #214) had an unintended side effect: Python's fallback iteration protocol calls `__getitem__(0)`, `__getitem__(1)`, ... until `IndexError`. Since `Rx.__getitem__` always succeeds (returning a new Rx for index-access expressions), every Rx became infinitely iterable. Pydantic triggers this when validating an Rx against a `list[...]` union branch — like chart `data` fields — spinning forever and eating gigabytes of RAM. This is what caused `prefab dev build-docs` to hang.

The fix adds `Rx.__iter__` that raises `TypeError`, breaking the fallback protocol. `LoopItem.__iter__` still works for `as (i, item)` destructuring since it overrides this method. Chart `data` fields are also updated from `| str` to `| RxStr` so Pydantic properly validates Rx through the Rx schema rather than relying on string coercion.