### PR TITLE
Support callable tool references in CallTool

### DIFF
--- a/src/prefab_ui/actions/mcp.py
+++ b/src/prefab_ui/actions/mcp.py
@@ -9,16 +9,25 @@ module.
 
 from __future__ import annotations
 
+import types
+from collections.abc import Callable
 from typing import Any, Literal
 
-from pydantic import Field
+from pydantic import Field, PrivateAttr, field_serializer
 
 from prefab_ui.actions.base import Action
+from prefab_ui.app import get_tool_resolver
 from prefab_ui.rx import RxStr
 
 
 class CallTool(Action):
     """Call an MCP server tool via ``app.callServerTool()``.
+
+    The ``tool`` argument can be a string name or a callable reference
+    to the tool function.  Callables are resolved to name strings at
+    serialization time via the resolver passed to
+    ``PrefabApp.to_json(tool_resolver=...)``.  Without a resolver,
+    the function's ``__name__`` is used as a fallback.
 
     If ``result_key`` is set, the tool's return value is written into
     client-side state at that key. The key supports interpolation:
@@ -36,10 +45,24 @@ class CallTool(Action):
         alias="resultKey",
         description="State key to store the tool result under",
     )
+    _tool_ref: Callable[..., Any] | None = PrivateAttr(default=None)
 
-    def __init__(self, tool: str, **kwargs: Any) -> None:
-        kwargs["tool"] = tool
-        super().__init__(**kwargs)
+    def __init__(self, tool: str | Callable[..., Any], **kwargs: Any) -> None:
+        if isinstance(tool, types.FunctionType):
+            kwargs["tool"] = tool.__name__
+            super().__init__(**kwargs)
+            self._tool_ref = tool
+        else:
+            kwargs["tool"] = tool
+            super().__init__(**kwargs)
+
+    @field_serializer("tool")
+    def _resolve_tool_ref(self, value: str) -> str:
+        if self._tool_ref is not None:
+            resolver = get_tool_resolver()
+            if resolver is not None:
+                return resolver(self._tool_ref)
+        return value
 
 
 class SendMessage(Action):

--- a/src/prefab_ui/app.py
+++ b/src/prefab_ui/app.py
@@ -20,6 +20,7 @@ Usage::
 from __future__ import annotations
 
 import json
+from collections.abc import Callable
 from contextvars import ContextVar
 from typing import Any
 
@@ -37,6 +38,17 @@ PROTOCOL_VERSION = "0.2"
 _initial_state: ContextVar[dict[str, Any] | None] = ContextVar(
     "_initial_state", default=None
 )
+
+# ── Tool Resolver ─────────────────────────────────────────────────────
+
+_tool_resolver: ContextVar[Callable[[Any], str] | None] = ContextVar(
+    "_tool_resolver", default=None
+)
+
+
+def get_tool_resolver() -> Callable[[Any], str] | None:
+    """Return the active tool resolver, or ``None``."""
+    return _tool_resolver.get()
 
 
 def set_initial_state(**kwargs: Any) -> _BoundStateProxy:
@@ -143,29 +155,49 @@ class PrefabApp(BaseModel):
                     raise ValueError(f"State key {key!r} uses reserved prefix '$'")
         return self
 
-    def to_json(self) -> dict[str, Any]:
+    def to_json(
+        self,
+        *,
+        tool_resolver: Callable[[Any], str] | None = None,
+    ) -> dict[str, Any]:
         """Produce the Prefab wire format.
 
         Returns a dict with ``version``, ``view``, ``defs``, and ``state``
         as top-level keys (omitting any that are None).
+
+        Parameters
+        ----------
+        tool_resolver:
+            Resolves callable tool references to name strings during
+            serialization.  Scoped to this call — safe for concurrent use
+            with different resolvers.
         """
-        result: dict[str, Any] = {"version": PROTOCOL_VERSION}
+        token = _tool_resolver.set(tool_resolver) if tool_resolver is not None else None
+        try:
+            result: dict[str, Any] = {"version": PROTOCOL_VERSION}
 
-        if self.view is not None:
-            result["view"] = self.view.to_json()
+            if self.view is not None:
+                result["view"] = self.view.to_json()
 
-        if self.defs:
-            result["defs"] = {d.name: d.to_json() for d in self.defs}
+            if self.defs:
+                result["defs"] = {d.name: d.to_json() for d in self.defs}
 
-        if self.state is not None:
-            result["state"] = pydantic_core.to_jsonable_python(self.state)
+            if self.state is not None:
+                result["state"] = pydantic_core.to_jsonable_python(self.state)
 
-        if self.theme is not None:
-            result["theme"] = self.theme.to_json()
+            if self.theme is not None:
+                result["theme"] = self.theme.to_json()
 
-        return result
+            return result
+        finally:
+            if token is not None:
+                _tool_resolver.reset(token)
 
-    def html(self) -> str:
+    def html(
+        self,
+        *,
+        tool_resolver: Callable[[Any], str] | None = None,
+    ) -> str:
         """Produce a complete, self-contained HTML page.
 
         The page includes the Prefab renderer (JS/CSS), any user-specified
@@ -185,7 +217,10 @@ class PrefabApp(BaseModel):
             for url in self.scripts:
                 head_parts.append(f'  <script src="{url}"></script>')
 
-        data_json = json.dumps(self.to_json(), separators=(",", ":"))
+        data_json = json.dumps(
+            self.to_json(tool_resolver=tool_resolver),
+            separators=(",", ":"),
+        )
         # Escape </ to prevent premature closing of the script tag
         safe_json = data_json.replace("</", r"<\/")
 

--- a/tests/actions/test_mcp.py
+++ b/tests/actions/test_mcp.py
@@ -1,5 +1,7 @@
 """Tests for MCP transport actions (CallTool, SendMessage, UpdateContext, RequestDisplayMode)."""
 
+import types
+
 import pytest
 
 from prefab_ui.actions.mcp import (
@@ -9,6 +11,7 @@ from prefab_ui.actions.mcp import (
     UpdateContext,
 )
 from prefab_ui.actions.ui import ShowToast
+from prefab_ui.app import PrefabApp, _tool_resolver
 from prefab_ui.components import Button
 
 
@@ -52,6 +55,100 @@ class TestCallToolSerialization:
         )
         j = btn.to_json()
         assert j["onClick"]["resultKey"] == "results"
+
+
+class TestCallToolCallableRef:
+    """CallTool accepts callable function references for the tool argument."""
+
+    def _dummy_tool(self) -> dict[str, str]:
+        return {"status": "ok"}
+
+    def test_callable_serializes_to_name(self):
+        def save_contact(name: str) -> dict[str, str]:
+            return {"name": name}
+
+        a = CallTool(save_contact)
+        d = a.model_dump()
+        assert d["tool"] == "save_contact"
+
+    def test_callable_with_resolver(self):
+        def save_contact(name: str) -> dict[str, str]:
+            return {"name": name}
+
+        token = _tool_resolver.set(lambda fn: f"{fn.__name__}-abc123")
+        try:
+            a = CallTool(save_contact)
+            d = a.model_dump()
+            assert d["tool"] == "save_contact-abc123"
+        finally:
+            _tool_resolver.reset(token)
+
+    def test_string_tool_unchanged(self):
+        a = CallTool("refresh")
+        d = a.model_dump()
+        assert d["tool"] == "refresh"
+
+    def test_callable_on_component(self):
+        def save_contact(name: str) -> dict[str, str]:
+            return {"name": name}
+
+        btn = Button(label="Save", on_click=CallTool(save_contact))
+        j = btn.to_json()
+        assert j["onClick"]["tool"] == "save_contact"
+
+    def test_callable_with_prefab_app(self):
+        def save_contact(name: str) -> dict[str, str]:
+            return {"name": name}
+
+        app = PrefabApp(
+            view=Button(
+                label="Save",
+                on_click=CallTool(save_contact),
+            ),
+        )
+
+        def resolver(fn: types.FunctionType) -> str:
+            return f"{fn.__name__}-resolved"
+
+        data = app.to_json(tool_resolver=resolver)
+        assert data["view"]["onClick"]["tool"] == "save_contact-resolved"
+
+    def test_resolver_scoped_to_call(self):
+        """Resolver ContextVar resets after to_json() returns."""
+
+        def my_tool() -> None:
+            pass
+
+        def resolver(fn: object) -> str:
+            return "resolved"
+
+        app = PrefabApp(
+            view=Button(label="Go", on_click=CallTool(my_tool)),
+        )
+        app.to_json(tool_resolver=resolver)
+
+        # After the call, the ContextVar should be reset
+        a = CallTool(my_tool)
+        d = a.model_dump()
+        assert d["tool"] == "my_tool"
+
+    def test_callable_with_arguments(self):
+        def search(query: str) -> list[str]:
+            return []
+
+        a = CallTool(search, arguments={"q": "{{ query }}"})
+        d = a.model_dump()
+        assert d["tool"] == "search"
+        assert d["arguments"]["q"] == "{{ query }}"
+
+    def test_callable_preserves_result_key(self):
+        def search(query: str) -> list[str]:
+            return []
+
+        a = CallTool(search, result_key="results")
+        d = a.model_dump(by_alias=True, exclude_none=True)
+        assert d["tool"] == "search"
+        assert d["resultKey"] == "results"
 
 
 class TestSendMessageSerialization:


### PR DESCRIPTION
`CallTool("save_contact")` breaks under namespace composition — the tool gets renamed but the string in the UI doesn't. This adds support for passing function references directly: `CallTool(save_contact)`.

Resolution happens at serialization time through a `tool_resolver` parameter on `PrefabApp.to_json()`. The resolver is scoped to a single serialization call via a ContextVar, so multiple apps can serialize concurrently with different resolvers.

```python
@app.tool()
def save_contact(name: str, email: str) -> dict:
    return {"name": name, "email": email}

@app.ui()
def contact_form():
    return Form(on_submit=CallTool(save_contact))

# FastMCP wires the resolver before serializing:
structured_content = app.to_json(tool_resolver=_resolve_tool_ref)
```

Without a resolver, `fn.__name__` is used as the fallback — so `CallTool(save_contact)` works standalone without any special wiring. The resolver adds namespace-aware resolution on top.

Implementation uses `@field_serializer("tool")` which is additive — it doesn't override the parent Action's `_serialize_rx` model serializer, so Rx coercion continues to work unchanged.