### PR TITLE
Fix Form.from_model dropping callable tool references

### DIFF
--- a/src/prefab_ui/components/form.py
+++ b/src/prefab_ui/components/form.py
@@ -222,7 +222,7 @@ def _maybe_enrich_tool_call(
     }
 
     kwargs: dict[str, Any] = {
-        "tool": on_submit.tool,
+        "tool": on_submit._tool_ref or on_submit.tool,
         "arguments": {"data": field_templates},
     }
     if on_submit.result_key is not None:

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -87,6 +87,45 @@ class TestCloseOverlayAction:
         assert callbacks[1]["action"] == "closeOverlay"
 
 
+class TestCallToolResolver:
+    """CallTool(fn) resolves callables via tool_resolver at serialization."""
+
+    def test_callable_resolved_by_tool_resolver(self):
+        from prefab_ui.app import PrefabApp
+        from prefab_ui.components import Column
+
+        def save(name: str) -> dict:
+            return {"name": name}
+
+        action = CallTool(save, arguments={"name": "test"})
+        view = Column()
+        view.children = [Button(label="Go", on_click=action)]
+        app = PrefabApp(view=view)
+
+        j = app.to_json(tool_resolver=lambda fn: fn.__name__ + "-abc123")
+        assert j["view"]["children"][0]["onClick"]["tool"] == "save-abc123"
+
+    def test_callable_without_resolver_uses_name(self):
+        def my_tool() -> None:
+            pass
+
+        action = CallTool(my_tool)
+        d = action.model_dump(by_alias=True, exclude_none=True)
+        assert d["tool"] == "my_tool"
+
+    def test_string_tool_unaffected_by_resolver(self):
+        from prefab_ui.app import PrefabApp
+        from prefab_ui.components import Column
+
+        action = CallTool("explicit_name")
+        view = Column()
+        view.children = [Button(label="Go", on_click=action)]
+        app = PrefabApp(view=view)
+
+        j = app.to_json(tool_resolver=lambda fn: "should_not_be_called")
+        assert j["view"]["children"][0]["onClick"]["tool"] == "explicit_name"
+
+
 class TestActionOnComponents:
     def test_button_on_click(self):
         b = Button(label="Go", on_click=CallTool("refresh"))

--- a/tests/test_form_model.py
+++ b/tests/test_form_model.py
@@ -330,6 +330,61 @@ class TestAutoFillConvention:
         j = form.to_json()
         assert j["onSubmit"]["tool"] == "save"
 
+    def test_callable_tool_ref_preserved_through_from_model(self):
+        """CallTool(fn) should resolve via tool_resolver after from_model enrichment."""
+        from prefab_ui.app import PrefabApp
+
+        def save_item(name: str) -> dict:
+            return {"name": name}
+
+        class M(BaseModel):
+            name: str
+
+        def resolver(fn: object) -> str:
+            assert fn is save_item
+            return "save_item-abc123"
+
+        form = Form.from_model(M, on_submit=CallTool(save_item))
+        app = PrefabApp(view=form)
+        j = app.to_json(tool_resolver=resolver)
+        view = j["view"]
+
+        assert view["onSubmit"]["tool"] == "save_item-abc123"
+        button = view["children"][-1]
+        assert button["onClick"]["tool"] == "save_item-abc123"
+
+    def test_callable_tool_ref_preserved_with_explicit_arguments(self):
+        """When arguments are provided (no enrichment), callable still resolves."""
+        from prefab_ui.app import PrefabApp
+
+        def save_item(name: str) -> dict:
+            return {"name": name}
+
+        class M(BaseModel):
+            name: str
+
+        form = Form.from_model(
+            M,
+            on_submit=CallTool(save_item, arguments={"custom": "val"}),
+        )
+        app = PrefabApp(view=form)
+        j = app.to_json(tool_resolver=lambda fn: fn.__name__ + "-resolved")
+        assert j["view"]["onSubmit"]["tool"] == "save_item-resolved"
+        assert j["view"]["onSubmit"]["arguments"] == {"custom": "val"}
+
+    def test_callable_without_resolver_uses_name(self):
+        """Without a resolver, CallTool(fn) falls back to fn.__name__."""
+
+        def my_tool(x: str) -> str:
+            return x
+
+        class M(BaseModel):
+            name: str
+
+        form = Form.from_model(M, on_submit=CallTool(my_tool))
+        j = form.to_json()
+        assert j["onSubmit"]["tool"] == "my_tool"
+
 
 # ---------------------------------------------------------------------------
 # Context-manager isolation


### PR DESCRIPTION
When `Form.from_model(Model, on_submit=CallTool(my_func))` auto-fills argument templates, it reconstructs a new `CallTool` using the already-resolved string name instead of the original callable. This means the `tool_resolver` passed to `to_json()` never fires for `from_model` forms — you get `"my_func"` instead of the resolved name like `"my_func-abc123"`.

The fix preserves the callable through the enrichment step so the resolver works identically whether you build a form manually or via `from_model`:

```python
form = Form.from_model(Contact, on_submit=CallTool(save_contact))
app = PrefabApp(view=form)
j = app.to_json(tool_resolver=my_resolver)
# j["view"]["onSubmit"]["tool"] == "save_contact-abc123"  ✓
```