### PR TITLE
Replace result_key with $result variable

### DIFF
--- a/docs/actions/call-tool.mdx
+++ b/docs/actions/call-tool.mdx
@@ -110,6 +110,48 @@ Button("Analyze", on_click=[
 
 The `SetState` executes first (instant), then `CallTool` fires the server request.
 
+## Handling Results
+
+The tool's return value is available as `$result` (Python: `RESULT`) inside `on_success` callbacks. Use `SetState` to write it into client-side state:
+
+```python Writing results to state
+from prefab_ui.components import Button
+from prefab_ui.actions import SetState
+from prefab_ui.actions.mcp import CallTool
+from prefab_ui.rx import RESULT
+
+Button(
+    "Search",
+    on_click=CallTool(
+        "search",
+        arguments={"q": "{{ query }}"},
+        on_success=SetState("results", RESULT),
+    ),
+)
+```
+
+`$result` is the success counterpart of `$error`: one is available in `on_success`, the other in `on_error`. You can combine them with any action — `ShowToast`, `AppendState`, or chain multiple actions in a list:
+
+```python Callbacks with result
+from prefab_ui.components import Button
+from prefab_ui.actions import AppendState, SetState, ShowToast
+from prefab_ui.actions.mcp import CallTool
+from prefab_ui.rx import ERROR, RESULT
+
+Button(
+    "Add Item",
+    on_click=CallTool(
+        "create_item",
+        arguments={"name": "{{ item_name }}"},
+        on_success=[
+            AppendState("items", RESULT),
+            ShowToast("Item created!", variant="success"),
+        ],
+        on_error=ShowToast(ERROR, variant="error"),
+    ),
+)
+```
+
 ## API Reference
 
 <Card icon="code" title="CallTool Parameters">
@@ -128,8 +170,7 @@ The `SetState` executes first (instant), then `CallTool` fires the server reques
 {
   "action": "toolCall",
   "tool": "string (required)",
-  "arguments?": "object",
-  "resultKey?": "string"
+  "arguments?": "object"
 }
 ```
 

--- a/docs/actions/fetch.mdx
+++ b/docs/actions/fetch.mdx
@@ -8,18 +8,21 @@ import { ComponentPreview } from '/snippets/component-preview.mdx'
 
 `Fetch` makes HTTP requests from the browser using the native `fetch()` API. Use it to call REST endpoints, load external data, or submit forms — anything that speaks HTTP without needing an MCP server in the middle.
 
-<ComponentPreview json={{"view":{"type":"Button","label":"Load Users","variant":"default","size":"default","disabled":false,"onClick":{"onSuccess":{"action":"showToast","message":"Users loaded!","variant":"success"},"action":"fetch","url":"/api/users","method":"GET","resultKey":"users"}}}} playground="ZnJvbSBwcmVmYWJfdWkuY29tcG9uZW50cyBpbXBvcnQgQnV0dG9uCmZyb20gcHJlZmFiX3VpLmFjdGlvbnMgaW1wb3J0IEZldGNoLCBTaG93VG9hc3QKCkJ1dHRvbigKICAgICJMb2FkIFVzZXJzIiwKICAgIG9uX2NsaWNrPUZldGNoLmdldCgKICAgICAgICAiL2FwaS91c2VycyIsCiAgICAgICAgcmVzdWx0X2tleT0idXNlcnMiLAogICAgICAgIG9uX3N1Y2Nlc3M9U2hvd1RvYXN0KCJVc2VycyBsb2FkZWQhIiwgdmFyaWFudD0ic3VjY2VzcyIpLAogICAgKSwKKQo=">
+<ComponentPreview json={{"view":{"type":"Button","label":"Load Users","variant":"default","size":"default","disabled":false,"onClick":{"onSuccess":[{"action":"setState","key":"users","value":"{{ $result }}"},{"action":"showToast","message":"Users loaded!","variant":"success"}],"action":"fetch","url":"/api/users","method":"GET"}}}} playground="ZnJvbSBwcmVmYWJfdWkuY29tcG9uZW50cyBpbXBvcnQgQnV0dG9uCmZyb20gcHJlZmFiX3VpLmFjdGlvbnMgaW1wb3J0IEZldGNoLCBTZXRTdGF0ZSwgU2hvd1RvYXN0CmZyb20gcHJlZmFiX3VpLnJ4IGltcG9ydCBSRVNVTFQKCkJ1dHRvbigKICAgICJMb2FkIFVzZXJzIiwKICAgIG9uX2NsaWNrPUZldGNoLmdldCgKICAgICAgICAiL2FwaS91c2VycyIsCiAgICAgICAgb25fc3VjY2Vzcz1bCiAgICAgICAgICAgIFNldFN0YXRlKCJ1c2VycyIsIFJFU1VMVCksCiAgICAgICAgICAgIFNob3dUb2FzdCgiVXNlcnMgbG9hZGVkISIsIHZhcmlhbnQ9InN1Y2Nlc3MiKSwKICAgICAgICBdLAogICAgKSwKKQo=">
 <CodeGroup>
 ```python Python icon="python"
 from prefab_ui.components import Button
-from prefab_ui.actions import Fetch, ShowToast
+from prefab_ui.actions import Fetch, SetState, ShowToast
+from prefab_ui.rx import RESULT
 
 Button(
     "Load Users",
     on_click=Fetch.get(
         "/api/users",
-        result_key="users",
-        on_success=ShowToast("Users loaded!", variant="success"),
+        on_success=[
+            SetState("users", RESULT),
+            ShowToast("Users loaded!", variant="success"),
+        ],
     ),
 )
 ```
@@ -32,11 +35,13 @@ Button(
     "size": "default",
     "disabled": false,
     "onClick": {
-      "onSuccess": {"action": "showToast", "message": "Users loaded!", "variant": "success"},
+      "onSuccess": [
+        {"action": "setState", "key": "users", "value": "{{ $result }}"},
+        {"action": "showToast", "message": "Users loaded!", "variant": "success"}
+      ],
       "action": "fetch",
       "url": "/api/users",
-      "method": "GET",
-      "resultKey": "users"
+      "method": "GET"
     }
   }
 }
@@ -44,7 +49,7 @@ Button(
 </CodeGroup>
 </ComponentPreview>
 
-The response is parsed automatically — JSON becomes an object, everything else becomes a string. If `result_key` is set, the parsed response is written into client-side state, making it immediately available via `{{ users }}` interpolation. The `on_success` callback fires after a successful request, so you can confirm the result with a toast or trigger follow-up actions.
+The response is parsed automatically — JSON becomes an object, everything else becomes a string. The `on_success` callback fires after a successful request, and the parsed response is available as `$result` (Python: `RESULT`). Use `SetState("users", RESULT)` inside `on_success` to write the response into client-side state, making it immediately available via `{{ users }}` interpolation.
 
 ## Classmethods
 
@@ -74,7 +79,8 @@ Fetch.delete(f"/api/users/{user_id}")
 You can also construct a `Fetch` directly for full control:
 
 ```python Full form
-from prefab_ui.rx import Rx
+from prefab_ui.actions import Fetch, SetState
+from prefab_ui.rx import RESULT, Rx
 
 form_data = Rx("form_data")
 
@@ -83,7 +89,7 @@ Fetch(
     method="POST",
     headers={"X-Custom": "value"},
     body={"data": form_data},
-    result_key="response",
+    on_success=SetState("response", RESULT),
 )
 ```
 
@@ -118,7 +124,7 @@ Like any action, `Fetch` composes in a list. A common pattern: show a loading st
 ```python Combined actions
 from prefab_ui.components import Button
 from prefab_ui.actions import Fetch, SetState
-from prefab_ui.rx import Rx
+from prefab_ui.rx import RESULT, Rx
 
 query = Rx("query")
 
@@ -129,7 +135,7 @@ Button(
         Fetch.post(
             "/api/submit",
             body={"q": query},
-            result_key="result",
+            on_success=SetState("result", RESULT),
         ),
         SetState("loading", False),
     ],
@@ -157,9 +163,6 @@ If the request fails, `SetState("loading", False)` never runs (the chain short-c
   Request body. Dicts are JSON-serialized automatically. Ignored for GET requests.
 </ParamField>
 
-<ParamField body="result_key" type="str">
-  State key to store the parsed response under. Supports dot-paths like `data.users`.
-</ParamField>
 </Card>
 
 ## Protocol Reference
@@ -170,8 +173,7 @@ If the request fails, `SetState("loading", False)` never runs (the chain short-c
   "url": "string (required)",
   "method?": "GET | POST | PUT | PATCH | DELETE",
   "headers?": "object",
-  "body?": "object | string",
-  "resultKey?": "string"
+  "body?": "object | string"
 }
 ```
 

--- a/docs/components/slot.mdx
+++ b/docs/components/slot.mdx
@@ -71,7 +71,7 @@ with Column(gap=4):
 </CodeGroup>
 </ComponentPreview>
 
-The layout defines *where* the dynamic content goes. The state (or an action that populates it) determines *what* appears there. In practice, the state key is often populated by a `CallTool` or `API` action with `result_key` — the action fetches a component tree and writes it into state, and the Slot picks it up automatically.
+The layout defines *where* the dynamic content goes. The state (or an action that populates it) determines *what* appears there. In practice, the state key is often populated by a `CallTool` or `Fetch` action using `SetState("key", RESULT)` in an `on_success` callback — the action fetches a component tree and writes it into state, and the Slot picks it up automatically.
 
 ## Fallback Content
 

--- a/docs/concepts/actions.mdx
+++ b/docs/concepts/actions.mdx
@@ -34,8 +34,8 @@ Most real interactions use both. A "Save" button typically sets a loading flag (
 
 | Server actions | Purpose |
 |----------------|---------|
-| `CallTool` | Call an MCP tool and optionally write the result to state |
-| `Fetch` | Make an HTTP request and optionally write the result to state |
+| `CallTool` | Call an MCP tool; result available as `$result` in `on_success` |
+| `Fetch` | Make an HTTP request; result available as `$result` in `on_success` |
 | `SendMessage` | Send a message to the conversation (MCP hosts only) |
 | `UpdateContext` | Push structured context to the model (MCP hosts only) |
 
@@ -171,21 +171,25 @@ Action lists handle the setup: things to do *before* or *alongside* an interacti
 Every action supports `on_success` and `on_error`. They fire after the action resolves, with the outcome determining which branch runs. Both accept a single action or a list.
 
 ```python
-from prefab_ui.actions.mcp import CallTool
 from prefab_ui.actions import SetState, ShowToast
+from prefab_ui.actions.mcp import CallTool
+from prefab_ui.rx import RESULT
 
 Button(
-    "Save", 
+    "Save",
     on_click=CallTool(
         "save_record",
         arguments={"data": Rx("form")},
-        on_success=ShowToast("Saved!", variant="success"),
+        on_success=[
+            SetState("result", RESULT),
+            ShowToast("Saved!", variant="success"),
+        ],
         on_error=ShowToast("{{ $error }}", variant="error"),
     ),
 )
 ```
 
-`$error` is available inside `on_error` callbacks; it holds the error message from the failed action.
+`$result` is available inside `on_success` callbacks; it holds the return value of the action that just completed. `$error` is available inside `on_error` callbacks; it holds the error message from the failed action. These are a matched pair: each exists only within its respective callback scope.
 
 Callbacks can themselves have callbacks, making it possible to chain dependent server calls: the result of the first determines what to fetch next.
 
@@ -193,12 +197,14 @@ Callbacks can themselves have callbacks, making it possible to chain dependent s
 CallTool(
     "get_user",
     arguments={"id": Rx("user_id")},
-    result_key="user",
-    on_success=CallTool(
-        "get_permissions",
-        arguments={"role": "{{ user.role }}"},
-        result_key="permissions",
-    ),
+    on_success=[
+        SetState("user", RESULT),
+        CallTool(
+            "get_permissions",
+            arguments={"role": "{{ user.role }}"},
+            on_success=SetState("permissions", RESULT),
+        ),
+    ],
 )
 ```
 
@@ -238,26 +244,29 @@ The button label switches and disables while the call is in flight. Both branche
 
 ### Populating results
 
-For search and filter patterns, use `result_key` to write the tool's response directly into state, then have a `ForEach` or `Slot` display it:
+For search and filter patterns, use `RESULT` in an `on_success` callback to write the tool's response directly into state, then have a `ForEach` or `Slot` display it:
 
 ```python
+from prefab_ui.actions import SetState
+from prefab_ui.actions.mcp import CallTool
 from prefab_ui.components import Button, Column, ForEach, Input, Text
+from prefab_ui.rx import RESULT
 
 with Column(gap=3):
     query = Input(name="q", placeholder="Search...")
     Button(
-        "Search", 
+        "Search",
         on_click=CallTool(
             "search",
             arguments={"q": query.rx},
-            result_key="results",
+            on_success=SetState("results", RESULT),
         ),
     )
     with ForEach("results"):
         Text("{{ name }}")
 ```
 
-When the tool returns, its `PrefabApp` state is merged into the client's state under `results`. The `ForEach` re-renders with whatever came back.
+When the tool returns, `RESULT` holds the response data. `SetState` writes it to `results`, and the `ForEach` re-renders with whatever came back.
 
 ### Optimistic updates
 

--- a/docs/concepts/state.mdx
+++ b/docs/concepts/state.mdx
@@ -197,6 +197,6 @@ If any segment along a path is missing or the wrong type, the expression resolve
 
 ## Writing to state
 
-Two things write to state: interactive controls (automatically, via the `name` prop) and [actions](/guides/actions) (explicitly, in response to events). `SetState` assigns a value. `ToggleState` flips a boolean. `AppendState` and `PopState` manipulate arrays. `CallTool` and `Fetch` can write their results into state via `result_key`.
+Two things write to state: interactive controls (automatically, via the `name` prop) and [actions](/guides/actions) (explicitly, in response to events). `SetState` assigns a value. `ToggleState` flips a boolean. `AppendState` and `PopState` manipulate arrays. `CallTool` and `Fetch` make their results available as `$result` in `on_success` callbacks, where you can write them to state with `SetState`.
 
 State is deliberately simple: a flat map with dot-path addressing for nesting. There are no computed properties, no watchers, no derived state in the store itself. Derived values belong in [expressions](/guides/expressions), where they're computed at render time from whatever state holds. Complex computations belong in Python, run before you return the component tree, or in a server action.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -199,9 +199,9 @@
                   "actions/show-toast",
                   "actions/update-state",
                   "actions/call-tool",
-                  "actions/request-display-mode",
                   "actions/send-message",
-                  "actions/update-context"
+                  "actions/update-context",
+                  "actions/request-display-mode"
                 ]
               },
               {
@@ -213,6 +213,7 @@
                   "reactive/host",
                   "reactive/index",
                   "reactive/item",
+                  "reactive/result",
                   "reactive/state"
                 ]
               },

--- a/docs/expressions/context.mdx
+++ b/docs/expressions/context.mdx
@@ -40,7 +40,7 @@ Text(f"You typed: {search.rx}")
 # search.rx is Rx("query") → {{ query }}
 ```
 
-**Actions** write to state when they fire. [SetState](/actions/update-state) sets a key to an explicit value (or defaults to `$event` — see below). [CallTool](/actions/call-tool) runs server-side logic and writes the result to state via `result_key`. Either way, the new value is immediately available to every expression that references that key.
+**Actions** write to state when they fire. [SetState](/actions/update-state) sets a key to an explicit value (or defaults to `$event` — see below). [CallTool](/actions/call-tool) and [Fetch](/actions/fetch) run server-side logic and make the result available as `$result` inside `on_success` callbacks, where you can write it to state with `SetState`. Either way, the new value is immediately available to every expression that references that key.
 
 ## Local Scope (`let`)
 
@@ -128,6 +128,26 @@ Available inside action handlers. It contains the value from the interaction tha
 | Button | `undefined` |
 
 When you need to capture the event value explicitly — for example, to store it under a different key or transform it — pass `EVENT` as the value: `SetState("last_volume", EVENT)`. For form controls like Slider and Input, the component's own state key updates automatically, so a separate `SetState` is only needed when you want to write the value somewhere else.
+
+### `$result`
+
+Available inside `on_success` callbacks. Contains the return value of the action that just completed — the parsed JSON from a `Fetch` response, or the `PrefabApp` result from a `CallTool`. Use it with `SetState` to write the result into state:
+
+```python
+from prefab_ui.components import Button
+from prefab_ui.actions import Fetch, SetState
+from prefab_ui.rx import RESULT
+
+Button(
+    "Load Users",
+    on_click=Fetch.get(
+        "/api/users",
+        on_success=SetState("users", RESULT),
+    ),
+)
+```
+
+`$result` is the success counterpart of `$error`: one is available in `on_success`, the other in `on_error`. Neither exists outside its callback scope.
 
 ### `$error`
 

--- a/docs/protocol/call-tool.mdx
+++ b/docs/protocol/call-tool.mdx
@@ -22,14 +22,6 @@ Call an MCP server tool via `app.callServerTool()`.
       "additionalProperties": true,
       "description": "Arguments to pass. Supports {{ key }} interpolation.",
       "type": "object"
-    },
-    "resultKey": {
-      "type": [
-        "string",
-        "null"
-      ],
-      "default": null,
-      "description": "State key to store the tool result under"
     }
   },
   "required": [

--- a/docs/protocol/fetch.mdx
+++ b/docs/protocol/fetch.mdx
@@ -56,14 +56,6 @@ Make an HTTP request from the browser.
       ],
       "default": null,
       "description": "Request body. Dicts are JSON-serialized automatically."
-    },
-    "resultKey": {
-      "type": [
-        "string",
-        "null"
-      ],
-      "default": null,
-      "description": "State key to store the response under."
     }
   },
   "required": [

--- a/docs/protocol/tool-call.mdx
+++ b/docs/protocol/tool-call.mdx
@@ -22,14 +22,6 @@ Call an MCP server tool via `app.callServerTool()`.
       "additionalProperties": true,
       "description": "Arguments to pass. Supports {{ key }} interpolation.",
       "type": "object"
-    },
-    "resultKey": {
-      "type": [
-        "string",
-        "null"
-      ],
-      "default": null,
-      "description": "State key to store the tool result under"
     }
   },
   "required": [

--- a/docs/reactive/result.mdx
+++ b/docs/reactive/result.mdx
@@ -1,0 +1,53 @@
+---
+title: RESULT
+sidebarTitle: $result
+description: The action's return value available in on_success callbacks.
+icon: circle-check
+---
+
+`RESULT` is a reactive reference to `$result` — the return value available inside `on_success` callbacks. When an action completes successfully, the framework captures its output and makes it available through this variable.
+
+```python
+from prefab_ui.components import Button
+from prefab_ui.actions import SetState
+from prefab_ui.actions.mcp import CallTool
+from prefab_ui.rx import RESULT
+
+Button(
+    "Search",
+    on_click=CallTool(
+        "search",
+        arguments={"q": "{{ query }}"},
+        on_success=SetState("results", RESULT),
+    ),
+)
+```
+
+## Where It's Available
+
+`RESULT` is only meaningful inside `on_success` handlers. Outside that context, `$result` is undefined. Every action that supports callbacks (`on_success` / `on_error`) makes this variable available when the action succeeds.
+
+For `CallTool`, `$result` is the tool's return value (parsed as JSON when possible). For `Fetch`, it's the parsed response body. You can use it with any action in the callback:
+
+```python
+from prefab_ui.actions import AppendState, SetState, ShowToast
+from prefab_ui.actions.mcp import CallTool
+from prefab_ui.rx import RESULT
+
+CallTool(
+    "create_item",
+    arguments={"name": "{{ item_name }}"},
+    on_success=[
+        AppendState("items", RESULT),
+        ShowToast("Created!", variant="success"),
+    ],
+)
+```
+
+`$result` is the success counterpart of `$error`: one is available in `on_success`, the other in `on_error`. Neither exists outside its callback scope.
+
+## Import
+
+```python
+from prefab_ui.rx import RESULT
+```

--- a/docs/running/api.mdx
+++ b/docs/running/api.mdx
@@ -14,7 +14,7 @@ Prefab has no dependency on any web framework. This guide uses [FastAPI](https:/
 A Prefab + FastAPI app has three kinds of routes:
 
 - **Page routes** return HTML — they build a component tree, wrap it in `PrefabApp`, and call `.html()`
-- **Data routes** return plain JSON (lists, dicts) — consumed via `result_key` into state
+- **Data routes** return plain JSON (lists, dicts) — written into state via `SetState` in an `on_success` callback
 - **Component routes** return a component tree as JSON (via `.to_json()`) — rendered by a [`Slot`](/components/slot)
 
 <Tip>
@@ -31,6 +31,7 @@ from prefab_ui.actions import Fetch, SetState
 from prefab_ui.app import PrefabApp
 from prefab_ui.components import Column, Input, Text
 from prefab_ui.components.control_flow import ForEach
+from prefab_ui.rx import RESULT
 
 app = FastAPI()
 
@@ -54,7 +55,7 @@ def page():
                 Fetch.get(
                     "/api/items",
                     params={"q": "{{ $event }}"},
-                    result_key="items",
+                    on_success=SetState("items", RESULT),
                 ),
             ],
         )
@@ -82,12 +83,15 @@ When an Input has `on_change`, you must include `SetState` to update the input's
 
 ### Loading Data
 
-`Fetch.get` makes a GET request and writes the parsed JSON response into client-side state via `result_key`. Components that reference that key re-render automatically.
+`Fetch.get` makes a GET request. The parsed JSON response is available as `$result` (Python: `RESULT`) inside the `on_success` callback. Use `SetState` to write it into client-side state, and components that reference that key re-render automatically.
 
 ```python
+from prefab_ui.actions import Fetch, SetState
+from prefab_ui.rx import RESULT
+
 Button(
     "Load Users",
-    on_click=Fetch.get("/api/users", result_key="users"),
+    on_click=Fetch.get("/api/users", on_success=SetState("users", RESULT)),
 )
 ```
 
@@ -136,7 +140,7 @@ For forms that shouldn't clutter the main layout, put them inside a `Dialog`. Us
 ```python {10-14}
 from prefab_ui.actions import CloseOverlay, Fetch, SetState, ShowToast
 from prefab_ui.components import Button, Column, Dialog, Form, Input
-from prefab_ui.rx import Rx
+from prefab_ui.rx import RESULT, Rx
 
 new_name = Rx("new_name")
 
@@ -149,7 +153,7 @@ with Dialog(title="New Item", description="Add an item to the catalog."):
             on_success=[
                 ShowToast("Created!", variant="success"),
                 SetState("new_name", ""),
-                Fetch.get("/api/items", result_key="items"),
+                Fetch.get("/api/items", on_success=SetState("items", RESULT)),
                 CloseOverlay(),
             ],
             on_error=ShowToast("{{ $error }}", variant="error"),
@@ -174,7 +178,7 @@ Button(
     variant="ghost",
     on_click=Fetch.delete(
         "/api/items/{{ id }}",
-        on_success=Fetch.get("/api/items", result_key="items"),
+        on_success=Fetch.get("/api/items", on_success=SetState("items", RESULT)),
         on_error=ShowToast("{{ $error }}", variant="error"),
     ),
 )
@@ -187,7 +191,9 @@ Data routes return plain values that templates interpolate. But sometimes you wa
 A component route builds a component tree in Python and returns its JSON representation. On the client, a [`Slot`](/components/slot) renders whatever component tree lands in its state key:
 
 ```python {11,25}
+from prefab_ui.actions import Fetch, SetState
 from prefab_ui.components import Card, CardContent, CardHeader, CardTitle, Text
+from prefab_ui.rx import RESULT
 
 @app.get("/api/items/{id}/detail")
 def item_detail(id: str):
@@ -208,7 +214,7 @@ def page():
                 "{{ name }}",
                 on_click=Fetch.get(
                     "/api/items/{{ id }}/detail",
-                    result_key="detail",
+                    on_success=SetState("detail", RESULT),
                 ),
             )
         with Slot("detail"):
@@ -279,7 +285,8 @@ If the request fails, the chain stops — `SetState("saving", False)` never runs
 After a successful POST or DELETE, you often want to reload the data list. Chain a `Fetch.get` inside `on_success`:
 
 ```python
-from prefab_ui.rx import Rx
+from prefab_ui.actions import Fetch, SetState, ShowToast
+from prefab_ui.rx import RESULT, Rx
 
 new_name = Rx("new_name")
 
@@ -288,7 +295,7 @@ Fetch.post(
     body={"name": new_name},
     on_success=[
         ShowToast("Created!", variant="success"),
-        Fetch.get("/api/items", result_key="items"),
+        Fetch.get("/api/items", on_success=SetState("items", RESULT)),
     ],
 )
 ```

--- a/docs/running/fastmcp.mdx
+++ b/docs/running/fastmcp.mdx
@@ -79,9 +79,13 @@ Return a `PrefabApp` when you need initial state, a page title, or reusable defi
 
 ### Calling Back to the Server
 
-[`CallTool`](/actions/call-tool) is the MCP equivalent of [`Fetch`](/actions/fetch). It sends a tool call through MCP and writes the response into client-side state:
+[`CallTool`](/actions/call-tool) is the MCP equivalent of [`Fetch`](/actions/fetch). It sends a tool call through MCP, and the response is available as `$result` (Python: `RESULT`) in the `on_success` callback:
 
 ```python
+from prefab_ui.actions import SetState
+from prefab_ui.actions.mcp import CallTool
+from prefab_ui.rx import RESULT
+
 @mcp.tool(app=True)
 def browse() -> PrefabApp:
     with Column(gap=4) as view:
@@ -90,7 +94,7 @@ def browse() -> PrefabApp:
             placeholder="Search...",
             on_change=[
                 SetState("q", "{{ $event }}"),
-                CallTool("search", arguments={"q": "{{ $event }}"}, result_key="results"),
+                CallTool("search", arguments={"q": "{{ $event }}"}, on_success=SetState("results", RESULT)),
             ],
         )
         Slot("results")
@@ -112,7 +116,7 @@ The first tool (`browse`) defines the layout with a `Slot`. The second tool (`se
 
 ### Dynamic Component Results with Slot
 
-When a `CallTool` has `result_key`, the tool's `PrefabApp` response is written into that state key. A [`Slot`](/components/slot) watching that key renders whatever component tree arrives:
+When a `CallTool` writes its result into state via `SetState("key", RESULT)` in `on_success`, a [`Slot`](/components/slot) watching that key renders whatever component tree arrives:
 
 ```python {5,11}
 # In the main view

--- a/examples/hitchhikers-guide/api_server.py
+++ b/examples/hitchhikers-guide/api_server.py
@@ -30,7 +30,7 @@ from prefab_ui.components import (
     Text,
 )
 from prefab_ui.components.control_flow import ForEach
-from prefab_ui.rx import ERROR, EVENT
+from prefab_ui.rx import ERROR, EVENT, RESULT
 
 app = FastAPI()
 
@@ -88,7 +88,10 @@ def guide():
                                 SetState("new_title", ""),
                                 SetState("new_category", ""),
                                 SetState("new_description", ""),
-                                Fetch.get("/api/entries", result_key="entries"),
+                                Fetch.get(
+                                    "/api/entries",
+                                    on_success=SetState("entries", RESULT),
+                                ),
                                 CloseOverlay(),
                             ],
                             on_error=ShowToast(ERROR, variant="error"),
@@ -109,7 +112,7 @@ def guide():
                 Fetch.get(
                     "/api/entries",
                     params={"q": EVENT},
-                    result_key="entries",
+                    on_success=SetState("entries", RESULT),
                 ),
             ],
         )
@@ -132,7 +135,7 @@ def guide():
                                     on_success=Fetch.get(
                                         "/api/entries",
                                         params={"q": "{{ q }}"},
-                                        result_key="entries",
+                                        on_success=SetState("entries", RESULT),
                                     ),
                                     on_error=ShowToast(ERROR, variant="error"),
                                 ),

--- a/examples/hitchhikers-guide/mcp_server.py
+++ b/examples/hitchhikers-guide/mcp_server.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 
 from data import ENTRIES, add_entry, delete_entry, search_entries
 from fastmcp import FastMCP
-from fastmcp.server.apps import AppConfig
 
 from prefab_ui.actions import CloseOverlay, SetState, ShowToast
 from prefab_ui.actions.mcp import CallTool, SendMessage, UpdateContext
@@ -34,7 +33,7 @@ from prefab_ui.components import (
     Tooltip,
 )
 from prefab_ui.components.control_flow import ForEach
-from prefab_ui.rx import ERROR, EVENT
+from prefab_ui.rx import ERROR, EVENT, RESULT
 
 mcp = FastMCP("Hitchhiker's Guide")
 
@@ -59,8 +58,8 @@ def browse() -> PrefabApp:
                             "category": "{{ new_category }}",
                             "description": "{{ new_description }}",
                         },
-                        result_key="entries",
                         on_success=[
+                            SetState("entries", RESULT),
                             ShowToast("Entry added!", variant="success"),
                             SetState("new_title", ""),
                             SetState("new_category", ""),
@@ -84,7 +83,7 @@ def browse() -> PrefabApp:
                 CallTool(
                     "search",
                     arguments={"q": EVENT},
-                    result_key="entries",
+                    on_success=SetState("entries", RESULT),
                 ),
             ],
         )
@@ -135,7 +134,7 @@ def browse() -> PrefabApp:
                                         on_click=CallTool(
                                             "delete_entry_tool",
                                             arguments={"title": entry.title},
-                                            result_key="entries",
+                                            on_success=SetState("entries", RESULT),
                                             on_error=ShowToast(
                                                 ERROR,
                                                 variant="error",
@@ -158,29 +157,26 @@ def browse() -> PrefabApp:
     )
 
 
-app_only = AppConfig(visibility=["app"])
-
-
-@mcp.tool(app=app_only)
-def search(q: str = "") -> PrefabApp:
+@mcp.tool()
+def search(q: str = "") -> list[dict]:
     """Search the Guide by keyword."""
-    return PrefabApp(state={"entries": search_entries(q)})
+    return search_entries(q)
 
 
-@mcp.tool(app=app_only)
+@mcp.tool()
 def add_entry_tool(
     title: str, category: str = "Uncategorized", description: str = ""
-) -> PrefabApp:
+) -> list[dict]:
     """Add a new entry to the Guide."""
     add_entry(title, category, description)
-    return PrefabApp(state={"entries": ENTRIES})
+    return ENTRIES
 
 
-@mcp.tool(app=app_only)
-def delete_entry_tool(title: str) -> PrefabApp:
+@mcp.tool()
+def delete_entry_tool(title: str) -> list[dict]:
     """Remove an entry from the Guide."""
     delete_entry(title)
-    return PrefabApp(state={"entries": ENTRIES})
+    return ENTRIES
 
 
 if __name__ == "__main__":

--- a/examples/pypi-downloads/api_server.py
+++ b/examples/pypi-downloads/api_server.py
@@ -29,6 +29,7 @@ from prefab_ui.components import (
     Text,
 )
 from prefab_ui.components.base import insert
+from prefab_ui.rx import RESULT
 
 app = FastAPI()
 
@@ -175,11 +176,13 @@ def page():
                             "min_date": "{{ min_date }}",
                             "max_date": "{{ max_date }}",
                         },
-                        result_key="dashboard_content",
-                        on_success=ShowToast(
-                            "Dashboard updated",
-                            variant="success",
-                        ),
+                        on_success=[
+                            SetState("dashboard_content", RESULT),
+                            ShowToast(
+                                "Dashboard updated",
+                                variant="success",
+                            ),
+                        ],
                         on_error=ShowToast("{{ $error }}", variant="error"),
                     ),
                 ):
@@ -213,7 +216,7 @@ def page():
                             Fetch.post(
                                 "/api/render",
                                 body={"show_direct": "{{ $event }}"},
-                                result_key="dashboard_content",
+                                on_success=SetState("dashboard_content", RESULT),
                             ),
                         ],
                     )

--- a/renderer/src/actions-fetch.test.ts
+++ b/renderer/src/actions-fetch.test.ts
@@ -47,13 +47,17 @@ describe("fetch action", () => {
     });
   });
 
-  it("writes result to state via resultKey", async () => {
+  it("passes $result to onSuccess callbacks", async () => {
     mockFetchResponse([{ name: "Alice" }]);
     const state = createStateStore();
     const action: ActionSpec = {
       action: "fetch",
       url: "/api/users",
-      resultKey: "users",
+      onSuccess: {
+        action: "setState",
+        key: "users",
+        value: "{{ $result }}",
+      },
     };
 
     await executeAction(action, null, state);
@@ -130,7 +134,7 @@ describe("fetch action", () => {
     expect(state.get("err")).toBe("404 Not Found");
   });
 
-  it("fires onSuccess with response data as $event", async () => {
+  it("passes $result (not $event) to onSuccess", async () => {
     mockFetchResponse({ count: 42 });
     const state = createStateStore();
     const action: ActionSpec = {
@@ -139,7 +143,7 @@ describe("fetch action", () => {
       onSuccess: {
         action: "setState",
         key: "result",
-        value: "{{ $event }}",
+        value: "{{ $result }}",
       },
     };
 
@@ -154,7 +158,11 @@ describe("fetch action", () => {
     const action: ActionSpec = {
       action: "fetch",
       url: "/api/text",
-      resultKey: "data",
+      onSuccess: {
+        action: "setState",
+        key: "data",
+        value: "{{ $result }}",
+      },
     };
 
     await executeAction(action, null, state);
@@ -175,7 +183,11 @@ describe("fetch action", () => {
     const action: ActionSpec = {
       action: "fetch",
       url: "/api/sneaky-json",
-      resultKey: "data",
+      onSuccess: {
+        action: "setState",
+        key: "data",
+        value: "{{ $result }}",
+      },
     };
 
     await executeAction(action, null, state);
@@ -210,7 +222,6 @@ describe("fetch action", () => {
     const action: ActionSpec = {
       action: "fetch",
       url: "/api/users/{{ userId }}",
-      resultKey: "user",
     };
 
     await executeAction(action, null, state);

--- a/renderer/src/actions.test.ts
+++ b/renderer/src/actions.test.ts
@@ -162,45 +162,45 @@ describe("executeAction", () => {
       expect(result).toBe(true);
     });
 
-    it("writes result to state via resultKey", async () => {
+    it("passes $result to onSuccess callbacks", async () => {
       app.callServerTool.mockResolvedValueOnce({
-        structuredContent: {
-          version: "0.2",
-          view: { type: "Text" },
-          state: { users: [{ name: "Alice" }] },
-        },
+        content: [{ type: "text", text: JSON.stringify([{ name: "Alice" }]) }],
       });
       const state = createStateStore();
       const action: ActionSpec = {
         action: "toolCall",
         tool: "get_users",
-        resultKey: "users",
+        onSuccess: {
+          action: "setState",
+          key: "users",
+          value: "{{ $result }}",
+        },
       };
 
       await executeAction(action, appAsApp, state);
 
-      // Single state key gets unwrapped
       expect(state.get("users")).toEqual([{ name: "Alice" }]);
     });
 
-    it("extracts state from envelope, ignoring protocol keys", async () => {
+    it("parses JSON text content as $result", async () => {
       app.callServerTool.mockResolvedValueOnce({
-        structuredContent: {
-          version: "0.2",
-          view: { type: "Column" },
-          state: { items: [1, 2], total: 2 },
-        },
+        content: [
+          { type: "text", text: JSON.stringify({ items: [1, 2], total: 2 }) },
+        ],
       });
       const state = createStateStore();
       const action: ActionSpec = {
         action: "toolCall",
         tool: "fetch",
-        resultKey: "data",
+        onSuccess: {
+          action: "setState",
+          key: "data",
+          value: "{{ $result }}",
+        },
       };
 
       await executeAction(action, appAsApp, state);
 
-      // Multiple state keys → object with both
       const data = state.get("data") as Record<string, unknown>;
       expect(data).toEqual({ items: [1, 2], total: 2 });
     });

--- a/renderer/src/actions.ts
+++ b/renderer/src/actions.ts
@@ -10,17 +10,15 @@
  *
  *   Button("Save", onClick=[
  *     SetState("saving", true),
- *     CallTool("save_item", resultKey="result",
- *       onSuccess=ShowToast("Saved!"),
+ *     CallTool("save_item",
+ *       onSuccess=SetState("result", "$result"),
  *       onError=ShowToast("Failed", variant="error")),
  *     SetState("saving", false),   // only runs if CallTool succeeded
  *   ])
  *
- * `resultKey` on CallTool writes the tool's response data into state under
- * that key, making results available for template interpolation in the UI.
- *
  * Interpolation context: all state keys as bare names, plus `$event` for
- * the triggering event value and `$error` for error messages in `onError`
+ * the triggering event value, `$result` for the action's return value in
+ * `onSuccess` callbacks, and `$error` for error messages in `onError`
  * callbacks.
  */
 
@@ -77,18 +75,26 @@ function extractErrorText(result: Record<string, unknown>): string {
 }
 
 /**
- * Extract user-facing data from a tool result's structuredContent.
+ * Extract user-facing data from a tool result's content blocks.
  *
- * Reads from the `state` envelope key. If exactly one state key exists,
- * unwraps to its value (so `result_key="users"` with a response
- * of `{state: {users: [...]}}` writes the array directly).
+ * MCP tool results contain an array of content blocks. This extracts text
+ * content and tries to parse it as JSON, falling back to the raw string.
  */
-function extractResultData(structured: Record<string, unknown>): unknown {
-  const state = structured.state as Record<string, unknown> | undefined;
-  if (!state) return undefined;
-  const entries = Object.entries(state);
-  if (entries.length === 1) return entries[0][1];
-  return state;
+function extractToolResultData(result: Record<string, unknown>): unknown {
+  const content = result.content as
+    | Array<{ type: string; text?: string }>
+    | undefined;
+  if (!content?.length) return undefined;
+  const text = content
+    .filter((c) => c.type === "text" && c.text)
+    .map((c) => c.text)
+    .join("");
+  if (!text) return undefined;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
 }
 
 /**
@@ -107,17 +113,19 @@ export async function executeAction(
   error?: string,
   scope?: Record<string, unknown>,
   overlayClose?: OverlayCloseFn,
+  result?: unknown,
 ): Promise<boolean> {
   if (depth > MAX_DEPTH) {
     console.warn("[Prefab] Action callback depth limit exceeded");
     return false;
   }
 
-  // Interpolation context: state + scope (ForEach vars) + $event + $error
+  // Interpolation context: state + scope (ForEach vars) + $event + $result + $error
   const ctx: Record<string, unknown> = {
     ...state.getAll(),
     ...scope,
     $event: event,
+    $result: result,
     $error: error,
   };
 
@@ -135,6 +143,7 @@ export async function executeAction(
 
   let success = true;
   let errorMessage: string | undefined;
+  let resultData: unknown;
 
   try {
     switch (resolved.action) {
@@ -142,20 +151,17 @@ export async function executeAction(
       case "toolCall": {
         const name = resolved.tool as string;
         const args = (resolved.arguments ?? {}) as Record<string, string>;
-        const result = await app?.callServerTool({ name, arguments: args });
-        if (result?.isError) {
+        const toolResult = await app?.callServerTool({
+          name,
+          arguments: args,
+        });
+        if (toolResult?.isError) {
           success = false;
-          errorMessage = extractErrorText(result);
+          errorMessage = extractErrorText(toolResult);
           break;
         }
-        // Write result data into state if resultKey is specified
-        const resultKey = resolved.resultKey as string | undefined;
-        if (resultKey && result?.structuredContent) {
-          const data = extractResultData(
-            result.structuredContent as Record<string, unknown>,
-          );
-          state.set(resultKey, data);
-        }
+        // Extract result data — available as $result in onSuccess callbacks
+        resultData = toolResult ? extractToolResultData(toolResult) : undefined;
         break;
       }
       case "sendMessage": {
@@ -305,26 +311,9 @@ export async function executeAction(
           }
         }
 
-        // Write to state if resultKey set
-        const resultKey = resolved.resultKey as string | undefined;
-        if (resultKey) {
-          state.set(resultKey, data);
-        }
-
-        // Fire onSuccess with response data as $event
-        if (resolved.onSuccess) {
-          await executeActions(
-            resolved.onSuccess,
-            app,
-            state,
-            data,
-            depth + 1,
-            undefined,
-            scope,
-            overlayClose,
-          );
-        }
-        return true;
+        // Response data is available as $result in onSuccess callbacks
+        resultData = data;
+        break;
       }
 
       case "openFilePicker": {
@@ -375,21 +364,9 @@ export async function executeAction(
           return true;
         }
 
-        // Fire onSuccess with the file data as $event
-        if (resolved.onSuccess) {
-          await executeActions(
-            resolved.onSuccess,
-            app,
-            state,
-            fileData,
-            depth + 1,
-            undefined,
-            scope,
-            overlayClose,
-          );
-        }
-        // Skip the generic onSuccess handling below
-        return true;
+        // File data is available as $result in onSuccess callbacks
+        resultData = fileData;
+        break;
       }
 
       case "setInterval": {
@@ -483,7 +460,7 @@ export async function executeAction(
     errorMessage = e instanceof Error ? e.message : String(e);
   }
 
-  // Dispatch lifecycle callbacks, passing $error to onError
+  // Dispatch lifecycle callbacks: $result to onSuccess, $error to onError
   if (success && resolved.onSuccess) {
     await executeActions(
       resolved.onSuccess,
@@ -494,6 +471,7 @@ export async function executeAction(
       undefined,
       scope,
       overlayClose,
+      resultData,
     );
   } else if (!success && resolved.onError) {
     await executeActions(
@@ -527,6 +505,7 @@ export async function executeActions(
   error?: string,
   scope?: Record<string, unknown>,
   overlayClose?: OverlayCloseFn,
+  result?: unknown,
 ): Promise<void> {
   const list = Array.isArray(actions) ? actions : [actions];
   for (const action of list) {
@@ -539,6 +518,7 @@ export async function executeActions(
       error,
       scope,
       overlayClose,
+      result,
     );
     if (!ok) break;
   }

--- a/renderer/src/app.tsx
+++ b/renderer/src/app.tsx
@@ -15,7 +15,7 @@
  *
  * State model: the `state` key in structuredContent holds client-side state.
  * The model sees initial state via structuredContent; all subsequent mutations
- * (SetState, form inputs, CallTool result_key) are renderer-private and never
+ * (SetState, form inputs, action callbacks) are renderer-private and never
  * propagate back.
  */
 

--- a/renderer/src/schemas/actions.ts
+++ b/renderer/src/schemas/actions.ts
@@ -26,7 +26,6 @@ export const toolCallSchema = z.object({
   action: z.literal("toolCall"),
   tool: z.string(),
   arguments: z.record(z.string(), z.unknown()).optional(),
-  resultKey: z.string().optional(),
   ...actionCallbacks,
 });
 
@@ -113,7 +112,6 @@ export const fetchSchema = z.object({
   method: z.enum(["GET", "POST", "PUT", "PATCH", "DELETE"]).optional(),
   headers: z.record(z.string(), z.string()).optional(),
   body: z.union([z.record(z.string(), z.unknown()), z.string()]).optional(),
-  resultKey: z.string().optional(),
   ...actionCallbacks,
 });
 

--- a/src/prefab_ui/actions/fetch.py
+++ b/src/prefab_ui/actions/fetch.py
@@ -7,11 +7,12 @@ that talks HTTP without going through an MCP server.
 Example::
 
     from prefab_ui.components import Button
-    from prefab_ui.actions import Fetch, ShowToast
+    from prefab_ui.actions import Fetch, SetState, ShowToast
+    from prefab_ui.rx import RESULT
 
     Button("Load Users", on_click=Fetch.get(
         "/api/users",
-        result_key="users",
+        on_success=SetState("users", RESULT),
         on_error=ShowToast("{{ $error }}", variant="error"),
     ))
 """
@@ -21,10 +22,9 @@ from __future__ import annotations
 from typing import Any, Literal
 from urllib.parse import quote
 
-from pydantic import Field, field_validator
+from pydantic import Field
 
 from prefab_ui.actions.base import Action
-from prefab_ui.actions.state import _validate_path
 from prefab_ui.rx import RxStr
 
 Method = Literal["GET", "POST", "PUT", "PATCH", "DELETE"]
@@ -33,13 +33,10 @@ Method = Literal["GET", "POST", "PUT", "PATCH", "DELETE"]
 class Fetch(Action):
     """Make an HTTP request from the browser.
 
-    Fires ``onSuccess`` with the parsed response body as ``$event``.
-    JSON responses are parsed automatically; other content types return
-    the raw text. Non-2xx responses trigger ``onError`` with the status
-    text as ``$error``.
-
-    If ``result_key`` is set, the response body is written into
-    client-side state at that key.
+    The parsed response body is available as ``$result`` in ``on_success``
+    callbacks. JSON responses are parsed automatically; other content types
+    return the raw text. Non-2xx responses trigger ``on_error`` with the
+    status text as ``$error``.
     """
 
     action: Literal["fetch"] = "fetch"
@@ -53,18 +50,6 @@ class Fetch(Action):
         default=None,
         description="Request body. Dicts are JSON-serialized automatically.",
     )
-    result_key: str | None = Field(
-        default=None,
-        alias="resultKey",
-        description="State key to store the response under.",
-    )
-
-    @field_validator("result_key")
-    @classmethod
-    def _validate_result_key(cls, v: str | None) -> str | None:
-        if v is not None:
-            _validate_path(v)
-        return v
 
     def __init__(self, url: str, **kwargs: Any) -> None:
         kwargs["url"] = url

--- a/src/prefab_ui/actions/mcp.py
+++ b/src/prefab_ui/actions/mcp.py
@@ -29,9 +29,8 @@ class CallTool(Action):
     ``PrefabApp.to_json(tool_resolver=...)``.  Without a resolver,
     the function's ``__name__`` is used as a fallback.
 
-    If ``result_key`` is set, the tool's return value is written into
-    client-side state at that key. The key supports interpolation:
-    ``result_key="detail_{{ selectedId }}"``.
+    The tool's return value is available as ``$result`` in ``on_success``
+    callbacks.
     """
 
     action: Literal["toolCall"] = "toolCall"
@@ -39,11 +38,6 @@ class CallTool(Action):
     arguments: dict[str, Any] = Field(
         default_factory=dict,
         description="Arguments to pass. Supports {{ key }} interpolation.",
-    )
-    result_key: str | None = Field(
-        default=None,
-        alias="resultKey",
-        description="State key to store the tool result under",
     )
     _tool_ref: Callable[..., Any] | None = PrivateAttr(default=None)
 

--- a/src/prefab_ui/components/__init__.py
+++ b/src/prefab_ui/components/__init__.py
@@ -19,7 +19,7 @@ from prefab_ui.components.base import (
     defer,
     insert,
 )
-from prefab_ui.rx import ERROR, EVENT, INDEX, ITEM, STATE, Rx, RxStr
+from prefab_ui.rx import ERROR, EVENT, INDEX, ITEM, RESULT, STATE, Rx, RxStr
 from prefab_ui.components.button import Button
 from prefab_ui.components.calendar import Calendar
 from prefab_ui.components.button_group import ButtonGroup
@@ -109,6 +109,7 @@ __all__ = [
     "H4",
     "INDEX",
     "ITEM",
+    "RESULT",
     "STATE",
     "Accordion",
     "AccordionItem",

--- a/src/prefab_ui/components/form.py
+++ b/src/prefab_ui/components/form.py
@@ -225,8 +225,6 @@ def _maybe_enrich_tool_call(
         "tool": on_submit._tool_ref or on_submit.tool,
         "arguments": {"data": field_templates},
     }
-    if on_submit.result_key is not None:
-        kwargs["result_key"] = on_submit.result_key
     if on_submit.on_success is not None:
         kwargs["on_success"] = on_submit.on_success
     if on_submit.on_error is not None:

--- a/src/prefab_ui/components/slot.py
+++ b/src/prefab_ui/components/slot.py
@@ -19,12 +19,15 @@ class Slot(ContainerComponent):
         with Slot("detail_view"):
             Text("Select an item to see details")
 
-    The slot content is typically populated by an action with
-    ``result_key``::
+    The slot content is typically populated by writing component JSON
+    into state via ``SetState`` in an ``on_success`` callback::
 
         Button(
             "Load Details",
-            on_click=CallTool("get_detail", result_key="detail_view"),
+            on_click=CallTool(
+                "get_detail",
+                on_success=SetState("detail_view", RESULT),
+            ),
         )
     """
 

--- a/src/prefab_ui/rx/__init__.py
+++ b/src/prefab_ui/rx/__init__.py
@@ -625,3 +625,6 @@ EVENT: Rx = Rx("$event")
 
 #: The error message in ``on_error`` handlers.
 ERROR: Rx = Rx("$error")
+
+#: The action result in ``on_success`` handlers.
+RESULT: Rx = Rx("$result")

--- a/tests/actions/test_fetch.py
+++ b/tests/actions/test_fetch.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import pytest
-
 from prefab_ui.actions import Fetch, SetState, ShowToast
 from prefab_ui.components import Button
 
@@ -29,15 +27,14 @@ class TestFetchSerialization:
         d = a.model_dump(by_alias=True, exclude_none=True)
         assert d["headers"]["Authorization"] == "Bearer {{ token }}"
 
-    def test_result_key_serializes(self):
-        a = Fetch("/api/users", result_key="users")
-        d = a.model_dump(by_alias=True, exclude_none=True)
-        assert d["resultKey"] == "users"
+    def test_on_success_with_result(self):
+        from prefab_ui.rx import RESULT
 
-    def test_result_key_excluded_when_none(self):
-        a = Fetch("/api/users")
+        a = Fetch("/api/users", on_success=SetState("users", RESULT))
         d = a.model_dump(by_alias=True, exclude_none=True)
-        assert "resultKey" not in d
+        assert d["onSuccess"]["action"] == "setState"
+        assert d["onSuccess"]["key"] == "users"
+        assert d["onSuccess"]["value"] == "{{ $result }}"
 
     def test_string_body(self):
         a = Fetch("/api/raw", method="POST", body="raw text content")
@@ -50,12 +47,20 @@ class TestFetchSerialization:
             d = a.model_dump(by_alias=True, exclude_none=True)
             assert d["method"] == method
 
-    def test_on_button(self):
-        btn = Button("Load", on_click=Fetch("/api/data", result_key="data"))
+    def test_on_button_with_on_success(self):
+        from prefab_ui.rx import RESULT
+
+        btn = Button(
+            "Load",
+            on_click=Fetch(
+                "/api/data",
+                on_success=SetState("data", RESULT),
+            ),
+        )
         j = btn.to_json()
         assert j["onClick"]["action"] == "fetch"
         assert j["onClick"]["url"] == "/api/data"
-        assert j["onClick"]["resultKey"] == "data"
+        assert j["onClick"]["onSuccess"]["action"] == "setState"
 
     def test_interpolation_in_url(self):
         a = Fetch("/api/users/{{ user_id }}")
@@ -115,10 +120,13 @@ class TestFetchClassmethods:
         d = a.model_dump(by_alias=True, exclude_none=True)
         assert d["method"] == "DELETE"
 
-    def test_classmethod_with_result_key(self):
-        a = Fetch.get("/api/users", result_key="users")
+    def test_classmethod_with_on_success(self):
+        from prefab_ui.rx import RESULT
+
+        a = Fetch.get("/api/users", on_success=SetState("users", RESULT))
         d = a.model_dump(by_alias=True, exclude_none=True)
-        assert d["resultKey"] == "users"
+        assert d["onSuccess"]["action"] == "setState"
+        assert d["onSuccess"]["value"] == "{{ $result }}"
 
     def test_classmethod_with_callbacks(self):
         a = Fetch.post(
@@ -130,20 +138,6 @@ class TestFetchClassmethods:
         d = a.model_dump(by_alias=True, exclude_none=True)
         assert d["onSuccess"]["action"] == "showToast"
         assert d["onError"]["variant"] == "error"
-
-
-class TestFetchResultKeyValidation:
-    def test_valid_key(self):
-        a = Fetch("/api", result_key="users")
-        assert a.result_key == "users"
-
-    def test_dot_path_key(self):
-        a = Fetch("/api", result_key="data.users")
-        assert a.result_key == "data.users"
-
-    def test_invalid_key_rejected(self):
-        with pytest.raises(ValueError, match="Invalid path segment"):
-            Fetch("/api", result_key="bad-key")
 
 
 class TestFetchActionChain:

--- a/tests/actions/test_mcp.py
+++ b/tests/actions/test_mcp.py
@@ -10,7 +10,6 @@ from prefab_ui.actions.mcp import (
     SendMessage,
     UpdateContext,
 )
-from prefab_ui.actions.ui import ShowToast
 from prefab_ui.app import PrefabApp, _tool_resolver
 from prefab_ui.components import Button
 
@@ -28,33 +27,17 @@ class TestCallToolSerialization:
         d = a.model_dump()
         assert d["arguments"]["q"] == "{{ query }}"
 
-    def test_result_key_serializes(self):
-        action = CallTool("search", result_key="results")
-        d = action.model_dump(by_alias=True, exclude_none=True)
-        assert d["resultKey"] == "results"
+    def test_on_success_with_result(self):
+        from prefab_ui.actions.state import SetState
+        from prefab_ui.rx import RESULT
 
-    def test_result_key_excluded_when_none(self):
-        action = CallTool("search")
-        d = action.model_dump(by_alias=True, exclude_none=True)
-        assert "resultKey" not in d
-
-    def test_result_key_with_callbacks(self):
         action = CallTool(
             "search",
-            result_key="results",
-            on_success=ShowToast("Found results!"),
+            on_success=SetState("results", RESULT),
         )
         d = action.model_dump(by_alias=True, exclude_none=True)
-        assert d["resultKey"] == "results"
-        assert d["onSuccess"]["action"] == "showToast"
-
-    def test_result_key_on_component(self):
-        btn = Button(
-            label="Search",
-            on_click=CallTool("search", result_key="results"),
-        )
-        j = btn.to_json()
-        assert j["onClick"]["resultKey"] == "results"
+        assert d["onSuccess"]["action"] == "setState"
+        assert d["onSuccess"]["value"] == "{{ $result }}"
 
 
 class TestCallToolCallableRef:
@@ -141,14 +124,18 @@ class TestCallToolCallableRef:
         assert d["tool"] == "search"
         assert d["arguments"]["q"] == "{{ query }}"
 
-    def test_callable_preserves_result_key(self):
+    def test_callable_with_on_success(self):
+        from prefab_ui.actions.state import SetState
+        from prefab_ui.rx import RESULT
+
         def search(query: str) -> list[str]:
             return []
 
-        a = CallTool(search, result_key="results")
+        a = CallTool(search, on_success=SetState("results", RESULT))
         d = a.model_dump(by_alias=True, exclude_none=True)
         assert d["tool"] == "search"
-        assert d["resultKey"] == "results"
+        assert d["onSuccess"]["action"] == "setState"
+        assert d["onSuccess"]["value"] == "{{ $result }}"
 
 
 class TestSendMessageSerialization:

--- a/tests/test_form_model.py
+++ b/tests/test_form_model.py
@@ -277,12 +277,10 @@ class TestAutoFillConvention:
             M,
             on_submit=CallTool(
                 "save",
-                result_key="result",
                 on_success=ShowToast("Saved!"),
             ),
         )
         j = form.to_json()
-        assert j["onSubmit"]["resultKey"] == "result"
         assert j["onSubmit"]["onSuccess"]["message"] == "Saved!"
 
     def test_action_list_not_auto_filled(self):


### PR DESCRIPTION
`CallTool` and `Fetch` had a `result_key` parameter that auto-wrote the action's response into state. This forced MCP tools to return `PrefabApp(state={...})` envelopes instead of plain data, and meant you couldn't call third-party MCP tools or transform/append results — it was always a full overwrite of a single key.

`$result` replaces this with a simple, composable primitive. It's the success counterpart of `$error`: available inside `on_success` callbacks, holding the action's return value. You decide what to do with it using existing actions.

```python
# Before — tool must return PrefabApp envelope, result_key auto-writes
CallTool("search", arguments={"q": EVENT}, result_key="entries")

# After — tool returns plain data, you compose with SetState/AppendState/etc.
CallTool("search", arguments={"q": EVENT}, on_success=SetState("entries", RESULT))

# Append instead of overwrite
CallTool("create_item", on_success=AppendState("items", RESULT))

# Use in a toast
CallTool("save", on_success=ShowToast("Saved {{ $result.name }}"))
```

Tools return whatever data makes sense — a list, a dict, a string — and the caller decides how to handle it. `Fetch` works the same way: `$result` holds the parsed response body in `on_success` instead of the old `$event` overloading.