### PR TITLE
Remove prek from Marvin workflows

### DIFF
--- a/.github/workflows/marvin-comment-on-issue.yml
+++ b/.github/workflows/marvin-comment-on-issue.yml
@@ -34,11 +34,6 @@ jobs:
       - name: Install dependencies
         run: uv sync --python 3.12
 
-      - name: Run prek
-        uses: j178/prek-action@v1
-        env:
-          SKIP: no-commit-to-branch
-
       - name: Generate Marvin App token
         id: marvin-token
         uses: actions/create-github-app-token@v2

--- a/.github/workflows/marvin-comment-on-pr.yml
+++ b/.github/workflows/marvin-comment-on-pr.yml
@@ -37,11 +37,6 @@ jobs:
       - name: Install dependencies
         run: uv sync --python 3.12
 
-      - name: Run prek
-        uses: j178/prek-action@v1
-        env:
-          SKIP: no-commit-to-branch
-
       - name: Generate Marvin App token
         id: marvin-token
         uses: actions/create-github-app-token@v2


### PR DESCRIPTION
The Marvin workflows run Claude to respond to `/marvin` mentions in issues and PRs. They were also running `prek` (linting) as a prerequisite, which is unnecessary for that purpose and was failing because renderer npm dependencies weren't installed.

Closes nothing — discovered via [this failed run](https://github.com/PrefectHQ/prefab/actions/runs/22809585447/workflow).