### PR TITLE
Fix Select size='sm' to be visually distinct

### DIFF
--- a/renderer/src/style-nova.css
+++ b/renderer/src/style-nova.css
@@ -1073,7 +1073,7 @@
 
 /* MARK: Select */
 .cn-select-trigger {
-  @apply border-input data-[placeholder]:text-muted-foreground dark:bg-input/30 dark:hover:bg-input/50 focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 gap-1.5 rounded-lg border bg-transparent py-2 pr-2 pl-2.5 text-sm transition-colors select-none focus-visible:ring-[3px] aria-invalid:ring-[3px] data-[size=default]:h-8 data-[size=sm]:h-7 data-[size=sm]:rounded-[min(var(--radius-md),10px)] *:data-[slot=select-value]:flex *:data-[slot=select-value]:gap-1.5 [&_svg:not([class*='size-'])]:size-4;
+  @apply border-input data-[placeholder]:text-muted-foreground dark:bg-input/30 dark:hover:bg-input/50 focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 gap-1.5 rounded-lg border bg-transparent text-sm transition-colors select-none focus-visible:ring-[3px] aria-invalid:ring-[3px] data-[size=default]:h-8 data-[size=default]:py-2 data-[size=default]:pr-2 data-[size=default]:pl-2.5 data-[size=sm]:h-7 data-[size=sm]:py-1 data-[size=sm]:pr-1.5 data-[size=sm]:pl-2 data-[size=sm]:text-xs data-[size=sm]:rounded-[min(var(--radius-md),10px)] *:data-[slot=select-value]:flex *:data-[slot=select-value]:gap-1.5 [&_svg:not([class*='size-'])]:size-4;
 }
 
 .cn-select-value {


### PR DESCRIPTION
The sm Select variant was only 4px shorter than default with identical text size and padding — barely distinguishable. Now sm gets `text-xs`, tighter padding (`py-1 pr-1.5 pl-2`), and the reduced height makes it clearly a smaller control.

Closes #177