### PR TITLE
Fix OpenLink and Fetch __init__ to accept Rx values

### DIFF
--- a/src/prefab_ui/actions/fetch.py
+++ b/src/prefab_ui/actions/fetch.py
@@ -51,7 +51,7 @@ class Fetch(Action):
         description="Request body. Dicts are JSON-serialized automatically.",
     )
 
-    def __init__(self, url: str, **kwargs: Any) -> None:
+    def __init__(self, url: RxStr, **kwargs: Any) -> None:
         kwargs["url"] = url
         super().__init__(**kwargs)
 

--- a/src/prefab_ui/actions/navigation.py
+++ b/src/prefab_ui/actions/navigation.py
@@ -16,6 +16,6 @@ class OpenLink(Action):
     action: Literal["openLink"] = "openLink"
     url: RxStr = Field(description="URL to open")
 
-    def __init__(self, url: str, **kwargs: Any) -> None:
+    def __init__(self, url: RxStr, **kwargs: Any) -> None:
         kwargs["url"] = url
         super().__init__(**kwargs)


### PR DESCRIPTION
`OpenLink` and `Fetch` declare `url: str` in their `__init__` signatures, but the underlying field is typed `RxStr = str | Rx`. Passing an `Rx` value (e.g. `OpenLink(RESULT)` after a fetch) fails static type checking even though it works at runtime.

```python
# Before: type error
OpenLink(RESULT)  # Expected str, found Rx

# After: works correctly
OpenLink(RESULT)
```