### PR TITLE
Purge jsDelivr cache after renderer publish

### DIFF
--- a/.github/workflows/publish-renderer.yml
+++ b/.github/workflows/publish-renderer.yml
@@ -47,3 +47,10 @@ jobs:
 
       - run: npm publish --access public --tag latest
         working-directory: renderer
+
+      - name: Purge jsDelivr @latest cache
+        run: |
+          # The docs loader imports from @latest on jsDelivr. After publishing
+          # a new version, purge the CDN cache so the @latest alias resolves
+          # to the just-published version immediately.
+          curl -s "https://purge.jsdelivr.net/npm/@prefecthq/prefab-ui@latest/dist/_renderer/embed.mjs"


### PR DESCRIPTION
The v0.11.2 release exposed a gap in our deploy pipeline: the docs site loaded a stale renderer from jsDelivr because the CDN was still caching `@latest` at v0.11.0. The welcome page GridItem had switched from `colSpan=2` (inline style) to `cssClass="md:col-span-2"` (CSS class) in #262, but the cached renderer CSS didn't include that class — so cols 3+4 collapsed into a single column.

Adds a `curl` to the jsDelivr purge API after `npm publish` so the `@latest` alias resolves to the just-published version immediately.