### PR TITLE
Compress playground URLs with gzip

### DIFF
--- a/docs-build/render_previews.py
+++ b/docs-build/render_previews.py
@@ -14,6 +14,7 @@ Run via: uv run docs-build/render_previews.py
 from __future__ import annotations
 
 import base64
+import gzip
 import json
 import re
 import shutil
@@ -263,7 +264,11 @@ def process_file(path: Path, *, docs_dir: Path) -> bool:
 
         # Build new opening tag with inline JSON and playground link
         attrs = _extract_attrs(opening_tag)
-        pg_encoded = base64.b64encode(python_source.encode()).decode()
+        pg_encoded = (
+            base64.urlsafe_b64encode(gzip.compress(python_source.encode()))
+            .rstrip(b"=")
+            .decode()
+        )
         new_opening = _build_opening_tag(attrs, inline_json, pg_encoded)
 
         # Ensure icon attribute on the Python fence line

--- a/renderer/package-lock.json
+++ b/renderer/package-lock.json
@@ -25,6 +25,7 @@
         "dompurify": "^3.3.1",
         "highlight.js": "^11.11.1",
         "lucide-react": "^0.563.0",
+        "pako": "^2.1.0",
         "react": "^19.0.0",
         "react-day-picker": "^9.13.0",
         "react-dom": "^19.0.0",
@@ -40,6 +41,7 @@
       "devDependencies": {
         "@tailwindcss/vite": "^4.0.0",
         "@types/node": "^25.2.1",
+        "@types/pako": "^2.0.4",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
         "@vitejs/plugin-react-swc": "^4.2.3",
@@ -2118,6 +2120,13 @@
       "dependencies": {
         "undici-types": "~7.16.0"
       }
+    },
+    "node_modules/@types/pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "19.2.13",
@@ -4947,6 +4956,12 @@
       "dependencies": {
         "wrappy": "1"
       }
+    },
+    "node_modules/pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
+      "license": "(MIT AND Zlib)"
     },
     "node_modules/parse-entities": {
       "version": "4.0.2",

--- a/renderer/package.json
+++ b/renderer/package.json
@@ -50,6 +50,7 @@
     "dompurify": "^3.3.1",
     "highlight.js": "^11.11.1",
     "lucide-react": "^0.563.0",
+    "pako": "^2.1.0",
     "react": "^19.0.0",
     "react-day-picker": "^9.13.0",
     "react-dom": "^19.0.0",
@@ -65,6 +66,7 @@
   "devDependencies": {
     "@tailwindcss/vite": "^4.0.0",
     "@types/node": "^25.2.1",
+    "@types/pako": "^2.0.4",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react-swc": "^4.2.3",

--- a/renderer/src/playground/playground.tsx
+++ b/renderer/src/playground/playground.tsx
@@ -27,6 +27,29 @@ import { Editor } from "./editor";
 import { executePython, loadPyodideRuntime } from "./pyodide";
 import { EXAMPLES, type Example } from "./examples";
 import { ThemePicker } from "./theme-picker";
+import pako from "pako";
+
+function gzipEncode(str: string): string {
+  const compressed = pako.gzip(new TextEncoder().encode(str));
+  let binary = "";
+  for (const byte of compressed) binary += String.fromCharCode(byte);
+  return btoa(binary)
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+function gzipDecode(encoded: string): string | null {
+  try {
+    const padded = encoded.replace(/-/g, "+").replace(/_/g, "/");
+    const binary = atob(padded);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+    return new TextDecoder().decode(pako.ungzip(bytes));
+  } catch {
+    return null;
+  }
+}
 
 type EditorMode = "python" | "json";
 type PyodideStatus = "idle" | "loading" | "ready" | "error";
@@ -188,19 +211,13 @@ export function Playground() {
         const params = new URLSearchParams(hash);
         const encodedCode = params.get("code");
         if (encodedCode) {
-          try {
-            setCode(decodeURIComponent(escape(atob(encodedCode))));
-          } catch {
-            // ignore malformed hash
-          }
+          const decoded = gzipDecode(encodedCode);
+          if (decoded) setCode(decoded);
         }
         const encodedTheme = params.get("theme");
         if (encodedTheme) {
-          try {
-            setThemeCss(decodeURIComponent(escape(atob(encodedTheme))));
-          } catch {
-            // ignore malformed hash
-          }
+          const decoded = gzipDecode(encodedTheme);
+          if (decoded) setThemeCss(decoded);
         }
       }
       return;
@@ -208,18 +225,12 @@ export function Playground() {
     function onMessage(e: MessageEvent) {
       if (e.data?.type === "pg-init-code") {
         if (typeof e.data.encoded === "string") {
-          try {
-            setCode(decodeURIComponent(escape(atob(e.data.encoded))));
-          } catch {
-            // ignore malformed payload
-          }
+          const decoded = gzipDecode(e.data.encoded);
+          if (decoded) setCode(decoded);
         }
         if (typeof e.data.theme === "string" && e.data.theme) {
-          try {
-            setThemeCss(decodeURIComponent(escape(atob(e.data.theme))));
-          } catch {
-            // ignore malformed payload
-          }
+          const decoded = gzipDecode(e.data.theme);
+          if (decoded) setThemeCss(decoded);
         }
       }
     }
@@ -230,16 +241,12 @@ export function Playground() {
 
   // Build the full hash string from code + theme.
   const buildHash = useCallback((codeStr: string, themeStr: string) => {
-    try {
-      const parts: string[] = [];
-      parts.push(`code=${btoa(unescape(encodeURIComponent(codeStr)))}`);
-      if (themeStr) {
-        parts.push(`theme=${btoa(unescape(encodeURIComponent(themeStr)))}`);
-      }
-      return parts.join("&");
-    } catch {
-      return null;
+    const parts: string[] = [];
+    parts.push(`code=${gzipEncode(codeStr)}`);
+    if (themeStr) {
+      parts.push(`theme=${gzipEncode(themeStr)}`);
     }
+    return parts.join("&");
   }, []);
 
   // Post code changes to parent so it can update the page URL hash.


### PR DESCRIPTION
Playground URLs previously used plain base64 to encode Python source code in the URL hash, which adds ~33% overhead with no compression. This switches to gzip + base64url encoding, which compresses the code before encoding it, producing URLs that are ~40% shorter.

Python side uses stdlib `gzip.compress()` + `base64.urlsafe_b64encode()`. JS side uses `pako` for sync gzip/ungzip with base64url on top. No new Python dependencies needed.

**Note:** This is a breaking change for existing bookmarked playground URLs (old base64-encoded URLs will not decode). Run `prefab dev build-docs` after merging to regenerate all playground props in the MDX files.