### PR TITLE
Render Metric delta as Badge pill

### DIFF
--- a/docs/components/metric.mdx
+++ b/docs/components/metric.mdx
@@ -465,7 +465,7 @@ with Column(gap=4):
 
 Place a [Sparkline](/components/sparkline) as a sibling to CardContent inside the Card. Use `pb-0 gap-0` on the Card to eliminate spacing below the metric, so the sparkline bleeds flush to the bottom edge.
 
-<ComponentPreview json={{"view":{"cssClass":"gap-4","type":"Grid","minColumnWidth":"14rem","children":[{"cssClass":"pb-0 gap-0","type":"Card","children":[{"cssClass":"pb-0","type":"CardContent","children":[{"type":"Metric","label":"Revenue","value":"$1.52M","delta":"+12%"}]},{"cssClass":"h-16","type":"Sparkline","data":[120,132,101,134,90,230,210,182,191,234,290,330],"variant":"success","fill":true,"curve":"linear","strokeWidth":1.5}]},{"cssClass":"pb-0 gap-0","type":"Card","children":[{"cssClass":"pb-0","type":"CardContent","children":[{"type":"Metric","label":"Response Time","value":"284ms","delta":"+18ms","trend":"up","trendSentiment":"negative"}]},{"cssClass":"h-16","type":"Sparkline","data":[180,200,220,205,240,260,250,275,290,284],"variant":"destructive","fill":true,"curve":"linear","strokeWidth":1.5}]},{"cssClass":"pb-0 gap-0","type":"Card","children":[{"cssClass":"pb-0","type":"CardContent","children":[{"type":"Metric","label":"Active Users","value":"26,104","delta":"+4.3%"}]},{"cssClass":"h-16","type":"Sparkline","data":[22,23,21,24,23,25,24,26,25,26],"variant":"info","fill":true,"curve":"linear","strokeWidth":1.5}]}]}}} playground="ZnJvbSBwcmVmYWJfdWkuY29tcG9uZW50cyBpbXBvcnQgQ2FyZCwgQ2FyZENvbnRlbnQsIEdyaWQKZnJvbSBwcmVmYWJfdWkuY29tcG9uZW50cy5jaGFydHMgaW1wb3J0IFNwYXJrbGluZQpmcm9tIHByZWZhYl91aS5jb21wb25lbnRzIGltcG9ydCBNZXRyaWMKCndpdGggR3JpZChtaW5fY29sdW1uX3dpZHRoPSIxNHJlbSIsIGdhcD00KToKICAgIHdpdGggQ2FyZChjc3NfY2xhc3M9InBiLTAgZ2FwLTAiKToKICAgICAgICB3aXRoIENhcmRDb250ZW50KGNzc19jbGFzcz0icGItMCIpOgogICAgICAgICAgICBNZXRyaWMobGFiZWw9IlJldmVudWUiLCB2YWx1ZT0iJDEuNTJNIiwgZGVsdGE9IisxMiUiKQogICAgICAgIFNwYXJrbGluZSgKICAgICAgICAgICAgZGF0YT1bMTIwLCAxMzIsIDEwMSwgMTM0LCA5MCwgMjMwLCAyMTAsIDE4MiwgMTkxLCAyMzQsIDI5MCwgMzMwXSwKICAgICAgICAgICAgdmFyaWFudD0ic3VjY2VzcyIsIGZpbGw9VHJ1ZSwgY3NzX2NsYXNzPSJoLTE2IiwKICAgICAgICApCiAgICB3aXRoIENhcmQoY3NzX2NsYXNzPSJwYi0wIGdhcC0wIik6CiAgICAgICAgd2l0aCBDYXJkQ29udGVudChjc3NfY2xhc3M9InBiLTAiKToKICAgICAgICAgICAgTWV0cmljKAogICAgICAgICAgICAgICAgbGFiZWw9IlJlc3BvbnNlIFRpbWUiLCB2YWx1ZT0iMjg0bXMiLAogICAgICAgICAgICAgICAgZGVsdGE9IisxOG1zIiwgdHJlbmQ9InVwIiwgdHJlbmRfc2VudGltZW50PSJuZWdhdGl2ZSIsCiAgICAgICAgICAgICkKICAgICAgICBTcGFya2xpbmUoCiAgICAgICAgICAgIGRhdGE9WzE4MCwgMjAwLCAyMjAsIDIwNSwgMjQwLCAyNjAsIDI1MCwgMjc1LCAyOTAsIDI4NF0sCiAgICAgICAgICAgIHZhcmlhbnQ9ImRlc3RydWN0aXZlIiwgZmlsbD1UcnVlLCBjc3NfY2xhc3M9ImgtMTYiLAogICAgICAgICkKICAgIHdpdGggQ2FyZChjc3NfY2xhc3M9InBiLTAgZ2FwLTAiKToKICAgICAgICB3aXRoIENhcmRDb250ZW50KGNzc19jbGFzcz0icGItMCIpOgogICAgICAgICAgICBNZXRyaWMobGFiZWw9IkFjdGl2ZSBVc2VycyIsIHZhbHVlPSIyNiwxMDQiLCBkZWx0YT0iKzQuMyUiKQogICAgICAgIFNwYXJrbGluZSgKICAgICAgICAgICAgZGF0YT1bMjIsIDIzLCAyMSwgMjQsIDIzLCAyNSwgMjQsIDI2LCAyNSwgMjZdLAogICAgICAgICAgICB2YXJpYW50PSJpbmZvIiwgZmlsbD1UcnVlLCBjc3NfY2xhc3M9ImgtMTYiLAogICAgICAgICkK">
+<ComponentPreview json={{"view":{"cssClass":"gap-4","type":"Grid","minColumnWidth":"14rem","children":[{"cssClass":"pb-0 gap-0","type":"Card","children":[{"type":"CardContent","children":[{"type":"Metric","label":"Revenue","value":"$1.52M","delta":"+12%"}]},{"cssClass":"h-16","type":"Sparkline","data":[120,132,101,134,90,230,210,182,191,234,290,330],"variant":"success","fill":true,"curve":"linear","strokeWidth":1.5}]},{"cssClass":"pb-0 gap-0","type":"Card","children":[{"type":"CardContent","children":[{"type":"Metric","label":"Response Time","value":"284ms","delta":"+18ms","trend":"up","trendSentiment":"negative"}]},{"cssClass":"h-16","type":"Sparkline","data":[180,200,220,205,240,260,250,275,290,284],"variant":"destructive","fill":true,"curve":"linear","strokeWidth":1.5}]},{"cssClass":"pb-0 gap-0","type":"Card","children":[{"type":"CardContent","children":[{"type":"Metric","label":"Active Users","value":"26,104","delta":"+4.3%"}]},{"cssClass":"h-16","type":"Sparkline","data":[22,23,21,24,23,25,24,26,25,26],"variant":"info","fill":true,"curve":"linear","strokeWidth":1.5}]}]}}} playground="ZnJvbSBwcmVmYWJfdWkuY29tcG9uZW50cyBpbXBvcnQgQ2FyZCwgQ2FyZENvbnRlbnQsIEdyaWQKZnJvbSBwcmVmYWJfdWkuY29tcG9uZW50cy5jaGFydHMgaW1wb3J0IFNwYXJrbGluZQpmcm9tIHByZWZhYl91aS5jb21wb25lbnRzIGltcG9ydCBNZXRyaWMKCndpdGggR3JpZChtaW5fY29sdW1uX3dpZHRoPSIxNHJlbSIsIGdhcD00KToKICAgIHdpdGggQ2FyZChjc3NfY2xhc3M9InBiLTAgZ2FwLTAiKToKICAgICAgICB3aXRoIENhcmRDb250ZW50KCk6CiAgICAgICAgICAgIE1ldHJpYyhsYWJlbD0iUmV2ZW51ZSIsIHZhbHVlPSIkMS41Mk0iLCBkZWx0YT0iKzEyJSIpCiAgICAgICAgU3BhcmtsaW5lKAogICAgICAgICAgICBkYXRhPVsxMjAsIDEzMiwgMTAxLCAxMzQsIDkwLCAyMzAsIDIxMCwgMTgyLCAxOTEsIDIzNCwgMjkwLCAzMzBdLAogICAgICAgICAgICB2YXJpYW50PSJzdWNjZXNzIiwgZmlsbD1UcnVlLCBjc3NfY2xhc3M9ImgtMTYiLAogICAgICAgICkKICAgIHdpdGggQ2FyZChjc3NfY2xhc3M9InBiLTAgZ2FwLTAiKToKICAgICAgICB3aXRoIENhcmRDb250ZW50KCk6CiAgICAgICAgICAgIE1ldHJpYygKICAgICAgICAgICAgICAgIGxhYmVsPSJSZXNwb25zZSBUaW1lIiwgdmFsdWU9IjI4NG1zIiwKICAgICAgICAgICAgICAgIGRlbHRhPSIrMThtcyIsIHRyZW5kPSJ1cCIsIHRyZW5kX3NlbnRpbWVudD0ibmVnYXRpdmUiLAogICAgICAgICAgICApCiAgICAgICAgU3BhcmtsaW5lKAogICAgICAgICAgICBkYXRhPVsxODAsIDIwMCwgMjIwLCAyMDUsIDI0MCwgMjYwLCAyNTAsIDI3NSwgMjkwLCAyODRdLAogICAgICAgICAgICB2YXJpYW50PSJkZXN0cnVjdGl2ZSIsIGZpbGw9VHJ1ZSwgY3NzX2NsYXNzPSJoLTE2IiwKICAgICAgICApCiAgICB3aXRoIENhcmQoY3NzX2NsYXNzPSJwYi0wIGdhcC0wIik6CiAgICAgICAgd2l0aCBDYXJkQ29udGVudCgpOgogICAgICAgICAgICBNZXRyaWMobGFiZWw9IkFjdGl2ZSBVc2VycyIsIHZhbHVlPSIyNiwxMDQiLCBkZWx0YT0iKzQuMyUiKQogICAgICAgIFNwYXJrbGluZSgKICAgICAgICAgICAgZGF0YT1bMjIsIDIzLCAyMSwgMjQsIDIzLCAyNSwgMjQsIDI2LCAyNSwgMjZdLAogICAgICAgICAgICB2YXJpYW50PSJpbmZvIiwgZmlsbD1UcnVlLCBjc3NfY2xhc3M9ImgtMTYiLAogICAgICAgICkK">
 <CodeGroup>
 ```python Python expandable icon="python"
 from prefab_ui.components import Card, CardContent, Grid
@@ -474,14 +474,14 @@ from prefab_ui.components import Metric
 
 with Grid(min_column_width="14rem", gap=4):
     with Card(css_class="pb-0 gap-0"):
-        with CardContent(css_class="pb-0"):
+        with CardContent():
             Metric(label="Revenue", value="$1.52M", delta="+12%")
         Sparkline(
             data=[120, 132, 101, 134, 90, 230, 210, 182, 191, 234, 290, 330],
             variant="success", fill=True, css_class="h-16",
         )
     with Card(css_class="pb-0 gap-0"):
-        with CardContent(css_class="pb-0"):
+        with CardContent():
             Metric(
                 label="Response Time", value="284ms",
                 delta="+18ms", trend="up", trend_sentiment="negative",
@@ -491,7 +491,7 @@ with Grid(min_column_width="14rem", gap=4):
             variant="destructive", fill=True, css_class="h-16",
         )
     with Card(css_class="pb-0 gap-0"):
-        with CardContent(css_class="pb-0"):
+        with CardContent():
             Metric(label="Active Users", value="26,104", delta="+4.3%")
         Sparkline(
             data=[22, 23, 21, 24, 23, 25, 24, 26, 25, 26],
@@ -510,7 +510,6 @@ with Grid(min_column_width="14rem", gap=4):
         "type": "Card",
         "children": [
           {
-            "cssClass": "pb-0",
             "type": "CardContent",
             "children": [{"type": "Metric", "label": "Revenue", "value": "$1.52M", "delta": "+12%"}]
           },
@@ -530,7 +529,6 @@ with Grid(min_column_width="14rem", gap=4):
         "type": "Card",
         "children": [
           {
-            "cssClass": "pb-0",
             "type": "CardContent",
             "children": [
               {
@@ -559,7 +557,6 @@ with Grid(min_column_width="14rem", gap=4):
         "type": "Card",
         "children": [
           {
-            "cssClass": "pb-0",
             "type": "CardContent",
             "children": [
               {"type": "Metric", "label": "Active Users", "value": "26,104", "delta": "+4.3%"}

--- a/loq.toml
+++ b/loq.toml
@@ -4,7 +4,7 @@
 default_max_lines = 750
 respect_gitignore = true
 
-exclude = ["**/uv.lock", ".git/**", "docs/**", "**/*.lock", "**/package-lock.json", "renderer/src/playground/examples.json", "src/prefab_ui/renderer/app.html"]
+exclude = ["**/uv.lock", ".git/**", ".claude/**", "docs/**", "**/*.lock", "**/package-lock.json", "renderer/src/playground/examples.json", "src/prefab_ui/renderer/app.html"]
 
 [[rules]]
 path = "**/*.css"

--- a/renderer/src/components/metric.tsx
+++ b/renderer/src/components/metric.tsx
@@ -5,6 +5,7 @@
 
 import { TrendingUp, TrendingDown, Minus } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { Badge } from "@/ui/badge";
 
 type TrendDirection = "up" | "down" | "neutral";
 type TrendSentiment = "positive" | "negative" | "neutral";
@@ -47,10 +48,10 @@ function inferSentiment(direction: TrendDirection): TrendSentiment {
   return "neutral";
 }
 
-const SENTIMENT_CLASSES: Record<TrendSentiment, string> = {
-  positive: "text-green-600 dark:text-green-500",
-  negative: "text-red-600 dark:text-red-500",
-  neutral: "text-muted-foreground",
+const SENTIMENT_BADGE_VARIANT: Record<TrendSentiment, string> = {
+  positive: "success",
+  negative: "destructive",
+  neutral: "secondary",
 };
 
 const TREND_ICONS: Record<TrendDirection, typeof TrendingUp> = {
@@ -76,26 +77,26 @@ export function PrefabMetric({
     (resolvedTrend != null ? inferSentiment(resolvedTrend) : undefined);
 
   const TrendIcon = resolvedTrend != null ? TREND_ICONS[resolvedTrend] : null;
-  const sentimentClass =
-    resolvedSentiment != null ? SENTIMENT_CLASSES[resolvedSentiment] : "";
+  const badgeVariant =
+    resolvedSentiment != null
+      ? SENTIMENT_BADGE_VARIANT[resolvedSentiment]
+      : "secondary";
 
   return (
     <div className={cn("flex flex-col gap-1", className, cssClass)}>
       <p className="text-sm font-medium text-muted-foreground">{label}</p>
-      <div className="flex items-baseline gap-2">
-        <span className="text-3xl font-bold tracking-tight">
+      <div className="flex items-center gap-2 flex-wrap">
+        <span className="text-3xl font-bold tracking-tight leading-none">
           {String(value)}
         </span>
         {delta != null && (
-          <span
-            className={cn(
-              "inline-flex items-center gap-0.5 text-sm font-medium",
-              sentimentClass,
-            )}
+          <Badge
+            variant={badgeVariant as "success" | "destructive" | "secondary"}
+            className="gap-1 text-xs font-medium translate-y-px"
           >
-            {TrendIcon && <TrendIcon className="size-3.5" />}
+            {TrendIcon && <TrendIcon className="size-3" />}
             {String(delta)}
-          </span>
+          </Badge>
         )}
       </div>
       {description && (


### PR DESCRIPTION
The Metric trend indicator was raw colored text with a squiggly arrow icon — it looked disconnected from the value and clipped on narrow cards. Now it renders as a proper Badge component with sentiment-mapped variants: `success` (green tint) for positive, `destructive` (red tint) for negative, `secondary` (gray) for neutral.

```python
Metric(label="Revenue", value="$1.52M", delta="+12%")
# delta now renders as a green badge pill: [↗ +12%]

Metric(label="Costs", value="$48K", delta="-15%", trend="down", trend_sentiment="positive")
# green badge (down is good for costs): [↘ -15%]
```

The value+delta row also uses `flex-wrap` now, so on narrow cards the badge wraps below the value instead of clipping.

Closes #268