### PR TITLE
Fix 29 broken doc links and add CI check

### DIFF
--- a/.github/workflows/run-static.yml
+++ b/.github/workflows/run-static.yml
@@ -40,3 +40,6 @@ jobs:
         uses: j178/prek-action@v1
         env:
           SKIP: no-commit-to-branch
+
+      - name: Check for broken docs links
+        run: cd docs && npx mint@latest broken-links

--- a/docs/actions/update-state.mdx
+++ b/docs/actions/update-state.mdx
@@ -203,7 +203,7 @@ with Column(gap=3):
 </CodeGroup>
 </ComponentPreview>
 
-Integer segments address array items. Inside a [ForEach](/components/for-each) loop, combine this with `{{ $index }}` to target the current row:
+Integer segments address array items. Inside a [ForEach](/components/foreach) loop, combine this with `{{ $index }}` to target the current row:
 
 ```python Array Paths
 set_initial_state(
@@ -283,7 +283,7 @@ with Column(gap=2):
 
 ## AppendState and PopState
 
-`AppendState` adds an item to a state array. `PopState` removes one by index. Together with [ForEach](/components/for-each), they let you build dynamic lists entirely client-side.
+`AppendState` adds an item to a state array. `PopState` removes one by index. Together with [ForEach](/components/foreach), they let you build dynamic lists entirely client-side.
 
 Type a name and click Add to see it appear in the list. Click × to remove a row.
 

--- a/docs/components/grid.mdx
+++ b/docs/components/grid.mdx
@@ -368,7 +368,7 @@ Pass a dictionary of breakpoints to `columns` for precise control at specific vi
 Grid(columns={"default": 1, "md": 2, "lg": 3})
 ```
 
-See [Responsive Layout Props](/css#responsive-layout-props) for responsive `gap`, `css_class`, and the `Responsive` helper.
+See [Responsive Layout Props](/styling/css#responsive-layout-props) for responsive `gap`, `css_class`, and the `Responsive` helper.
 
 ## Nested Content
 

--- a/docs/components/sparkline.mdx
+++ b/docs/components/sparkline.mdx
@@ -630,4 +630,4 @@ with Table():
 }
 ```
 
-For the complete protocol schema, see [Sparkline](/protocol/sparkline).
+For the complete protocol schema, see [Sparkline](/components/sparkline).

--- a/docs/concepts/actions.mdx
+++ b/docs/concepts/actions.mdx
@@ -56,7 +56,7 @@ Slider(name="volume", on_change=SetState("last_changed_volume", "{{ $event }}"))
 Input(on_change=CallTool("search", arguments={"q": "{{ $event }}"}))
 ```
 
-The [Expression Reference](/guides/expression-reference) has the full table of what each component emits.
+The [Expression Reference](/concepts/expression-reference) has the full table of what each component emits.
 
 ## Chaining actions
 

--- a/docs/concepts/composition.mdx
+++ b/docs/concepts/composition.mdx
@@ -120,7 +120,7 @@ This is the core idea of Prefab composition: nesting containers. Every Prefab in
 
 The layout patterns above work with any component. Prefab ships with a large library of prebuilt components: [typography](/components/typography), [badges](/components/badge), [progress bars](/components/progress), [inputs](/components/input), [charts](/components/bar-chart), [data tables](/components/data-table), and [many more](/playground). You can browse them all in the [Playground](/playground).
 
-These components compose with Row and Column exactly the way the colored placeholders did. Prefab also includes layout components beyond these two, such as [Grid](/components/grid), [Dashboard](/components/dashboard), and [Pages](/components/pages), for more complex arrangements; they appear later on this page or in their own docs.
+These components compose with Row and Column exactly the way the colored placeholders did. Prefab also includes layout components beyond these two, such as [Grid](/components/grid), [Dashboard](/components/dashboard-grid), and [Pages](/components/pages), for more complex arrangements; they appear later on this page or in their own docs.
 
 Here's the same Column and Row pattern, with real content:
 
@@ -508,7 +508,7 @@ with Column(gap=3):
 
 ### Build-time vs render-time
 
-Prefab UIs are declarative: your Python code runs once to build a component tree, then the renderer takes over. Python `for` loops and `if` statements produce a fixed result at build time. `ForEach` and `If/Elif/Else` are reactive: they live in the component tree and respond to state changes at render time. Use Python control flow for data that is fixed at build time, and use the control-flow components when the UI needs to respond to dynamic state. For any logic that needs to run after build time, use [server actions](/guides/actions).
+Prefab UIs are declarative: your Python code runs once to build a component tree, then the renderer takes over. Python `for` loops and `if` statements produce a fixed result at build time. `ForEach` and `If/Elif/Else` are reactive: they live in the component tree and respond to state changes at render time. Use Python control flow for data that is fixed at build time, and use the control-flow components when the UI needs to respond to dynamic state. For any logic that needs to run after build time, use [server actions](/concepts/actions).
 
 ## Forward references
 

--- a/docs/concepts/core-concepts.mdx
+++ b/docs/concepts/core-concepts.mdx
@@ -65,7 +65,7 @@ with Card(css_class="w-48") as view:
 </CodeGroup>
 </ComponentPreview>
 
-`Row` arranges children horizontally, `Column` stacks them vertically, `Grid` places them in a grid, and they all nest freely. Switch to the Protocol tab to see the JSON that this Python produces; that's what the renderer actually receives. The [Composition](/guides/composition) guide covers layout primitives, cards, grids, loops, and forward references.
+`Row` arranges children horizontally, `Column` stacks them vertically, `Grid` places them in a grid, and they all nest freely. Switch to the Protocol tab to see the JSON that this Python produces; that's what the renderer actually receives. The [Composition](/concepts/composition) guide covers layout primitives, cards, grids, loops, and forward references.
 
 ## State
 
@@ -73,7 +73,7 @@ State is a key-value store that the renderer maintains for the lifetime of your 
 
 Interactive components are the most natural source of state. An `Input(name="city")` writes its current text to the `city` key on every keystroke. A `Slider(name="volume")` writes its position on every drag. Components with a `value` prop also seed their state key automatically: `Input(value="London")` means the key starts with `"London"` before the user types anything.
 
-The [State](/guides/state) guide covers seeding, form bindings, dot paths for nested data, and how state gets written.
+The [State](/concepts/state) guide covers seeding, form bindings, dot paths for nested data, and how state gets written.
 
 ## Expressions
 
@@ -83,7 +83,7 @@ Beyond reading, expressions can compute: `{{ price * quantity }}` multiplies two
 
 In Python, you write expressions using the `Rx` class. `Rx("count")` compiles to `{{ count }}`, and operators chain naturally: `(price * quantity).currency()` compiles to `{{ price * quantity | currency }}`. Stateful components have a `.rx` shorthand; `slider.rx` returns an `Rx` bound to the slider's state key, so you can wire components together without writing key names by hand.
 
-The [Expressions](/guides/expressions) guide covers the Rx DSL, operators, and formatting. The [Expression Reference](/guides/expression-reference) is the lookup page for every operator, pipe, and special variable.
+The [Expressions](/concepts/expressions) guide covers the Rx DSL, operators, and formatting. The [Expression Reference](/concepts/expression-reference) is the lookup page for every operator, pipe, and special variable.
 
 ## Actions
 
@@ -93,7 +93,7 @@ Actions are what happen when users interact. Click a button, change a slider, su
 
 Most real interactions use both. A "Save" button sets a loading flag (instant), calls the server (async), then shows success or failure (instant, based on the outcome). Actions can be sequenced as lists and chained through callbacks.
 
-The [Actions](/guides/actions) guide covers both families, chaining, the `$event` variable, and common patterns like loading state and optimistic updates.
+The [Actions](/concepts/actions) guide covers both families, chaining, the `$event` variable, and common patterns like loading state and optimistic updates.
 
 ## How it runs
 

--- a/docs/concepts/expression-reference.mdx
+++ b/docs/concepts/expression-reference.mdx
@@ -7,7 +7,7 @@ icon: book-open
 
 import { ComponentPreview } from '/snippets/component-preview.mdx'
 
-This page is a detailed companion to the [Expressions](/guides/expressions) guide. It covers every operator, pipe, and special variable available in `{{ }}` expressions and their `Rx` equivalents, with enough context to use each one confidently.
+This page is a detailed companion to the [Expressions](/concepts/expressions) guide. It covers every operator, pipe, and special variable available in `{{ }}` expressions and their `Rx` equivalents, with enough context to use each one confidently.
 
 Every entry shows both the Python `Rx` syntax and the equivalent `{{ }}` protocol syntax. They compile to the same thing; choose whichever fits your context.
 

--- a/docs/concepts/expressions.mdx
+++ b/docs/concepts/expressions.mdx
@@ -9,7 +9,7 @@ import { ComponentPreview } from '/snippets/component-preview.mdx'
 
 Expressions are how components read and compute from state. Every `{{ }}` you write is a live binding: the renderer evaluates it against current state, tracks which keys it depends on, and re-evaluates whenever any of them change. The display stays current automatically, so you write the expression once and the renderer handles the rest.
 
-The expression language is intentionally bounded. Prefab UIs are designed to be safely serializable, so the expression grammar covers arithmetic, comparisons, boolean logic, conditionals, and formatting. That's enough to drive any display while keeping business logic where it belongs: in your Python code or in a [server action](/guides/actions).
+The expression language is intentionally bounded. Prefab UIs are designed to be safely serializable, so the expression grammar covers arithmetic, comparisons, boolean logic, conditionals, and formatting. That's enough to drive any display while keeping business logic where it belongs: in your Python code or in a [server action](/concepts/actions).
 
 ## Template expressions
 
@@ -220,7 +220,7 @@ with Column(gap=3):
 </CodeGroup>
 </ComponentPreview>
 
-`price * quantity` compiles to `{{ price * quantity }}`, and `.currency()` formats the result for display. The [Expression Reference](/guides/expression-reference) has the complete operator table.
+`price * quantity` compiles to `{{ price * quantity }}`, and `.currency()` formats the result for display. The [Expression Reference](/concepts/expression-reference) has the complete operator table.
 
 ### String concatenation
 
@@ -273,7 +273,7 @@ score > 0 & score < 100
 This is a Python quirk. The `{{ }}` protocol expressions use standard precedence and don't require extra parentheses.
 </Warning>
 
-The `||` operator short-circuits, which makes it useful as a falsy default: `{{ name || 'Anonymous' }}` returns `'Anonymous'` when `name` is falsy (empty string, `false`, `0`, or undefined). For null/undefined-only defaults, use the `default` pipe instead; see [Expression Reference](/guides/expression-reference).
+The `||` operator short-circuits, which makes it useful as a falsy default: `{{ name || 'Anonymous' }}` returns `'Anonymous'` when `name` is falsy (empty string, `false`, `0`, or undefined). For null/undefined-only defaults, use the `default` pipe instead; see [Expression Reference](/concepts/expression-reference).
 
 ### Ternary
 
@@ -405,7 +405,7 @@ Rx("score").default(0).number()
 
 The `.default()` pipe provides a fallback value when the key is null or undefined. Unlike `||`, which triggers on any falsy value (including `0` and empty string), `.default()` only triggers on null/undefined. Use `.default()` when `0` or `""` are valid values you want to preserve.
 
-The [Expression Reference](/guides/expression-reference) has the complete pipe catalog with detailed examples for every formatter.
+The [Expression Reference](/concepts/expression-reference) has the complete pipe catalog with detailed examples for every formatter.
 
 ## Type preservation
 

--- a/docs/concepts/state.mdx
+++ b/docs/concepts/state.mdx
@@ -201,6 +201,6 @@ If any segment along a path is missing or the wrong type, the expression resolve
 
 ## Writing to state
 
-Two things write to state: interactive controls (automatically, via the `name` prop) and [actions](/guides/actions) (explicitly, in response to events). `SetState` assigns a value. `ToggleState` flips a boolean. `AppendState` and `PopState` manipulate arrays. `CallTool` and `Fetch` make their results available as `$result` in `on_success` callbacks, where you can write them to state with `SetState`.
+Two things write to state: interactive controls (automatically, via the `name` prop) and [actions](/concepts/actions) (explicitly, in response to events). `SetState` assigns a value. `ToggleState` flips a boolean. `AppendState` and `PopState` manipulate arrays. `CallTool` and `Fetch` make their results available as `$result` in `on_success` callbacks, where you can write them to state with `SetState`.
 
-State is deliberately simple: a flat map with dot-path addressing for nesting. There are no computed properties, no watchers, no derived state in the store itself. Derived values belong in [expressions](/guides/expressions), where they're computed at render time from whatever state holds. Complex computations belong in Python, run before you return the component tree, or in a server action.
+State is deliberately simple: a flat map with dot-path addressing for nesting. There are no computed properties, no watchers, no derived state in the store itself. Derived values belong in [expressions](/concepts/expressions), where they're computed at render time from whatever state holds. Complex computations belong in Python, run before you return the component tree, or in a server action.

--- a/docs/examples/todo.mdx
+++ b/docs/examples/todo.mdx
@@ -336,11 +336,11 @@ with Grid(min_column_width="12rem", gap=6, align="start"):
 
 ## How It Works
 
-The state is an array of groups, each containing a `name`, a `todos` array, and a `new_todo` input buffer. [ForEach](/components/for-each) iterates the groups, and a nested ForEach iterates each group's todos.
+The state is an array of groups, each containing a `name`, a `todos` array, and a `new_todo` input buffer. [ForEach](/components/foreach) iterates the groups, and a nested ForEach iterates each group's todos.
 
 **Nested loops** — `with ForEach("groups") as (gi, group)` destructures the loop binding into an index (`gi`) and item (`group`), matching Python's `enumerate` convention. Each ForEach automatically captures `$item` and `$index` into scoped `let` bindings, so the outer loop's `group` and `gi` survive even after the inner loop shadows `$item` and `$index`. The inner `ForEach(f"groups.{gi}.todos") as (ti, todo)` uses `gi` to target the right group and `ti` to target individual todos.
 
-**Inline editing** — instead of showing todo text as a `Text` component, each item uses a borderless `Input` styled with `border-0 shadow-none p-0` so it looks like plain text but is directly editable. [Dot-path auto-binding](/actions/set-state#dot-paths) handles the read and write — the input's `name` points at the exact item in state (`f"groups.{gi}.todos.{ti}.text"`).
+**Inline editing** — instead of showing todo text as a `Text` component, each item uses a borderless `Input` styled with `border-0 shadow-none p-0` so it looks like plain text but is directly editable. [Dot-path auto-binding](/actions/update-state#dot-paths) handles the read and write — the input's `name` points at the exact item in state (`f"groups.{gi}.todos.{ti}.text"`).
 
 **Disabling the Add button** — `disabled=~group.new_todo` evaluates to true when the input is empty, so the button stays disabled until you type something. `group` is the outer ForEach's item, so `group.new_todo` accesses the group's input buffer.
 

--- a/docs/expressions/overview.mdx
+++ b/docs/expressions/overview.mdx
@@ -234,7 +234,7 @@ This is a design choice, not a limitation. Prefab splits interactivity into thre
 | Layer | Where it runs | What it does |
 |-------|---------------|--------------|
 | **Expressions** | Client (browser) | Compute display values — arithmetic, formatting, conditional text |
-| **[Actions](/actions/overview)** | Client (browser) | Mutate state — SetState, ToggleState, ShowToast |
+| **[Actions](/concepts/actions)** | Client (browser) | Mutate state — SetState, ToggleState, ShowToast |
 | **[CallTool](/actions/call-tool)** | Server | Run business logic — data fetching, validation, persistence |
 
 If you find yourself wanting to filter a list by a complex predicate, fetch data from an API, or run business logic — that's not an expression problem, it's a [CallTool](/actions/call-tool) problem. Expressions handle the display; actions and tools handle everything else.

--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -53,15 +53,15 @@ Try editing `app.py` while the server is running. Change the heading text, swap 
 
 ## What just happened
 
-Prefab components nest using Python's `with` statement — `Card`, `Column`, `Input` compose into a tree that compiles to JSON, which a bundled React renderer turns into real HTML. The [Composition](/getting-started/composition) page walks through this in detail.
+Prefab components nest using Python's `with` statement — `Card`, `Column`, `Input` compose into a tree that compiles to JSON, which a bundled React renderer turns into real HTML. The [Composition](/concepts/composition) page walks through this in detail.
 
 Every form control syncs its value to a client-side state key. The `.rx` property returns a reactive reference — `name_input.rx` in an f-string becomes `{{ name }}` in the protocol, and any component containing it re-renders whenever the input changes. No server round-trip needed. Read more about [reactive expressions](/expressions/overview).
 
-`ShowToast` is a client-side [action](/actions/overview) — it runs entirely in the browser. Prefab has several of these (`SetState`, `ToggleState`, `OpenLink`), plus server actions like `CallTool` for when you need a backend.
+`ShowToast` is a client-side [action](/concepts/actions) — it runs entirely in the browser. Prefab has several of these (`SetState`, `ToggleState`, `OpenLink`), plus server actions like `CallTool` for when you need a backend.
 
 ## Where to go from here
 
-- [**Composition**](/getting-started/composition) — learn how to build any interface by nesting components
+- [**Composition**](/concepts/composition) — learn how to build any interface by nesting components
 - [**Playground**](/playground) — browse all 35+ components interactively
 - [**Reactive Expressions**](/expressions/overview) — operators, conditionals, and pipes for client-side logic
 - [**API Server**](/running/api) and [**FastMCP**](/running/fastmcp) — wire up a backend when you need server logic

--- a/docs/overview.mdx
+++ b/docs/overview.mdx
@@ -231,7 +231,7 @@ with Card() as view:
 </CodeGroup>
 </ComponentPreview>
 
-See the component reference pages in the sidebar for the full catalog, and the [Playground](/servers/playground) to try components interactively.
+See the component reference pages in the sidebar for the full catalog, and the [Playground](/playground) to try components interactively.
 
 ## The `ui=True` Flag
 

--- a/docs/welcome.mdx
+++ b/docs/welcome.mdx
@@ -1505,18 +1505,18 @@ with Card():
 pip install prefab-ui
 ```
 
-Prefab requires Python 3.10+. See [Installation](/installation) for version pinning guidance.
+Prefab requires Python 3.10+. See [Installation](/getting-started/installation) for version pinning guidance.
 
 ## What's in the Box
 
 <CardGroup cols={2}>
-  <Card title="Quickstart" icon="rocket" href="/quickstart">
+  <Card title="Quickstart" icon="rocket" href="/getting-started/quickstart">
     Install, create an app, see it render. Two minutes, no prerequisites.
   </Card>
   <Card title="Components" icon="cube" href="/components/button">
     35+ components: layout, typography, forms, data display, and interactive elements. Nest them with Python context managers.
   </Card>
-  <Card title="Actions" icon="bolt" href="/actions/overview">
+  <Card title="Actions" icon="bolt" href="/concepts/actions">
     Declarative interactivity — state updates, server calls, navigation, and toast notifications. Chain them with lifecycle callbacks.
   </Card>
   <Card title="Expressions" icon="lightbulb" href="/expressions/overview">


### PR DESCRIPTION
Ran \`npx mint@latest broken-links\` and found 29 broken links across 14 files. Most were stale \`/guides/\` paths that moved to \`/concepts/\`, plus a few renamed components and missing anchors.

Also adds \`npx mint@latest broken-links\` to the static CI workflow so new broken links get caught before merge.

Closes #273