### PR TITLE
DataTable: pandas/polars DataFrame support

### DIFF
--- a/docs/components/data-table.mdx
+++ b/docs/components/data-table.mdx
@@ -206,6 +206,31 @@ DataTable(
 </CodeGroup>
 </ComponentPreview>
 
+## From DataFrame
+
+If you have a pandas DataFrame, pass it directly as `rows`. Columns are generated automatically from `df.columns`, or supply `columns` explicitly for full control.
+
+```python
+import pandas as pd
+from prefab_ui.components import DataTable
+
+df = pd.DataFrame({
+    "name": ["Alice", "Bob", "Carol"],
+    "age": [30, 25, 35],
+    "role": ["Admin", "Editor", "Viewer"],
+})
+
+DataTable(rows=df, searchable=True)
+```
+
+Use `from_dataframe` when you want to control sortability across all columns at once:
+
+```python
+DataTable.from_dataframe(df, sortable=True, paginated=True, page_size=20)
+```
+
+pandas is an optional dependency — if it is not installed, `rows` behaves as usual and only accepts lists of dicts.
+
 ## API Reference
 
 <Card icon="code" title="DataTable Parameters">
@@ -213,8 +238,8 @@ DataTable(
   Column definitions. Each column specifies a `key`, `header`, and optional `sortable` flag.
 </ParamField>
 
-<ParamField body="rows" type="list[dict] | str" default="[]">
-  Row data as a list of dicts, or a `{{ field }}` interpolation reference.
+<ParamField body="rows" type="list[dict] | DataFrame | str" default="[]">
+  Row data as a list of dicts, a pandas DataFrame (columns auto-generated), or a `{{ field }}` interpolation reference.
 </ParamField>
 
 <ParamField body="searchable" type="bool" default="False">

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,6 +104,14 @@ unknown-argument = "ignore"
 missing-argument = "ignore"
 invalid-argument-type = "ignore"
 
+# pandas is an optional dependency not installed in the dev environment;
+# suppress the unresolved-import diagnostic for this file only.
+[[tool.ty.overrides]]
+include = ["src/prefab_ui/components/data_table.py"]
+
+[tool.ty.overrides.rules]
+unresolved-import = "ignore"
+
 [tool.ruff.lint]
 fixable = ["ALL"]
 ignore = ["COM812", "PLR0913", "SIM102"]

--- a/src/prefab_ui/components/data_table.py
+++ b/src/prefab_ui/components/data_table.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from prefab_ui.components.base import Component
 
@@ -48,6 +48,7 @@ class DataTable(Component):
     """High-level data table with sorting, filtering, and pagination.
 
     Accepts flat ``columns`` and ``rows`` — the renderer handles the rest.
+    Pass a pandas DataFrame as ``rows`` and columns are auto-generated.
 
     Example::
 
@@ -63,7 +64,9 @@ class DataTable(Component):
     """
 
     type: Literal["DataTable"] = "DataTable"
-    columns: list[DataTableColumn] = Field(description="Column definitions")
+    columns: list[DataTableColumn] = Field(
+        default_factory=list, description="Column definitions"
+    )
     rows: list[dict[str, Any]] | str = Field(
         default_factory=list,
         description="Row data or {{ interpolation }} reference",
@@ -73,6 +76,48 @@ class DataTable(Component):
     page_size: int = Field(
         default=10, alias="pageSize", description="Rows per page when paginated"
     )
+
+    @model_validator(mode="before")
+    @classmethod
+    def _coerce_dataframe(cls, data: Any) -> Any:
+        if not isinstance(data, dict):
+            return data
+        rows = data.get("rows")
+        if rows is None:
+            return data
+        try:
+            import pandas as pd
+        except ImportError:
+            return data
+        if not isinstance(rows, pd.DataFrame):
+            return data
+        if not data.get("columns"):
+            data = dict(data)
+            data["columns"] = [
+                DataTableColumn(key=str(col), header=str(col)) for col in rows.columns
+            ]
+        data["rows"] = rows.to_dict(orient="records")
+        return data
+
+    @classmethod
+    def from_dataframe(
+        cls,
+        df: Any,
+        sortable: bool = False,
+        **kwargs: Any,
+    ) -> DataTable:
+        """Create a DataTable from a pandas DataFrame.
+
+        All columns are generated from ``df.columns``. Pass ``sortable=True``
+        to enable sorting on every column, or build ``columns`` manually for
+        per-column control.
+        """
+        columns = [
+            DataTableColumn(key=str(col), header=str(col), sortable=sortable)
+            for col in df.columns
+        ]
+        rows = df.to_dict(orient="records")
+        return cls(columns=columns, rows=rows, **kwargs)
 
     def to_json(self) -> dict[str, Any]:
         d = super().to_json()

--- a/tests/components/test_table.py
+++ b/tests/components/test_table.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+from unittest.mock import patch
+
+import pytest
+
 from prefab_ui.components import (
     Badge,
     DataTable,
@@ -132,3 +136,58 @@ class TestDataTableComponent:
         )
         j = dt.to_json()
         assert j["rows"] == "{{ users }}"
+
+
+class TestDataTableDataFrame:
+    def test_from_dataframe_columns_and_rows(self):
+        pd = pytest.importorskip("pandas")
+        df = pd.DataFrame({"name": ["Alice", "Bob"], "age": [30, 25]})
+        dt = DataTable.from_dataframe(df)
+        j = dt.to_json()
+        assert [c["key"] for c in j["columns"]] == ["name", "age"]
+        assert [c["header"] for c in j["columns"]] == ["name", "age"]
+        assert all(c["sortable"] is False for c in j["columns"])
+        assert j["rows"] == [{"name": "Alice", "age": 30}, {"name": "Bob", "age": 25}]
+
+    def test_from_dataframe_sortable(self):
+        pd = pytest.importorskip("pandas")
+        df = pd.DataFrame({"x": [1, 2], "y": [3, 4]})
+        dt = DataTable.from_dataframe(df, sortable=True)
+        j = dt.to_json()
+        assert all(c["sortable"] is True for c in j["columns"])
+
+    def test_from_dataframe_extra_kwargs(self):
+        pd = pytest.importorskip("pandas")
+        df = pd.DataFrame({"val": [10, 20]})
+        dt = DataTable.from_dataframe(df, searchable=True, paginated=True, page_size=5)
+        j = dt.to_json()
+        assert j["searchable"] is True
+        assert j["paginated"] is True
+        assert j["pageSize"] == 5
+
+    def test_rows_dataframe_auto_converts(self):
+        pd = pytest.importorskip("pandas")
+        df = pd.DataFrame({"name": ["Alice", "Bob"], "age": [30, 25]})
+        dt = DataTable(rows=df)
+        j = dt.to_json()
+        assert [c["key"] for c in j["columns"]] == ["name", "age"]
+        assert j["rows"] == [{"name": "Alice", "age": 30}, {"name": "Bob", "age": 25}]
+
+    def test_rows_dataframe_explicit_columns_preserved(self):
+        pd = pytest.importorskip("pandas")
+        df = pd.DataFrame({"name": ["Alice"], "age": [30]})
+        explicit_cols = [DataTableColumn(key="name", header="Full Name", sortable=True)]
+        dt = DataTable(columns=explicit_cols, rows=df)
+        j = dt.to_json()
+        assert j["columns"][0]["header"] == "Full Name"
+        assert j["columns"][0]["sortable"] is True
+        assert len(j["columns"]) == 1
+
+    def test_rows_dataframe_pandas_not_installed(self):
+        with patch.dict("sys.modules", {"pandas": None}):
+            # Without pandas, passing a non-DataFrame rows value still works normally
+            dt = DataTable(
+                columns=[DataTableColumn(key="x", header="X")],
+                rows=[{"x": 1}],
+            )
+            assert dt.rows == [{"x": 1}]


### PR DESCRIPTION
Pass a DataFrame directly to DataTable — columns auto-generate from df.columns, rows auto-convert via to_dict.

```python
DataTable(rows=df)
DataTable.from_dataframe(df, sortable=True)
```