### PR TITLE
DataTable: cell formatting (number, currency, date)

### DIFF
--- a/docs/components/data-table.mdx
+++ b/docs/components/data-table.mdx
@@ -206,6 +206,69 @@ DataTable(
 </CodeGroup>
 </ComponentPreview>
 
+## Cell Formatting
+
+The `format` field on `DataTableColumn` formats numeric and date values without requiring a component cell. Use `'type'` or `'type:arg'` syntax to control the output.
+
+<ComponentPreview json={{"view":{"type":"DataTable","columns":[{"key":"product","header":"Product","sortable":false},{"key":"revenue","header":"Revenue","sortable":true,"format":"currency"},{"key":"growth","header":"Growth","sortable":true,"format":"percent:1"},{"key":"units","header":"Units","sortable":true,"format":"number"},{"key":"launched","header":"Launched","sortable":false,"format":"date:medium"}],"rows":[{"product":"Widget Pro","revenue":128450,"growth":0.142,"units":3210,"launched":"2023-03-15"},{"product":"Gadget Plus","revenue":84200,"growth":0.087,"units":1980,"launched":"2022-11-01"},{"product":"Doohickey","revenue":52100,"growth":-0.031,"units":870,"launched":"2024-01-20"}],"searchable":false,"paginated":false,"pageSize":10}}}>
+<CodeGroup>
+```python Python icon="python"
+from prefab_ui.components import DataTable, DataTableColumn
+
+DataTable(
+    columns=[
+        DataTableColumn(key="product", header="Product"),
+        DataTableColumn(key="revenue", header="Revenue", sortable=True, format="currency"),
+        DataTableColumn(key="growth", header="Growth", sortable=True, format="percent:1"),
+        DataTableColumn(key="units", header="Units", sortable=True, format="number"),
+        DataTableColumn(key="launched", header="Launched", format="date:medium"),
+    ],
+    rows=[
+        {"product": "Widget Pro", "revenue": 128450, "growth": 0.142, "units": 3210, "launched": "2023-03-15"},
+        {"product": "Gadget Plus", "revenue": 84200, "growth": 0.087, "units": 1980, "launched": "2022-11-01"},
+        {"product": "Doohickey", "revenue": 52100, "growth": -0.031, "units": 870, "launched": "2024-01-20"},
+    ],
+)
+```
+```json Protocol icon="brackets-curly"
+{
+  "view": {
+    "type": "DataTable",
+    "columns": [
+      {"key": "product", "header": "Product"},
+      {"key": "revenue", "header": "Revenue", "sortable": true, "format": "currency"},
+      {"key": "growth", "header": "Growth", "sortable": true, "format": "percent:1"},
+      {"key": "units", "header": "Units", "sortable": true, "format": "number"},
+      {"key": "launched", "header": "Launched", "format": "date:medium"}
+    ],
+    "rows": [
+      {"product": "Widget Pro", "revenue": 128450, "growth": 0.142, "units": 3210, "launched": "2023-03-15"},
+      {"product": "Gadget Plus", "revenue": 84200, "growth": 0.087, "units": 1980, "launched": "2022-11-01"},
+      {"product": "Doohickey", "revenue": 52100, "growth": -0.031, "units": 870, "launched": "2024-01-20"}
+    ],
+    "searchable": false,
+    "paginated": false,
+    "pageSize": 10
+  }
+}
+```
+</CodeGroup>
+</ComponentPreview>
+
+Supported format strings:
+
+| Format | Example output | Notes |
+|--------|---------------|-------|
+| `number` | `1,234,567` | Locale thousands separator |
+| `number:2` | `1,234.50` | Fixed decimal places |
+| `currency` | `$1,234.50` | USD by default |
+| `currency:EUR` | `€1,234.50` | Any ISO 4217 code |
+| `percent` | `14%` | Value should be `0.14`, not `14` |
+| `percent:1` | `14.2%` | Fixed decimal places |
+| `date` | `Mar 15, 2023` | Medium style by default |
+| `date:short` | `3/15/23` | short / medium / long / full |
+| `date:long` | `March 15, 2023` | |
+
 ## API Reference
 
 <Card icon="code" title="DataTable Parameters">
@@ -246,6 +309,11 @@ DataTable(
 <ParamField body="sortable" type="bool" default="False">
   Enable click-to-sort on this column.
 </ParamField>
+
+<ParamField body="format" type="str | None" default="None">
+  Format string for cell values. Accepts `number`, `number:N`, `currency`, `currency:CODE`,
+  `percent`, `percent:N`, `date`, `date:short|medium|long|full`. Ignored when the cell value is a component.
+</ParamField>
 </Card>
 
 ## Protocol Reference
@@ -266,7 +334,8 @@ DataTable(
 {
   "key": "string (required)",
   "header": "string (required)",
-  "sortable?": false
+  "sortable?": false,
+  "format?": "string"
 }
 ```
 

--- a/renderer/src/components/data-display.tsx
+++ b/renderer/src/components/data-display.tsx
@@ -33,6 +33,54 @@ interface DataTableColumnSpec {
   key: string;
   header: string;
   sortable?: boolean;
+  format?: string;
+}
+
+function formatCellValue(value: unknown, format: string): string {
+  const [type, arg] = format.split(":") as [string, string | undefined];
+
+  if (type === "number") {
+    const fractionDigits = arg !== undefined ? parseInt(arg, 10) : undefined;
+    return new Intl.NumberFormat(undefined, {
+      ...(fractionDigits !== undefined && {
+        minimumFractionDigits: fractionDigits,
+        maximumFractionDigits: fractionDigits,
+      }),
+    }).format(Number(value));
+  }
+
+  if (type === "currency") {
+    const currency = arg ?? "USD";
+    return new Intl.NumberFormat(undefined, {
+      style: "currency",
+      currency,
+    }).format(Number(value));
+  }
+
+  if (type === "percent") {
+    const fractionDigits = arg !== undefined ? parseInt(arg, 10) : undefined;
+    return new Intl.NumberFormat(undefined, {
+      style: "percent",
+      ...(fractionDigits !== undefined && {
+        minimumFractionDigits: fractionDigits,
+        maximumFractionDigits: fractionDigits,
+      }),
+    }).format(Number(value));
+  }
+
+  if (type === "date") {
+    const styleMap: Record<string, Intl.DateTimeFormatOptions["dateStyle"]> = {
+      short: "short",
+      medium: "medium",
+      long: "long",
+      full: "full",
+    };
+    const dateStyle = arg !== undefined ? styleMap[arg] ?? "medium" : "medium";
+    const date = value instanceof Date ? value : new Date(String(value));
+    return new Intl.DateTimeFormat(undefined, { dateStyle }).format(date);
+  }
+
+  return value != null ? String(value) : "";
 }
 
 interface DataTableProps {
@@ -87,6 +135,9 @@ export function PrefabDataTable({
           const value = getValue();
           if (renderNode && isComponentNode(value)) {
             return renderNode(value);
+          }
+          if (spec.format !== undefined && value != null) {
+            return formatCellValue(value, spec.format);
           }
           return value != null ? String(value) : "";
         },

--- a/renderer/src/schemas/data_table.ts
+++ b/renderer/src/schemas/data_table.ts
@@ -5,6 +5,7 @@ const dataTableColumnSchema = z.object({
   key: z.string(),
   header: z.string(),
   sortable: z.boolean().optional(),
+  format: z.string().optional(),
 });
 
 export const dataTableSchema = componentBase.extend({

--- a/src/prefab_ui/components/data_table.py
+++ b/src/prefab_ui/components/data_table.py
@@ -42,6 +42,13 @@ class DataTableColumn(BaseModel):
     key: str = Field(description="Data key to display in this column")
     header: str = Field(description="Column header text")
     sortable: bool = Field(default=False, description="Enable sorting for this column")
+    format: str | None = Field(
+        default=None,
+        description=(
+            "Cell format: 'number', 'number:2' (decimals), 'currency', 'currency:EUR',"
+            " 'percent', 'percent:1', 'date', 'date:long'"
+        ),
+    )
 
 
 class DataTable(Component):

--- a/tests/components/test_table.py
+++ b/tests/components/test_table.py
@@ -132,3 +132,30 @@ class TestDataTableComponent:
         )
         j = dt.to_json()
         assert j["rows"] == "{{ users }}"
+
+    def test_data_table_column_format_in_json(self):
+        dt = DataTable(
+            columns=[
+                DataTableColumn(key="revenue", header="Revenue", format="currency"),
+                DataTableColumn(key="growth", header="Growth", format="percent:1"),
+                DataTableColumn(key="units", header="Units", format="number:0"),
+                DataTableColumn(key="date", header="Date", format="date:long"),
+            ],
+            rows=[],
+        )
+        j = dt.to_json()
+        cols = {c["key"]: c for c in j["columns"]}
+        assert cols["revenue"]["format"] == "currency"
+        assert cols["growth"]["format"] == "percent:1"
+        assert cols["units"]["format"] == "number:0"
+        assert cols["date"]["format"] == "date:long"
+
+    def test_data_table_column_format_none_by_default(self):
+        col = DataTableColumn(key="name", header="Name")
+        j = col.model_dump(exclude_none=True)
+        assert "format" not in j
+
+    def test_data_table_column_format_serialized(self):
+        col = DataTableColumn(key="price", header="Price", format="currency:EUR")
+        j = col.model_dump()
+        assert j["format"] == "currency:EUR"


### PR DESCRIPTION
Format cell values via DataTableColumn without creating component cells.

```python
DataTableColumn(key="revenue", header="Revenue", format="currency")
DataTableColumn(key="growth", header="Growth", format="percent:1")
DataTableColumn(key="date", header="Date", format="date:long")
```