### PR TITLE
DataTable: row selection with checkboxes

### DIFF
--- a/docs/components/data-table.mdx
+++ b/docs/components/data-table.mdx
@@ -206,6 +206,33 @@ DataTable(
 </CodeGroup>
 </ComponentPreview>
 
+## Row Selection
+
+Set `selectable=True` to add a checkbox column. The header checkbox selects all visible rows; individual row checkboxes select single rows. When the selection changes, `on_select` fires with `$event` set to the list of selected row indices.
+
+<ComponentPreview json={{}}>
+<CodeGroup>
+```python Python icon="python"
+from prefab_ui.components import DataTable, DataTableColumn
+from prefab_ui.actions import SetState
+
+DataTable(
+    columns=[
+        DataTableColumn(key="name", header="Name"),
+        DataTableColumn(key="role", header="Role"),
+    ],
+    rows=[
+        {"name": "Alice Johnson", "role": "Admin"},
+        {"name": "Bob Smith", "role": "Editor"},
+        {"name": "Carol White", "role": "Viewer"},
+    ],
+    selectable=True,
+    on_select=SetState(key="selected_rows", value="{{ $event }}"),
+)
+```
+</CodeGroup>
+</ComponentPreview>
+
 ## API Reference
 
 <Card icon="code" title="DataTable Parameters">
@@ -228,6 +255,15 @@ DataTable(
 <ParamField body="page_size" type="int" default="10">
   Number of rows per page when `paginated=True`.
 </ParamField>
+
+<ParamField body="selectable" type="bool" default="False">
+  Show a checkbox column for multi-row selection.
+</ParamField>
+
+<ParamField body="on_select" type="Action | list[Action] | None" default="None">
+  Action(s) fired when the selection changes. `$event` is the list of selected row indices.
+</ParamField>
+
 
 <ParamField body="css_class" type="str | None" default="None">
   Additional Tailwind CSS classes.
@@ -258,6 +294,8 @@ DataTable(
   "searchable?": false,
   "paginated?": false,
   "pageSize?": 10,
+  "selectable?": false,
+  "onSelect?": "Action | Action[]",
   "cssClass?": "string"
 }
 ```

--- a/renderer/src/components/data-display.tsx
+++ b/renderer/src/components/data-display.tsx
@@ -5,7 +5,7 @@
  * and pagination using shadcn Table primitives.
  */
 
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect, useRef } from "react";
 import { cn } from "@/lib/utils";
 import {
   useReactTable,
@@ -16,6 +16,7 @@ import {
   flexRender,
   type ColumnDef,
   type SortingState,
+  type RowSelectionState,
 } from "@tanstack/react-table";
 import {
   Table,
@@ -41,6 +42,8 @@ interface DataTableProps {
   searchable?: boolean;
   paginated?: boolean;
   pageSize?: number;
+  selectable?: boolean;
+  onSelect?: (selectedIndices: number[]) => void;
   className?: string;
 }
 
@@ -50,14 +53,66 @@ export function PrefabDataTable({
   searchable = false,
   paginated = false,
   pageSize = 10,
+  selectable = false,
+  onSelect,
   className,
 }: DataTableProps) {
   const [sorting, setSorting] = useState<SortingState>([]);
   const [globalFilter, setGlobalFilter] = useState("");
+  const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
   const renderNode = useRenderNode();
 
+  // Fire onSelect when selection changes, passing original row indices
+  const onSelectRef = useRef(onSelect);
+  onSelectRef.current = onSelect;
+  const prevSelectionRef = useRef<RowSelectionState>({});
+  useEffect(() => {
+    if (!selectable || !onSelectRef.current) return;
+    // Skip the initial mount (no selection yet)
+    if (rowSelection === prevSelectionRef.current) return;
+    prevSelectionRef.current = rowSelection;
+    const selectedIndices = Object.keys(rowSelection)
+      .filter((k) => rowSelection[k])
+      .map(Number);
+    onSelectRef.current(selectedIndices);
+  }, [rowSelection, selectable]);
+
   // Build @tanstack/react-table column defs from our flat spec
-  const columns = useMemo<ColumnDef<Record<string, unknown>>[]>(
+  const selectionColumn = useMemo<ColumnDef<Record<string, unknown>>>(
+    () => ({
+      id: "_select",
+      header: ({ table }) => {
+        const allSelected = table.getIsAllPageRowsSelected();
+        const someSelected = table.getIsSomePageRowsSelected();
+        return (
+          <input
+            type="checkbox"
+            className="size-4 cursor-pointer accent-primary"
+            checked={allSelected}
+            ref={(el) => {
+              if (el) el.indeterminate = !allSelected && someSelected;
+            }}
+            onChange={table.getToggleAllPageRowsSelectedHandler()}
+            aria-label="Select all"
+          />
+        );
+      },
+      cell: ({ row }) => (
+        <input
+          type="checkbox"
+          className="size-4 cursor-pointer accent-primary"
+          checked={row.getIsSelected()}
+          disabled={!row.getCanSelect()}
+          onChange={row.getToggleSelectedHandler()}
+          aria-label="Select row"
+        />
+      ),
+      size: 40,
+    }),
+    [],
+  );
+
+  const dataColumns = useMemo<ColumnDef<Record<string, unknown>>[]>(
     () =>
       columnSpecs.map((spec) => ({
         accessorKey: spec.key,
@@ -94,18 +149,27 @@ export function PrefabDataTable({
     [columnSpecs, renderNode],
   );
 
+  const columns = useMemo(
+    () => (selectable ? [selectionColumn, ...dataColumns] : dataColumns),
+    [selectable, selectionColumn, dataColumns],
+  );
+
   const table = useReactTable({
     data: rows,
     columns,
-    state: { sorting, globalFilter },
+    state: { sorting, globalFilter, rowSelection },
     onSortingChange: setSorting,
     onGlobalFilterChange: setGlobalFilter,
+    onRowSelectionChange: setRowSelection,
+    enableRowSelection: selectable,
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
     getFilteredRowModel: searchable ? getFilteredRowModel() : undefined,
     getPaginationRowModel: paginated ? getPaginationRowModel() : undefined,
     initialState: paginated ? { pagination: { pageSize } } : undefined,
   });
+
+  const colCount = columns.length;
 
   return (
     <div className={cn("w-full min-w-0", className)}>
@@ -141,7 +205,10 @@ export function PrefabDataTable({
           {table.getRowModel().rows.length ? (
             <>
               {table.getRowModel().rows.map((row) => (
-                <TableRow key={row.id}>
+                <TableRow
+                  key={row.id}
+                  data-state={row.getIsSelected() ? "selected" : undefined}
+                >
                   {row.getVisibleCells().map((cell) => (
                     <TableCell key={cell.id}>
                       {flexRender(
@@ -159,13 +226,13 @@ export function PrefabDataTable({
                   length: pageSize - table.getRowModel().rows.length,
                 }).map((_, i) => (
                   <TableRow key={`pad-${i}`} className="border-transparent">
-                    <TableCell colSpan={columns.length}>&nbsp;</TableCell>
+                    <TableCell colSpan={colCount}>&nbsp;</TableCell>
                   </TableRow>
                 ))}
             </>
           ) : (
             <TableRow>
-              <TableCell colSpan={columns.length} className="h-24 text-center">
+              <TableCell colSpan={colCount} className="h-24 text-center">
                 No results.
               </TableCell>
             </TableRow>

--- a/renderer/src/prop-transforms.ts
+++ b/renderer/src/prop-transforms.ts
@@ -13,7 +13,12 @@ import type { StateStore } from "./state";
 import type { OverlayCloseFn } from "./overlay-context";
 
 /** Props that carry action specs (serialized from Python Action types). */
-export const ACTION_PROPS = new Set(["onClick", "onChange", "onSubmit"]);
+export const ACTION_PROPS = new Set([
+  "onClick",
+  "onChange",
+  "onSubmit",
+  "onSelect",
+]);
 
 /**
  * Types whose children represent data items rather than nested components.
@@ -84,9 +89,14 @@ export function bindActions(
           eventValue = target.value;
         }
       }
-      // Slider returns an array — unwrap single-thumb to scalar,
-      // keep array for range mode (two thumbs)
-      if (Array.isArray(event) && typeof event[0] === "number") {
+      // Slider (onChange) returns an array — unwrap single-thumb to scalar,
+      // keep array for range mode (two thumbs). Skip for onSelect which
+      // intentionally passes an array of selected indices.
+      if (
+        propName === "onChange" &&
+        Array.isArray(event) &&
+        typeof event[0] === "number"
+      ) {
         eventValue = props.range ? event : event[0];
       }
       await executeActions(

--- a/renderer/src/schemas/data_table.ts
+++ b/renderer/src/schemas/data_table.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { componentBase } from "./base.ts";
+import { actionOrList } from "./actions.ts";
 
 const dataTableColumnSchema = z.object({
   key: z.string(),
@@ -16,6 +17,8 @@ export const dataTableSchema = componentBase.extend({
   searchable: z.boolean().optional(),
   paginated: z.boolean().optional(),
   pageSize: z.number().int().optional(),
+  selectable: z.boolean().optional(),
+  onSelect: actionOrList.optional(),
 });
 
 export type DataTableWire = z.infer<typeof dataTableSchema>;

--- a/schemas/fixtures/components/DataTable.json
+++ b/schemas/fixtures/components/DataTable.json
@@ -4,5 +4,6 @@
   "rows": [],
   "searchable": false,
   "paginated": false,
-  "pageSize": 10
+  "pageSize": 10,
+  "selectable": false
 }

--- a/src/prefab_ui/components/data_table.py
+++ b/src/prefab_ui/components/data_table.py
@@ -24,6 +24,7 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 
+from prefab_ui.actions import Action
 from prefab_ui.components.base import Component
 
 
@@ -72,6 +73,12 @@ class DataTable(Component):
     paginated: bool = Field(default=False, description="Show pagination controls")
     page_size: int = Field(
         default=10, alias="pageSize", description="Rows per page when paginated"
+    )
+    selectable: bool = Field(default=False, description="Show row selection checkboxes")
+    on_select: Action | list[Action] | None = Field(
+        default=None,
+        alias="onSelect",
+        description="Action(s) when selection changes. $event is the list of selected row indices.",
     )
 
     def to_json(self) -> dict[str, Any]:

--- a/tests/components/test_table.py
+++ b/tests/components/test_table.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from prefab_ui.actions import SetState
 from prefab_ui.components import (
     Badge,
     DataTable,
@@ -132,3 +133,56 @@ class TestDataTableComponent:
         )
         j = dt.to_json()
         assert j["rows"] == "{{ users }}"
+
+    def test_data_table_selectable_default_false(self):
+        dt = DataTable(
+            columns=[DataTableColumn(key="name", header="Name")],
+            rows=[{"name": "Alice"}],
+        )
+        j = dt.to_json()
+        assert j.get("selectable") is False
+
+    def test_data_table_selectable_true(self):
+        dt = DataTable(
+            columns=[DataTableColumn(key="name", header="Name")],
+            rows=[{"name": "Alice"}],
+            selectable=True,
+        )
+        j = dt.to_json()
+        assert j["selectable"] is True
+
+    def test_data_table_on_select_single_action(self):
+        action = SetState(key="selection", value="{{ $event }}")
+        dt = DataTable(
+            columns=[DataTableColumn(key="name", header="Name")],
+            rows=[{"name": "Alice"}],
+            selectable=True,
+            on_select=action,
+        )
+        j = dt.to_json()
+        assert "onSelect" in j
+        assert j["onSelect"]["action"] == "setState"
+        assert j["onSelect"]["key"] == "selection"
+
+    def test_data_table_on_select_list_of_actions(self):
+        actions = [
+            SetState(key="selection", value="{{ $event }}"),
+            SetState(key="count", value="{{ $event | length }}"),
+        ]
+        dt = DataTable(
+            columns=[DataTableColumn(key="name", header="Name")],
+            rows=[{"name": "Alice"}],
+            selectable=True,
+            on_select=actions,
+        )
+        j = dt.to_json()
+        assert isinstance(j["onSelect"], list)
+        assert len(j["onSelect"]) == 2
+
+    def test_data_table_on_select_none_by_default(self):
+        dt = DataTable(
+            columns=[DataTableColumn(key="name", header="Name")],
+            rows=[{"name": "Alice"}],
+        )
+        j = dt.to_json()
+        assert j.get("onSelect") is None


### PR DESCRIPTION
Add `selectable=True` for checkbox-based row selection with select-all header.

```python
DataTable(
    columns=[...],
    rows=[...],
    selectable=True,
    on_select=ShowToast("Selected: {{ $event }}"),
)
```