### PR TITLE
Resolve string tool names through the tool resolver

### DIFF
--- a/docs/actions/call-tool.mdx
+++ b/docs/actions/call-tool.mdx
@@ -180,13 +180,15 @@ def browse():
 
 Callable references provide two advantages over string names. First, the resolver handles name mangling (global keys, namespace prefixes) so your code doesn't need to know the final tool name. Second, the resolver can inspect the tool's metadata and inject hints into the serialized action — for example, `unwrapResult`.
 
+String names are also resolved when a resolver is active. `CallTool("save_contact")` will pass the string `"save_contact"` through the resolver, which can map it to a global key like `"save_contact-a1b2c3d4"`. This means you can use string names in a FastMCPApp context and still get correct name resolution — useful when you don't have a direct reference to the tool function (e.g., tools defined in mounted sub-apps).
+
 ### Automatic Result Unwrapping
 
 MCP requires `structuredContent` to be a JSON object, so FastMCP wraps non-object tool returns (lists, strings, numbers) in a `{"result": X}` envelope. Without correction, `$result` in your `on_success` callback would contain this envelope instead of the actual data.
 
 When you use a callable reference, the resolver detects this wrapping and sets `unwrapResult: true` on the serialized action. The renderer sees the flag and automatically extracts the inner value, so `$result` contains exactly what your tool returned.
 
-This only happens with callable references. If you use a string name (`CallTool("search")`), the resolver isn't involved and no unwrapping occurs — `$result` will contain the raw `structuredContent` from the server.
+String names go through the same resolver, so they also benefit from `unwrapResult` when the resolver can identify the tool. However, if the resolver doesn't recognize a string name (e.g., a dynamically constructed name), it may not be able to determine whether unwrapping is needed.
 
 ## API Reference
 

--- a/src/prefab_ui/actions/mcp.py
+++ b/src/prefab_ui/actions/mcp.py
@@ -55,13 +55,13 @@ class CallTool(Action):
     @model_serializer(mode="wrap")
     def _serialize_with_resolver(self, handler: Any) -> dict[str, Any]:
         data: dict[str, Any] = _coerce_rx(handler(self))  # type: ignore[assignment]
-        if self._tool_ref is not None:
-            resolver = get_tool_resolver()
-            if resolver is not None:
-                resolved = resolver(self._tool_ref)
-                data["tool"] = resolved.name
-                if resolved.unwrap_result:
-                    data["unwrapResult"] = True
+        resolver = get_tool_resolver()
+        if resolver is not None:
+            ref = self._tool_ref if self._tool_ref is not None else self.tool
+            resolved = resolver(ref)
+            data["tool"] = resolved.name
+            if resolved.unwrap_result:
+                data["unwrapResult"] = True
         return {k: v for k, v in data.items() if v is not None}
 
 

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -117,21 +117,19 @@ class TestCallToolResolver:
         d = action.model_dump(by_alias=True, exclude_none=True)
         assert d["tool"] == "my_tool"
 
-    def test_string_tool_unaffected_by_resolver(self):
-        from prefab_ui.app import PrefabApp
+    def test_string_tool_resolved_by_resolver(self):
+        from prefab_ui.app import PrefabApp, ResolvedTool
         from prefab_ui.components import Column
 
-        action = CallTool("explicit_name")
+        action = CallTool("save_contact")
         view = Column()
         view.children = [Button(label="Go", on_click=action)]
         app = PrefabApp(view=view)
 
-        from prefab_ui.app import ResolvedTool
-
         j = app.to_json(
-            tool_resolver=lambda fn: ResolvedTool(name="should_not_be_called")
+            tool_resolver=lambda ref: ResolvedTool(name="save_contact-a1b2c3d4")
         )
-        assert j["view"]["children"][0]["onClick"]["tool"] == "explicit_name"
+        assert j["view"]["children"][0]["onClick"]["tool"] == "save_contact-a1b2c3d4"
 
 
 class TestActionOnComponents:


### PR DESCRIPTION
`CallTool` previously only consulted the tool resolver for callable references — string tool names were serialized as-is, even when a resolver was active. This meant `CallTool("save_contact")` in a FastMCPApp context would emit the bare name instead of the resolved global key like `"save_contact-a1b2c3d4"`.

Now the serializer always passes through the resolver when one exists, using either the callable ref or the string name as input. This is the Prefab-side half of enabling string-based tool resolution; the FastMCP side (a `_NAME_TO_GLOBAL_KEY` registry) is independent and can land separately.

```python
# String names now resolve the same way callables do
Button("Save", on_click=CallTool("save_contact"))
# → {"tool": "save_contact-a1b2c3d4"} when resolver is active
```