### PR TITLE
Fix playground code scrolling under line numbers

### DIFF
--- a/renderer/src/playground/editor.tsx
+++ b/renderer/src/playground/editor.tsx
@@ -146,7 +146,8 @@ const baseEditorStyles = {
     paddingRight: "1rem",
   },
   ".cm-gutters": {
-    backgroundColor: "transparent",
+    backgroundColor:
+      "color-mix(in srgb, var(--color-muted) 30%, var(--color-background))",
     border: "none",
     paddingLeft: "0.5rem",
     paddingRight: "0.25rem",


### PR DESCRIPTION
The playground editor's line number gutter had a transparent background, so horizontally-scrolled code would bleed underneath the sticky gutter column. This gives the gutter an opaque background using `color-mix()` to match the container's `bg-muted/30` overlay on `bg-background` — works across all themes since it references CSS variables.

Closes #310