### PR TITLE
Pass FastMCPApp identity on callServerTool requests

### DIFF
--- a/renderer/src/actions.test.ts
+++ b/renderer/src/actions.test.ts
@@ -2,7 +2,12 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { App } from "@modelcontextprotocol/ext-apps";
 import { createStateStore } from "./testing/state-store";
 import { createMockApp, type MockApp } from "./testing/mock-app";
-import { executeAction, executeActions, type ActionSpec } from "./actions";
+import {
+  executeAction,
+  executeActions,
+  setAppName,
+  type ActionSpec,
+} from "./actions";
 
 // Mock sonner to avoid DOM access
 vi.mock("sonner", () => ({
@@ -23,6 +28,7 @@ describe("executeAction", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    setAppName(undefined);
     app = createMockApp();
     appAsApp = app as unknown as App;
   });
@@ -218,6 +224,41 @@ describe("executeAction", () => {
       expect(app.callServerTool).toHaveBeenCalledWith({
         name: "search",
         arguments: { q: "hello" },
+        _meta: undefined,
+      });
+    });
+
+    it("includes _meta.fastmcp.app when appName is set", async () => {
+      setAppName("Contacts");
+      const state = createStateStore();
+      const action: ActionSpec = {
+        action: "toolCall",
+        tool: "save_contact",
+        arguments: { name: "Alice" },
+      };
+
+      await executeAction(action, appAsApp, state);
+
+      expect(app.callServerTool).toHaveBeenCalledWith({
+        name: "save_contact",
+        arguments: { name: "Alice" },
+        _meta: { fastmcp: { app: "Contacts" } },
+      });
+    });
+
+    it("omits _meta when appName is not set", async () => {
+      const state = createStateStore();
+      const action: ActionSpec = {
+        action: "toolCall",
+        tool: "search",
+      };
+
+      await executeAction(action, appAsApp, state);
+
+      expect(app.callServerTool).toHaveBeenCalledWith({
+        name: "search",
+        arguments: {},
+        _meta: undefined,
       });
     });
   });

--- a/renderer/src/actions.ts
+++ b/renderer/src/actions.ts
@@ -55,6 +55,20 @@ export function clearAllIntervals(): void {
 }
 
 /**
+ * FastMCPApp identity for scoping callServerTool requests.
+ *
+ * When set, every outgoing tool call includes
+ * `_meta: { fastmcp: { app: appName } }` so the server can route the
+ * call to the correct app's tool registry.
+ */
+let appName: string | undefined;
+
+/** Set the app name used to scope server tool calls. */
+export function setAppName(name: string | undefined): void {
+  appName = name;
+}
+
+/**
  * Extract a human-readable error message from a failed action result.
  *
  * Looks for text content in the result's content array (the standard MCP
@@ -155,6 +169,7 @@ export async function executeAction(
         const toolResult = await app?.callServerTool({
           name,
           arguments: args,
+          _meta: appName ? { fastmcp: { app: appName } } : undefined,
         });
         if (toolResult?.isError) {
           success = false;

--- a/renderer/src/app.tsx
+++ b/renderer/src/app.tsx
@@ -33,7 +33,7 @@ import type {
 import { RenderTree, type ComponentNode } from "./renderer";
 import { useStateStore } from "./state";
 import { earlyBridge } from "./early-bridge";
-import { clearAllIntervals } from "./actions";
+import { clearAllIntervals, setAppName } from "./actions";
 import { resolveTheme, buildThemeCss } from "./themes";
 
 /** Protocol versions this renderer understands. */
@@ -143,6 +143,13 @@ export function App() {
         ComponentNode
       >;
       const stateData = (structured.state ?? {}) as Record<string, unknown>;
+
+      // Scope server tool calls to this app when the server provides
+      // an app identity via _meta.fastmcp.app in the structured content.
+      const meta = structured._meta as
+        | { fastmcp?: { app?: string } }
+        | undefined;
+      setAppName(meta?.fastmcp?.app);
 
       // Full state reset — host is providing a fresh view + state.
       // Preserve $host across resets so host context stays available.


### PR DESCRIPTION
When a FastMCPApp serves multiple apps or uses namespace transforms, the server needs to know which app a tool call is for. FastMCP now injects `_meta.fastmcp.app` into the structured content it sends to the renderer. The renderer reads this on init and echoes it back as `_meta: { fastmcp: { app: "Contacts" } }` on every `callServerTool` call, letting the server scope tool lookups by app name instead of relying on UUID-suffixed global keys.

This is a renderer-only change — no Python-side modifications. When `_meta.fastmcp.app` isn't present in the structured content (non-FastMCPApp usage), `_meta` is omitted from tool calls and behavior is unchanged.