### PR TITLE
Add parent= kwarg for imperative tree-building

### DIFF
--- a/dev-docs/generative-ui.md
+++ b/dev-docs/generative-ui.md
@@ -1,0 +1,91 @@
+# Generative UI
+
+Prefab supports generative UI: an LLM writes Python code that builds a component tree, and the user sees it rendered in real time as the code streams in.
+
+## Tree-building patterns
+
+There are three ways to build a component tree, each suited to different contexts:
+
+### Context managers (idiomatic)
+
+Visual nesting mirrors the component hierarchy. The preferred style for hand-written code.
+
+```python
+with Column(gap=4) as root:
+    Heading("Sales Report")
+    with Row():
+        Text("Revenue: $1.2M")
+        Text("Growth: 15%")
+```
+
+Requires Python's `with` statement and relies on ContextVars internally.
+
+### `parent=` (imperative)
+
+Each line is an independent statement that attaches a component to a parent.
+
+```python
+root = Column(gap=4)
+Heading("Sales Report", parent=root)
+row = Row(parent=root)
+Text("Revenue: $1.2M", parent=row)
+Text("Growth: 15%", parent=row)
+```
+
+This exists for two reasons:
+
+1. **Sandbox compatibility.** Monty (pydantic-monty) sandboxes Python execution but supports neither context managers nor ContextVars. The `parent=` pattern works purely through function calls and attribute mutation.
+
+2. **Streaming evaluation.** When an LLM generates code token by token, each `Component(..., parent=root)` line can be evaluated as soon as it's complete — the UI builds up incrementally. With `children=[...]` you must wait for the closing bracket. With `with Column():` you need the entire block.
+
+### `children=` (batch)
+
+Pass children as a list at construction time.
+
+```python
+Column(gap=4, children=[
+    Heading("Sales Report"),
+    Row(children=[
+        Text("Revenue: $1.2M"),
+        Text("Growth: 15%"),
+    ]),
+])
+```
+
+Works in any environment but the entire tree must be complete before evaluation. Not suitable for streaming.
+
+## Implementation: `parent=`
+
+The `parent=` kwarg is handled in `Component.__init__` (`components/base.py`). It is not a Pydantic field — it's popped from kwargs before Pydantic ever sees it, so it never serializes.
+
+The implementation uses "undo" rather than "prevent": `super().__init__()` runs normally (which may auto-attach the component to the context manager stack via `model_post_init`), then `__init__` removes the component from the stack parent and appends it to the explicit parent instead. This avoids introducing new ContextVars — the only ContextVar touched is the existing `_component_stack`, and only for cleanup.
+
+When there's no active context manager (the common case for sandbox/streaming), there's no stack to undo — the component just appends to the explicit parent directly.
+
+## Streaming architecture
+
+The renderer already supports full tree replacement. Each time a tool result arrives via `handleToolResult` in `app.tsx`, the renderer replaces the view and React's reconciliation diffs it — existing components stay mounted, new ones appear. No renderer changes are needed for streaming.
+
+The work for streaming is on the Python/FastMCP side: a streaming tool that yields progressively larger `PrefabApp` objects as the LLM generates more code. Each yield sends an updated tree to the renderer.
+
+## Monty shims
+
+Monty doesn't support classes, so Prefab components are exposed as plain functions that call real constructors outside the sandbox:
+
+```python
+def make_shim(cls):
+    def shim(**kwargs):
+        return cls(**kwargs)
+    return shim
+```
+
+Since `parent=` is handled natively by `Component.__init__`, the shims need no special logic — they just pass through kwargs.
+
+## PR chain
+
+This capability is being built across a series of PRs:
+
+1. **`parent=` kwarg on Component** — the foundation
+2. **Monty shims** — function wrappers exposing components to the sandbox
+3. **Streaming tool execution** — FastMCP sends progressive tree updates during tool execution
+4. **Error boundaries** — graceful handling of bad LLM-generated code mid-stream

--- a/src/prefab_ui/components/base.py
+++ b/src/prefab_ui/components/base.py
@@ -250,6 +250,13 @@ class Component(BaseModel):
     Components serialize to JSON via ``to_json()`` for the React renderer.
     When created inside a ``ContainerComponent`` context manager, they
     automatically append themselves to the parent's children list.
+
+    Alternatively, pass ``parent=<container>`` to attach to a specific
+    container without using a context manager::
+
+        root = Column(gap=4)
+        Heading("Sales Report", parent=root)
+        Text("Q3 results", parent=root)
     """
 
     model_config = {"populate_by_name": True, "arbitrary_types_allowed": True}
@@ -269,6 +276,28 @@ class Component(BaseModel):
         alias="cssClass",
         description="CSS/Tailwind classes for styling. Accepts a Responsive() for breakpoint-aware classes.",
     )
+
+    def __init__(self, /, **kwargs: Any) -> None:
+        parent = kwargs.pop("parent", None)
+        if parent is not None:
+            if not isinstance(parent, ContainerComponent):
+                raise TypeError(
+                    f"parent must be a container component like Column or Row, "
+                    f"got {type(parent).__name__}"
+                )
+            if kwargs.get("defer", False):
+                raise ValueError(
+                    "Cannot use parent= and defer=True together — "
+                    "parent= attaches immediately, defer=True prevents attachment"
+                )
+        super().__init__(**kwargs)
+        if parent is not None:
+            # Undo stack auto-attach that model_post_init may have done
+            stack = _component_stack.get() or []
+            if stack:
+                with contextlib.suppress(ValueError):
+                    stack[-1].children.remove(self)
+            parent.children.append(self)
 
     @model_validator(mode="before")
     @classmethod

--- a/tests/components/test_base.py
+++ b/tests/components/test_base.py
@@ -1,4 +1,4 @@
-"""Tests for context manager nesting, defer, and insert."""
+"""Tests for context manager nesting, defer, insert, and parent=."""
 
 from __future__ import annotations
 
@@ -254,3 +254,97 @@ class TestInsert:
         text = col.children[0]
         assert "{{ " in text.content  # type: ignore[attr-defined]
         assert col.children[1] is volume
+
+
+class TestParent:
+    def test_basic_attachment(self):
+        col = Column()
+        t = Text(content="hello", parent=col)
+        assert len(col.children) == 1
+        assert col.children[0] is t
+
+    def test_outside_context_manager(self):
+        col = Column()
+        Text(content="a", parent=col)
+        Text(content="b", parent=col)
+        assert len(col.children) == 2
+        assert col.children[0].content == "a"  # type: ignore[attr-defined]
+        assert col.children[1].content == "b"  # type: ignore[attr-defined]
+
+    def test_explicit_parent_wins_over_stack(self):
+        target = Column()
+        with Column() as outer:
+            Text(content="auto-attached")
+            Text(content="explicit", parent=target)
+        assert len(outer.children) == 1
+        assert outer.children[0].content == "auto-attached"  # type: ignore[attr-defined]
+        assert len(target.children) == 1
+        assert target.children[0].content == "explicit"  # type: ignore[attr-defined]
+
+    def test_nested_contexts(self):
+        target = Column()
+        with Column() as outer:
+            with Row() as inner:
+                Text(content="in-row", parent=target)
+        assert len(target.children) == 1
+        assert len(inner.children) == 0
+        assert len(outer.children) == 1  # just the Row
+
+    def test_does_not_serialize(self):
+        col = Column()
+        t = Text(content="hello", parent=col)
+        j = t.to_json()
+        assert "parent" not in j
+
+    def test_with_stateful_component(self):
+        col = Column()
+        slider = Slider(value=50, parent=col)
+        assert slider.name is not None
+        assert slider.rx is not None
+        assert len(col.children) == 1
+        assert col.children[0] is slider
+
+    def test_non_container_raises_type_error(self):
+        leaf = Text(content="not a container")
+        with pytest.raises(TypeError, match="container component"):
+            Text(content="child", parent=leaf)
+
+    def test_parent_and_defer_raises(self):
+        col = Column()
+        with pytest.raises(ValueError, match="parent.*defer"):
+            Text(content="conflict", parent=col, defer=True)
+
+    def test_container_with_children_and_parent(self):
+        target = Column()
+        row = Row(
+            children=[Text(content="a"), Text(content="b")],
+            parent=target,
+        )
+        assert len(target.children) == 1
+        assert target.children[0] is row
+        assert len(row.children) == 2
+
+    def test_inside_defer_context(self):
+        target = Column()
+        with defer():
+            Text(content="hello", parent=target)
+        assert len(target.children) == 1
+
+    def test_multiple_children_ordering(self):
+        col = Column()
+        Text(content="first", parent=col)
+        Text(content="second", parent=col)
+        Text(content="third", parent=col)
+        assert [c.content for c in col.children] == ["first", "second", "third"]  # type: ignore[attr-defined]
+
+    def test_generative_ui_pattern(self):
+        """The motivating use case: imperative tree-building for sandboxed code."""
+        root = Column()
+        Heading("Sales Report", parent=root)
+        with Row(parent=root) as metrics:
+            Text(content="Revenue: $1.2M", parent=metrics)
+            Text(content="Growth: 15%", parent=metrics)
+        assert len(root.children) == 2
+        assert isinstance(root.children[0], Heading)
+        assert isinstance(root.children[1], Row)
+        assert len(root.children[1].children) == 2


### PR DESCRIPTION
Components can now attach to a specific parent without context managers:

```python
root = Column(gap=4)
Heading("Sales Report", parent=root)
BarChart(data=data, series=[...], parent=root)
```

This is the foundation for generative UI — an LLM writes Python that builds Prefab component trees, and each line is independently evaluable. Context managers require the full block to be syntactically complete before evaluation; `parent=` inverts that dependency so each statement stands alone. That inversion is what makes streaming possible: evaluate a line, re-send the growing tree, the renderer diffs it via React reconciliation.

The implementation pops `parent` from kwargs before Pydantic sees it (never serializes), lets `model_post_init` run normally, then undoes any stack auto-attach and appends to the explicit parent. No new ContextVars — just 12 lines in `Component.__init__`.

All three tree-building patterns (`with` blocks, `parent=`, `children=`) produce identical component trees and can be mixed freely. `parent=` inside a `with` block correctly attaches only to the explicit parent.

Closes #327