### PR TITLE
Accept Rx() for DataTable rows

### DIFF
--- a/src/prefab_ui/components/data_table.py
+++ b/src/prefab_ui/components/data_table.py
@@ -30,6 +30,7 @@ from pydantic import BaseModel, Field, model_validator
 
 from prefab_ui.actions import Action
 from prefab_ui.components.base import Component, _merge_css_classes
+from prefab_ui.rx import Rx
 
 
 def _serialize_cell_value(value: Any) -> Any:
@@ -129,7 +130,7 @@ class DataTable(Component):
             rows = data.get("rows")
         else:
             return data
-        if rows is None:
+        if rows is None or isinstance(rows, (str, Rx)):
             return data
         if hasattr(rows, "columns") and hasattr(rows, "to_dict"):
             if hasattr(rows, "to_dicts"):
@@ -143,7 +144,7 @@ class DataTable(Component):
         return data
 
     columns: list[DataTableColumn] = Field(description="Column definitions")
-    rows: list[dict[str, Any]] | str = Field(
+    rows: list[dict[str, Any]] | str | Rx = Field(
         default_factory=list,
         description="Row data, {{ interpolation }} reference, or DataFrame",
     )

--- a/tests/components/test_table.py
+++ b/tests/components/test_table.py
@@ -16,6 +16,7 @@ from prefab_ui.components import (
     TableRow,
 )
 from prefab_ui.components.charts import Sparkline
+from prefab_ui.rx import Rx
 
 
 class TestTableComponents:
@@ -144,6 +145,15 @@ class TestDataTableComponent:
         assert "onRowClick" in j
         assert j["onRowClick"]["action"] == "showToast"
         assert j["onRowClick"]["message"] == "Row clicked"
+
+    def test_data_table_rx_rows(self):
+        rx = Rx("users")
+        dt = DataTable(
+            columns=[DataTableColumn(key="name", header="Name")],
+            rows=rx,
+        )
+        j = dt.to_json()
+        assert j["rows"] == "{{ users }}"
 
     def test_data_table_on_row_click_list(self):
         dt = DataTable(


### PR DESCRIPTION
`DataTable.rows` was typed as `list[dict[str, Any]] | str`, so passing an `Rx()` reactive reference failed Pydantic validation. This adds `Rx` to the union and guards the `_coerce_dataframe` validator against `Rx` objects — whose `__getattr__` returns a new `Rx` for any attribute, making `hasattr` checks for DataFrame duck-typing incorrectly pass.

```python
DataTable(
    columns=[DataTableColumn(key="name", header="Name")],
    rows=Rx("users"),  # now works
)
```