### PR TITLE
Fix OpenLink in prefab serve mode

### DIFF
--- a/renderer/src/actions.ts
+++ b/renderer/src/actions.ts
@@ -226,10 +226,18 @@ export async function executeAction(
         break;
       }
       case "openLink": {
-        const result = await app?.openLink({ url: resolved.url as string });
-        if (result?.isError) {
-          success = false;
-          errorMessage = extractErrorText(result);
+        const url = resolved.url as string;
+        if (app) {
+          try {
+            const result = await app.openLink({ url });
+            if (result?.isError) {
+              window.open(url, "_blank", "noopener,noreferrer");
+            }
+          } catch {
+            window.open(url, "_blank", "noopener,noreferrer");
+          }
+        } else {
+          window.open(url, "_blank", "noopener,noreferrer");
         }
         break;
       }


### PR DESCRIPTION
`OpenLink` actions silently fail in `prefab serve` because the renderer's MCP App instance is created eagerly but never connects to a host. Calling `app.openLink()` on the closed instance throws, and the outer catch swallows the error — the link never opens.

The fix adds a `window.open()` fallback in the renderer's action dispatcher. If the MCP host handles `openLink` successfully, behavior is unchanged. If the call fails (serve mode, closed connection) or `app` is null (preview/playground), the renderer opens the URL directly via `window.open()`.

Fixes #346