### PR TITLE
Sanitize NaN/Inf to null in JSON serialization

### DIFF
--- a/src/prefab_ui/app.py
+++ b/src/prefab_ui/app.py
@@ -31,6 +31,7 @@ import pydantic_core
 from pydantic import BaseModel, Field, PrivateAttr, model_validator
 
 from prefab_ui.renderer import _get_origin, get_renderer_csp, get_renderer_head
+from prefab_ui.rx import _sanitize_floats
 from prefab_ui.themes import Theme
 
 PROTOCOL_VERSION = "0.2"
@@ -78,7 +79,8 @@ _PAGE_TEMPLATE = """\
 def _serialize_state(state: dict[str, Any]) -> dict[str, Any]:
     """Serialize state for the wire protocol."""
     return {
-        key: pydantic_core.to_jsonable_python(value) for key, value in state.items()
+        key: _sanitize_floats(pydantic_core.to_jsonable_python(value))
+        for key, value in state.items()
     }
 
 

--- a/src/prefab_ui/components/base.py
+++ b/src/prefab_ui/components/base.py
@@ -7,7 +7,7 @@ import re
 from collections.abc import Generator
 from contextlib import contextmanager
 from contextvars import ContextVar
-from typing import Annotated, Any, ClassVar, Literal
+from typing import Annotated, Any, ClassVar, Literal, cast
 
 from pydantic import (
     BaseModel,
@@ -19,7 +19,7 @@ from pydantic import (
 from typing_extensions import Self
 
 from prefab_ui.css import Responsive
-from prefab_ui.rx import Rx, _coerce_rx, _generate_key
+from prefab_ui.rx import Rx, _coerce_rx, _generate_key, _sanitize_floats
 
 _component_stack: ContextVar[list[ContainerComponent] | None] = ContextVar(
     "_component_stack", default=None
@@ -345,7 +345,8 @@ class Component(BaseModel):
         Produces a JSON object with `type` set to the class name plus
         props, with `None` values excluded. Children are serialized recursively.
         """
-        return self.model_dump(by_alias=True, exclude_none=True)
+        data = self.model_dump(by_alias=True, exclude_none=True)
+        return cast(dict[str, Any], _sanitize_floats(data))
 
 
 class ContainerComponent(Component):

--- a/src/prefab_ui/rx/__init__.py
+++ b/src/prefab_ui/rx/__init__.py
@@ -30,6 +30,7 @@ quantity > 0                  # {{ quantity > 0 }}
 
 from __future__ import annotations
 
+import math
 from collections.abc import Callable
 from contextvars import ContextVar
 from typing import Any, NamedTuple, Protocol, runtime_checkable
@@ -534,6 +535,17 @@ def _coerce_rx(value: object) -> object:
         return {k: _coerce_rx(v) for k, v in value.items()}
     if isinstance(value, list):
         return [_coerce_rx(v) for v in value]
+    return value
+
+
+def _sanitize_floats(value: object) -> object:
+    """Replace non-finite floats (NaN, Inf, -Inf) with None for JSON safety."""
+    if isinstance(value, float):
+        return None if not math.isfinite(value) else value
+    if isinstance(value, dict):
+        return {k: _sanitize_floats(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_sanitize_floats(v) for v in value]
     return value
 
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -84,6 +84,59 @@ class TestPrefabAppFromJson:
         assert result["view"]["children"] == [view_dict]
 
 
+class TestNonFiniteFloatSanitization:
+    """Non-finite floats (NaN, Inf) must become null in JSON output."""
+
+    def test_nan_in_component_data(self):
+        from prefab_ui.components.charts import BarChart, ChartSeries
+
+        data = [{"x": "a", "y": float("nan")}]
+        chart = BarChart(
+            data=data, series=[ChartSeries(dataKey="y", label="y")], xAxis="x"
+        )
+        result = chart.to_json()
+        assert result["data"][0]["y"] is None
+
+    def test_inf_in_component_data(self):
+        from prefab_ui.components.charts import BarChart, ChartSeries
+
+        data = [{"x": "a", "y": float("inf")}, {"x": "b", "y": float("-inf")}]
+        chart = BarChart(
+            data=data, series=[ChartSeries(dataKey="y", label="y")], xAxis="x"
+        )
+        result = chart.to_json()
+        assert result["data"][0]["y"] is None
+        assert result["data"][1]["y"] is None
+
+    def test_nan_in_state(self):
+        app = PrefabApp(state={"score": float("nan"), "count": 3})
+        result = app.to_json()
+        assert result["state"]["score"] is None
+        assert result["state"]["count"] == 3
+
+    def test_html_output_is_valid_json(self):
+        from prefab_ui.components.charts import BarChart, ChartSeries
+
+        data = [{"x": "a", "y": float("nan")}]
+        with Column() as view:
+            BarChart(data=data, series=[ChartSeries(dataKey="y", label="y")], xAxis="x")
+        app = PrefabApp(view=view)
+        html = app.html()
+        # Extract the JSON blob from the script tag
+        start = html.index('type="application/json">') + len('type="application/json">')
+        end = html.index("</script>", start)
+        raw = html[start:end].replace(r"<\/", "</")
+        parsed = json.loads(raw)
+        assert parsed["view"]["children"][0]["children"][0]["data"][0]["y"] is None
+
+    def test_finite_floats_preserved(self):
+        app = PrefabApp(state={"val": 3.14, "neg": -2.5, "zero": 0.0})
+        result = app.to_json()
+        assert result["state"]["val"] == 3.14
+        assert result["state"]["neg"] == -2.5
+        assert result["state"]["zero"] == 0.0
+
+
 class TestPrefabAppContextManager:
     def test_basic(self):
         with PrefabApp(state={"x": 1}) as app:


### PR DESCRIPTION
`float('nan')` and `float('inf')` in `Any`-typed fields (like chart `data`) pass through `model_dump()` unchanged. Python's `json.dumps()` then emits bare `NaN`/`Infinity` tokens, which aren't valid JSON and kill `JSON.parse` in the renderer — preventing the entire app from rendering.

A `_sanitize_floats` helper now recursively replaces non-finite floats with `None` (→ JSON `null`) at two choke points: `Component.to_json()` for component props, and `_serialize_state()` for app state.

```python
data = [{"x": "a", "y": float("nan")}, {"x": "b", "y": 3}]
BarChart(data=data, series=[ChartSeries(dataKey="y", label="y")], xAxis="x")
# data[0]["y"] serializes as null instead of NaN
```

Fixes #345