### PR TITLE
Fix pipe args dropping type info

### DIFF
--- a/renderer/src/custom-handlers.test.ts
+++ b/renderer/src/custom-handlers.test.ts
@@ -57,8 +57,8 @@ describe("custom-handlers", () => {
       _resetHandlers({
         pipes: {
           double: (value: unknown) => Number(value) * 2,
-          suffix: (value: unknown, arg?: string) =>
-            String(value) + (arg ?? "!"),
+          suffix: (value: unknown, arg?: unknown) =>
+            String(value) + String(arg ?? "!"),
         },
       });
     });

--- a/renderer/src/custom-handlers.ts
+++ b/renderer/src/custom-handlers.ts
@@ -10,7 +10,7 @@
  * Custom action handlers are invoked by the `callHandler` action.
  */
 
-export type PipeFn = (value: unknown, arg?: string) => unknown;
+export type PipeFn = (value: unknown, arg?: unknown) => unknown;
 
 export interface HandlerContext {
   /** Snapshot of the current state (not a live reference). */

--- a/renderer/src/expression.test.ts
+++ b/renderer/src/expression.test.ts
@@ -470,6 +470,22 @@ describe("evaluate", () => {
       );
     });
 
+    it("default pipe preserves boolean false", () => {
+      expect(evaluate("flag | default:false", {})).toBe(false);
+    });
+
+    it("default pipe preserves boolean true", () => {
+      expect(evaluate("flag | default:true", {})).toBe(true);
+    });
+
+    it("default pipe preserves number 0", () => {
+      expect(evaluate("count | default:0", {})).toBe(0);
+    });
+
+    it("default pipe preserves null", () => {
+      expect(evaluate("value | default:null", {})).toBe(null);
+    });
+
     it("first of array", () => {
       expect(evaluate("items | first", { items: [10, 20, 30] })).toBe(10);
     });

--- a/renderer/src/expression.ts
+++ b/renderer/src/expression.ts
@@ -31,20 +31,20 @@ import { getCustomPipe } from "./custom-handlers";
 
 // ── Pipe Registry ──────────────────────────────────────────────────────
 
-type PipeFn = (value: unknown, arg?: string) => unknown;
+type PipeFn = (value: unknown, arg?: unknown) => unknown;
 
 const pipes: Record<string, PipeFn> = {
   percent(value, arg) {
     const num = Number(value);
     if (isNaN(num)) return String(value);
-    const decimals = arg ? parseInt(arg) : 0;
+    const decimals = arg != null ? parseInt(String(arg)) : 0;
     return `${(num * 100).toFixed(decimals)}%`;
   },
 
   number(value, arg) {
     const num = Number(value);
     if (isNaN(num)) return String(value);
-    const decimals = arg ? parseInt(arg) : undefined;
+    const decimals = arg != null ? parseInt(String(arg)) : undefined;
     return num.toLocaleString("en-US", {
       minimumFractionDigits: decimals,
       maximumFractionDigits: decimals,
@@ -54,7 +54,7 @@ const pipes: Record<string, PipeFn> = {
   compact(value, arg) {
     const num = Number(value);
     if (isNaN(num)) return String(value);
-    const decimals = arg ? parseInt(arg) : undefined;
+    const decimals = arg != null ? parseInt(String(arg)) : undefined;
     return num.toLocaleString("en-US", {
       notation: "compact",
       maximumFractionDigits: decimals,
@@ -64,14 +64,14 @@ const pipes: Record<string, PipeFn> = {
   currency(value, arg) {
     const num = Number(value);
     if (isNaN(num)) return String(value);
-    const currency = arg ?? "USD";
+    const currency = String(arg ?? "USD");
     return num.toLocaleString("en-US", { style: "currency", currency });
   },
 
   date(value, arg) {
     const d = new Date(String(value));
     if (isNaN(d.getTime())) return String(value);
-    const style = (arg ?? "medium") as "short" | "medium" | "long";
+    const style = String(arg ?? "medium") as "short" | "medium" | "long";
     if (style === "short") return d.toLocaleDateString("en-US");
     if (style === "long")
       return d.toLocaleDateString("en-US", {
@@ -130,19 +130,19 @@ const pipes: Record<string, PipeFn> = {
   },
 
   join(value, arg) {
-    if (Array.isArray(value)) return value.join(arg ?? ", ");
+    if (Array.isArray(value)) return value.join(String(arg ?? ", "));
     return String(value);
   },
 
   truncate(value, arg) {
     const s = String(value);
-    const n = arg ? parseInt(arg) : 0;
+    const n = arg != null ? parseInt(String(arg)) : 0;
     if (n > 0 && s.length > n) return s.slice(0, n) + "...";
     return s;
   },
 
   default(value, arg) {
-    if (value == null) return arg ?? "";
+    if (value == null) return arg === undefined ? "" : arg;
     return value;
   },
 
@@ -165,34 +165,36 @@ const pipes: Record<string, PipeFn> = {
   round(value, arg) {
     const num = Number(value);
     if (isNaN(num)) return value;
-    const decimals = arg ? parseInt(arg) : 0;
+    const decimals = arg != null ? parseInt(String(arg)) : 0;
     const factor = Math.pow(10, decimals);
     return Math.round(num * factor) / factor;
   },
 
   selectattr(value, arg) {
     if (!Array.isArray(value) || !arg) return value;
+    const key = String(arg);
     return value.filter(
       (item) =>
         item != null &&
         typeof item === "object" &&
-        !!(item as Record<string, unknown>)[arg],
+        !!(item as Record<string, unknown>)[key],
     );
   },
 
   rejectattr(value, arg) {
     if (!Array.isArray(value) || !arg) return value;
+    const key = String(arg);
     return value.filter(
       (item) =>
         item != null &&
         typeof item === "object" &&
-        !(item as Record<string, unknown>)[arg],
+        !(item as Record<string, unknown>)[key],
     );
   },
 
   pluralize(value, arg) {
     const count = Number(value);
-    const singular = arg ?? "item";
+    const singular = String(arg ?? "item");
     return count === 1 ? singular : singular + "s";
   },
 };
@@ -398,11 +400,14 @@ class Parser {
       if (next.type === "ident") {
         // Named pipe transform
         const name = this.advance().value;
-        let arg: string | undefined;
+        let arg: unknown;
         if (this.peek().type === "colon") {
           this.advance(); // consume ':'
           const argTok = this.advance();
-          arg = argTok.value;
+          if (argTok.type === "bool") arg = argTok.value === "true";
+          else if (argTok.type === "number") arg = parseFloat(argTok.value);
+          else if (argTok.type === "null") arg = null;
+          else arg = argTok.value;
         }
         const fn = pipes[name] ?? getCustomPipe(name);
         if (fn) {


### PR DESCRIPTION
Named pipe arguments (`| default:false`, `| default:0`) were always extracted as strings regardless of token type. The expression engine correctly tokenized `false` as a boolean, but the pipe arg extraction just grabbed `.value` (a string) and passed it through. This meant `| default:false` returned the string `"false"` — truthy in JS — breaking any boolean prop that relied on it.

The visible symptom: the "One-Shot Delay" button on the [SetInterval docs page](https://prefab.prefect.io/docs/actions/set-interval) was permanently disabled because `disabled="{{ waiting | default:false }}"` evaluated to `"false"` (truthy string) instead of `false` (boolean).

The default value *shorthand* (`value | false`) already handled this correctly — it checked token type and converted. Only the named pipe codepath (`value | pipeName:arg`) dropped types.

The fix widens `PipeFn`'s `arg` from `string` to `unknown` and converts pipe arg tokens to their proper JS types (bool → boolean, number → number, null → null) at parse time, matching what the shorthand already did.