### PR TITLE
Gate PRs on fresh docs, purge all CDN files on release

### DIFF
--- a/.github/workflows/publish-renderer.yml
+++ b/.github/workflows/publish-renderer.yml
@@ -49,8 +49,12 @@ jobs:
         working-directory: renderer
 
       - name: Purge jsDelivr @latest cache
+        working-directory: renderer
         run: |
-          # The docs loader imports from @latest on jsDelivr. After publishing
-          # a new version, purge the CDN cache so the @latest alias resolves
-          # to the just-published version immediately.
-          curl -s "https://purge.jsdelivr.net/npm/@prefecthq/prefab-ui@latest/dist/_renderer/embed.mjs"
+          # Purge every published file from the CDN cache so @latest resolves
+          # to the just-published version immediately. Individual chunk hashes
+          # change between releases, so purging only the shim is not enough.
+          for f in dist/**/*.{js,mjs,html}; do
+            echo "Purging $f"
+            curl -s "https://purge.jsdelivr.net/npm/@prefecthq/prefab-ui@latest/$f" > /dev/null
+          done

--- a/.github/workflows/regenerate-docs.yml
+++ b/.github/workflows/regenerate-docs.yml
@@ -1,21 +1,19 @@
-name: Regenerate docs
+name: Check docs
 
 on:
   pull_request:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
-  regenerate_docs:
+  check_docs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@v6
-        with:
-          ref: ${{ github.head_ref }}
 
       - name: Setup uv
         uses: ./.github/actions/setup-uv
@@ -25,14 +23,22 @@ jobs:
       - name: Install renderer dependencies
         run: cd renderer && npm ci
 
-      - name: Regenerate docs
+      - name: Build docs
         run: uv run prefab dev build-docs
 
-      - name: Commit regenerated docs
+      - name: Check for stale generated files
         run: |
-          git diff --quiet docs/ && exit 0
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add docs/
-          git commit -m "Regenerate docs"
-          git push
+          STALE_FILES=$(git diff --name-only docs/ renderer/src/playground/bundle.json renderer/src/playground/examples.json)
+          if [ -n "$STALE_FILES" ]; then
+            echo "::error::Generated docs are out of date. Run 'prefab dev build-docs' and commit the output."
+            echo ""
+            echo "Stale files:"
+            echo "$STALE_FILES"
+            echo ""
+            echo "To fix:"
+            echo "  uv run prefab dev build-docs"
+            echo "  git add docs/ renderer/src/playground/bundle.json renderer/src/playground/examples.json"
+            echo "  git commit -m 'Regenerate docs'"
+            exit 1
+          fi
+          echo "All generated files are up to date."


### PR DESCRIPTION
Two reliability fixes that prevent the stale-docs-on-release problem we hit with v0.14.1.

**Check docs workflow** — the regenerate-docs workflow was auto-committing stale docs on PRs. Now it fails instead, with a clear error message telling you to run `prefab dev build-docs`. Since releases are cut from main and main only accepts PRs, this guarantees docs are never stale at release time.

**CDN purge** — the publish-renderer workflow was only purging the `embed.mjs` shim from jsDelivr, leaving stale code-split chunks cached for up to 7 days. Now it purges every file under `dist/` so the CDN serves fresh content immediately after a release.