### PR TITLE
Fix DropZone rejecting files when accept="*/*"

### DIFF
--- a/renderer/src/file-utils.ts
+++ b/renderer/src/file-utils.ts
@@ -84,6 +84,8 @@ export function filterByAccept(
     .map((t) => t.trim().toLowerCase())
     .filter(Boolean);
 
+  if (tokens.includes("*/*")) return files;
+
   const accepted: File[] = [];
   for (const file of files) {
     const fileType = file.type.toLowerCase();


### PR DESCRIPTION
`filterByAccept()` handles wildcard MIME patterns like `image/*` by slicing off the trailing `*` and checking `fileType.startsWith(prefix)`. For `*/*`, this produces prefix `*/`, which no real MIME type starts with, so every file gets rejected. The fix treats `*/*` as "accept all" by returning early when it appears in the accept tokens.

Closes #356