### PR TITLE
Update Don't Panic messaging and version pinning docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **The generative UI framework that even humans can use.**
 
-🚧 *Don't panic. Prefab is under **extremely** active development. You probably shouldn't use it yet.* 🚧
+🚧 *Don't panic. Prefab is under very active development.* 🚧
 
 [![PyPI - Version](https://img.shields.io/pypi/v/prefab-ui)](https://pypi.org/project/prefab-ui)
 [![Tests](https://github.com/PrefectHQ/prefab/actions/workflows/run-tests.yml/badge.svg)](https://github.com/PrefectHQ/prefab/actions/workflows/run-tests.yml)

--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -28,11 +28,11 @@ prefab version
 
 ## Versioning Policy
 
-Prefab is pre-1.0 software under **extremely** active development. The API surface is evolving quickly — components get added, renamed, and reworked as the project discovers what patterns work best for building agent-native UIs.
+Prefab is pre-1.0 software under very active development. The API surface is evolving quickly — components get added, renamed, and reworked as the project discovers what patterns work best for building agent-native UIs.
 
 ### What This Means in Practice
 
-**Minor versions (0.x.0) may include breaking changes.** Prefab follows semantic versioning with the standard pre-1.0 caveat: while the major version is `0`, any minor version bump can change the public API. A bump from `0.5.0` to `0.6.0` might rename components, change default behaviors, or restructure modules.
+**Minor versions (0.x.0) may include breaking changes.** Prefab follows semantic versioning with the standard pre-1.0 caveat: while the major version is `0`, any minor version bump can change the public API. A bump from `0.15.0` to `0.16.0` might rename components, change default behaviors, or restructure modules.
 
 **Patch versions (0.0.x) are safe updates.** Patch releases contain only bug fixes without breaking changes.
 
@@ -41,14 +41,14 @@ Prefab is pre-1.0 software under **extremely** active development. The API surfa
 For any use beyond experimentation, pin to an exact version:
 
 ```
-prefab-ui==0.5.0  # Good
-prefab-ui>=0.5.0  # Bad — may install breaking changes
+prefab-ui==0.15.0  # Good
+prefab-ui>=0.15.0  # Bad — may install breaking changes
 ```
 
 Or pin to a minor range if you want patch fixes:
 
 ```
-prefab-ui>=0.5,<0.6  # OK — gets patches, not breaking changes
+prefab-ui>=0.15,<0.16  # OK — gets patches, not breaking changes
 ```
 
 ### Breaking Change Philosophy
@@ -56,7 +56,7 @@ prefab-ui>=0.5,<0.6  # OK — gets patches, not breaking changes
 Prefab is young, and that means being willing to fix API mistakes early rather than carrying them forever. Each breaking change is a deliberate decision to keep the framework simple and consistent rather than accumulating design debt.
 
 When breaking changes occur:
-- They only happen in minor versions (e.g., 0.5.x to 0.6.0)
+- They only happen in minor versions (e.g., 0.15.x to 0.16.0)
 - Release notes explain what changed and how to migrate
 - Changes must substantially benefit users to justify disruption
 

--- a/docs/running/fastmcp.mdx
+++ b/docs/running/fastmcp.mdx
@@ -7,9 +7,9 @@ icon: rocket
 
 Prefab integrates with [FastMCP](https://github.com/PrefectHQ/fastmcp) to build [MCP Apps](https://modelcontextprotocol.io/docs/extensions/apps) — interactive UIs that render directly inside the conversation. Mark any tool with `app=True` and return a component tree or a `PrefabApp`:
 
-<Warning>
-MCP App support requires a development branch of FastMCP that has not been released yet. This page will be updated with install instructions when it ships.
-</Warning>
+<Note>
+When you install `fastmcp[apps]`, FastMCP pulls in `prefab-ui` with only a minimum version — no upper bound. For production, pin `prefab-ui` explicitly in your own dependencies (e.g. `prefab-ui==0.15.0`). See [Versioning Policy](/getting-started/installation#versioning-policy) for details.
+</Note>
 
 ```python
 from fastmcp import FastMCP

--- a/docs/welcome.mdx
+++ b/docs/welcome.mdx
@@ -10,7 +10,7 @@ import _C_showcase from '/snippets/gen/welcome/code_showcase.mdx'
 import { ComponentPreview } from '/snippets/component-preview.mdx'
 
 <Warning>
-*Don't panic. Prefab is under **extremely** active development. You probably shouldn't use it yet.*
+*Don't panic. Prefab is under very active development.*
 </Warning>
 
 **Prefab is a frontend framework with a Python DSL that compiles to JSON.** Build [MCP Apps](/running/fastmcp), data dashboards, and interactive tools with layouts, forms, charts, data tables, and full interactivity. A bundled React renderer turns the JSON into a self-contained application.


### PR DESCRIPTION
Following PrefectHQ/fastmcp#3688, which added version-pinning warnings to FastMCP's docs, this updates Prefab's own docs to match.

The old "you probably shouldn't use it yet" message no longer reflects reality — people are using Prefab in production via FastMCP apps. The new messaging across README, welcome page, and installation docs shifts from discouraging use to setting expectations: it's moving fast, pin your version.

The FastMCP integration page (`docs/running/fastmcp.mdx`) replaces the stale "requires a development branch" warning with a pinning callout explaining that `fastmcp[apps]` only floors the version, and linking to the versioning policy. Version examples throughout installation docs are bumped from `0.5.0` to `0.15.0`.