### PR TITLE
Add READMEs to satellite npm packages

### DIFF
--- a/renderer/docs-package/README.md
+++ b/renderer/docs-package/README.md
@@ -1,0 +1,7 @@
+# @prefecthq/prefab-ui-docs
+
+Shadow DOM preview renderer for [Prefab](https://prefab.prefect.io) documentation.
+
+This package contains the embed build used by Mintlify doc previews. It is published automatically alongside the main `@prefecthq/prefab-ui` package and should not be installed directly.
+
+If you're building with Prefab, see the [main package](https://www.npmjs.com/package/@prefecthq/prefab-ui).

--- a/renderer/playground-package/README.md
+++ b/renderer/playground-package/README.md
@@ -1,0 +1,7 @@
+# @prefecthq/prefab-ui-playground
+
+Interactive playground for [Prefab](https://prefab.prefect.io) — runs Python in the browser via Pyodide.
+
+This package contains the self-contained playground HTML. It is published automatically alongside the main `@prefecthq/prefab-ui` package and should not be installed directly.
+
+If you're building with Prefab, see the [main package](https://www.npmjs.com/package/@prefecthq/prefab-ui).


### PR DESCRIPTION
Adds minimal READMEs to @prefecthq/prefab-ui-docs and @prefecthq/prefab-ui-playground so they don't show blank pages on npmjs.com. Both point users back to the main package.