### PR TITLE
Support f-strings with Rx in .then() and combinators

### DIFF
--- a/skills/prefab-ui/references/reactive.md
+++ b/skills/prefab-ui/references/reactive.md
@@ -31,6 +31,25 @@ quantity > 0                          # {{ quantity > 0 }}
 Pipe methods: `.currency()`, `.percent()`, `.compact()`, `.date()`,
 `.upper()`, `.lower()`, `.truncate(N)`, `.length()`, `.join(sep)`.
 
+### F-strings with Rx
+
+Python f-strings work naturally with Rx. When Python evaluates
+`f"{STATE.cpu}%"`, it calls `str()` on the Rx which produces
+`"{{ cpu }}%"`. Prefab detects these embedded template markers and
+expands them into proper expressions automatically:
+
+```python
+# All equivalent — use whichever reads best:
+Metric(value=STATE.cpu + "%")                     # {{ cpu + '%' }}
+Metric(value=f"{STATE.cpu}%")                     # also {{ cpu + '%' }}
+
+# Works inside .then() too:
+STATE.cpu.then(f"{STATE.cpu}%", "...")             # {{ cpu ? cpu + '%' : '...' }}
+
+# Multiple interpolations:
+Text(f"Hello {STATE.name}, {STATE.count} items")  # {{ 'Hello ' + name + ', ' + count + ' items' }}
+```
+
 ## STATE
 
 For keys defined elsewhere (e.g. by `result_key` on `CallTool`):

--- a/src/prefab_ui/rx/__init__.py
+++ b/src/prefab_ui/rx/__init__.py
@@ -127,6 +127,10 @@ def _format_scalar(value: object) -> str:
     """Format a non-Rx Python value as an expression token.
 
     Strings → single-quoted, numbers → bare, bools → true/false, None → null.
+
+    Strings containing ``{{ expr }}`` templates (e.g. from f-strings like
+    ``f"{STATE.x}%"``) are expanded into concatenation expressions so
+    ``"{{ stats.cpu }}%"`` becomes ``stats.cpu + '%'``.
     """
     if isinstance(value, bool):
         return "true" if value else "false"
@@ -135,8 +139,37 @@ def _format_scalar(value: object) -> str:
     if value is None:
         return "null"
     if isinstance(value, str):
+        if "{{" in value:
+            return _expand_template_string(value)
         return f"'{value}'"
     return str(value)
+
+
+def _expand_template_string(s: str) -> str:
+    """Convert a string with ``{{ }}`` markers into a concatenation expression.
+
+    ``"{{ x }}%"`` → ``x + '%'``
+    ``"Hello {{ name }}, you have {{ count }} items"``
+    → ``'Hello ' + name + ', you have ' + count + ' items'``
+    """
+    import re
+
+    parts: list[str] = []
+    last_end = 0
+    for m in re.finditer(r"\{\{\s*(.*?)\s*\}\}", s):
+        # Text before this template
+        before = s[last_end : m.start()]
+        if before:
+            parts.append(f"'{before}'")
+        # The expression inside {{ }}
+        parts.append(m.group(1))
+        last_end = m.end()
+    # Text after the last template
+    after = s[last_end:]
+    if after:
+        parts.append(f"'{after}'")
+
+    return " + ".join(parts) if parts else "''"
 
 
 def _resolve_operand(value: object, min_prec: int, *, strict: bool = False) -> str:
@@ -423,7 +456,7 @@ class Rx:
     # ── Ternary ──────────────────────────────────────────────────────
 
     def then(self, if_true: object, if_false: object) -> Rx:
-        """Ternary conditional: `condition ? if_true : if_false`."""
+        """Ternary conditional: ``condition ? if_true : if_false``."""
         return Rx(_Ternary(self, if_true, if_false), _PREC_TERNARY)
 
     # ── Pipes ────────────────────────────────────────────────────────


### PR DESCRIPTION
When you write `f"{STATE.cpu}%"`, Python calls `str()` on the Rx object, producing `"{{ cpu }}%"` — a plain string with embedded template markers. Previously, passing this to `.then()` or other Rx combinators would produce nested `{{ }}` templates that the renderer couldn't evaluate.

Now `_format_scalar` detects embedded template markers and expands them into concatenation expressions:

```python
# These are now equivalent:
STATE.cpu + "%"                          # {{ cpu + '%' }}
f"{STATE.cpu}%"                          # {{ cpu + '%' }}

# Works inside .then():
STATE.cpu.then(f"{STATE.cpu}%", "...")   # {{ cpu ? cpu + '%' : '...' }}
```