### PR TITLE
Update actions/setup-node to v6

### DIFF
--- a/.github/workflows/publish-renderer.yml
+++ b/.github/workflows/publish-renderer.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "24"
           cache: "npm"

--- a/.github/workflows/run-renderer-tests.yml
+++ b/.github/workflows/run-renderer-tests.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "22"
           cache: "npm"


### PR DESCRIPTION
Fixes Node.js 20 deprecation warning on GitHub Actions.