### PR TITLE
Move Carousel to Layout section, add to agent skill

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -116,6 +116,7 @@
                 "group": "Layout",
                 "expanded": false,
                 "pages": [
+                  "components/carousel",
                   "components/column",
                   "components/conditional",
                   "components/container",
@@ -140,7 +141,6 @@
                   "components/button",
                   "components/button-group",
                   "components/card",
-                  "components/carousel",
                   "components/code",
                   "components/data-table",
                   "components/dialog",

--- a/skills/prefab-ui/SKILL.md
+++ b/skills/prefab-ui/SKILL.md
@@ -202,6 +202,48 @@ Grid(columns=3, gap=4)               # grid-cols-3 gap-4
 
 Use `css_class` for anything beyond these: `Column(css_class="max-w-2xl mx-auto")`.
 
+### Carousel
+
+Carousel cycles through children. Each direct child becomes one slide.
+Three modes through configuration:
+
+```python
+# Interactive carousel — arrows, dots, swipe
+with Carousel(show_dots=True):
+    Card(...)
+    Card(...)
+
+# Peek — show partial adjacent slides (1.3 = 1 full + 30% of next)
+with Carousel(visible=1.3, align="center", dim_inactive=True):
+    Card(...)
+
+# Multiple visible slides
+with Carousel(visible=3, gap=16):
+    Card(...)
+
+# Auto-advancing reel
+with Carousel(auto_advance=3000, show_controls=False):
+    Card(...)
+
+# Vertical reel
+with Carousel(direction="down", auto_advance=2000, show_controls=False):
+    Div(style={"height": "160px"})
+
+# Marquee — continuous smooth scroll
+with Carousel(continuous=True, speed=3, show_controls=False):
+    Badge("A")
+    Badge("B")
+
+# Fade transition
+with Carousel(effect="fade", auto_advance=2000, show_controls=False):
+    Card(...)
+```
+
+Key props: `visible` (int/float/None), `gap`, `direction` (left/right/up/down),
+`auto_advance` (ms), `continuous`, `speed` (1-10), `effect` (slide/fade),
+`dim_inactive`, `show_controls`, `controls_position` (overlay/outside),
+`show_dots`, `align` (start/center/end), `loop`.
+
 ## Actions
 
 Actions are Pydantic models. All support `on_success` and `on_error`:


### PR DESCRIPTION
Carousel is a container component — belongs under Layout in the docs nav, not Components. Also adds Carousel patterns to the prefab-ui agent skill so LLMs know how to use it.