### PR TITLE
Add GA4 analytics to docs

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -387,6 +387,11 @@
       }
     ]
   },
+  "integrations": {
+    "ga4": {
+      "measurementId": "G-VV148KLN95"
+    }
+  },
   "search": {
     "prompt": "Search the docs..."
   },


### PR DESCRIPTION
Wires up Google Analytics 4 (measurement ID `G-VV148KLN95`) to the Mintlify docs site via the `integrations.ga4` config key.