### PR TITLE
Stop fighting app.html merge conflicts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+# Treat the bundled renderer as a build artifact. Line-by-line merging
+# of a minified, chunked bundle produces nonsense conflicts on every
+# branch, so let git resolve the file to the upstream/base version and
+# rely on the `check_generated` CI workflow to regenerate it from source
+# if needed.
+#
+# Each clone needs `git config merge.ours.driver true` once — see
+# CONTRIBUTING.md.
+src/prefab_ui/renderer/app.html merge=ours

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,6 +22,13 @@ repos:
 
   - repo: local
     hooks:
+      - id: install-ours-merge-driver
+        name: install app.html merge driver
+        entry: git config merge.ours.driver true
+        language: system
+        pass_filenames: false
+        always_run: true
+
       - id: ty
         name: ty check
         entry: uv run --isolated ty check

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,18 @@ An open issue is not an invitation to submit a PR. Issues track problems; whethe
 - **Write tests.** Bug fixes should include a test that fails without the fix.
 - **Fix the cause, not the symptom.**
 
+## One-time clone setup
+
+The bundled renderer (`src/prefab_ui/renderer/app.html`) is a minified, chunked Vite build. Its line-level contents aren't stable between builds, so trying to merge two branches' versions of it produces nonsense conflicts. We mark it in `.gitattributes` with `merge=ours` so git resolves conflicts by keeping the upstream side, and the `check_generated` CI workflow regenerates it from source as needed.
+
+For that to take effect, run this once per clone:
+
+```bash
+git config merge.ours.driver true
+```
+
+It tells git to treat the `ours` merge driver as a no-op that succeeds — which lets the `.gitattributes` directive do its job.
+
 ## What we'll close without review
 
 - PRs that don't reference an issue or address a clearly self-evident bug

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,17 +36,11 @@ An open issue is not an invitation to submit a PR. Issues track problems; whethe
 - **Write tests.** Bug fixes should include a test that fails without the fix.
 - **Fix the cause, not the symptom.**
 
-## One-time clone setup
+## The `app.html` merge driver
 
-The bundled renderer (`src/prefab_ui/renderer/app.html`) is a minified, chunked Vite build. Its line-level contents aren't stable between builds, so trying to merge two branches' versions of it produces nonsense conflicts. We mark it in `.gitattributes` with `merge=ours` so git resolves conflicts by keeping the upstream side, and the `check_generated` CI workflow regenerates it from source as needed.
+The bundled renderer (`src/prefab_ui/renderer/app.html`) is a minified, chunked Vite build. Its line contents aren't stable between builds, so trying to merge two branches' versions of it produces nonsense conflicts. We mark it in `.gitattributes` with `merge=ours` so git resolves conflicts by keeping the upstream side, and the `check_generated` CI workflow regenerates it from source afterwards if the final tree actually warrants a different bundle.
 
-For that to take effect, run this once per clone:
-
-```bash
-git config merge.ours.driver true
-```
-
-It tells git to treat the `ours` merge driver as a no-op that succeeds — which lets the `.gitattributes` directive do its job.
+The `ours` driver needs one piece of local git config (`merge.ours.driver = true`). That gets installed automatically by a prek hook on your first commit, so there is nothing to run by hand.
 
 ## What we'll close without review
 


### PR DESCRIPTION
Every PR that sits on a branch long enough eventually conflicts with main on `src/prefab_ui/renderer/app.html`. The file is a minified, chunked Vite bundle — its variable names and chunk suffixes shuffle between runs even when the source doesn't change, so the `check_generated` workflow auto-commits drift on every PR. When main moves forward with its own auto-regen, the two thousand-line rewrites collide and git's text merger spits out a useless conflict.

Mark the file in `.gitattributes` with `merge=ours`. During a rebase or merge, git resolves `app.html` to the upstream side instead of trying to line-merge two versions of minified output, and the existing `check_generated` CI workflow regenerates from source afterwards if the final tree actually warrants a different bundle. The real merged content is a pure function of the source — taking either side locally and letting CI rebuild is always correct.

The `ours` driver needs one piece of local git config (`merge.ours.driver = true`); a new prek local hook installs it automatically on the first commit after clone, so there is nothing to run by hand. Verified locally with a real line-level conflict inside the bundle script block — the rebase completes cleanly and the working tree ends up on main's side.