### PR TITLE
fix(skills): package skills in build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,12 @@ source = "uv-dynamic-versioning"
 [tool.hatch.build.targets.wheel]
 packages = ["src/prefab_ui"]
 
+[tool.hatch.build.targets.sdist.force-include]
+"skills" = "src/prefab_ui/skills"
+
+[tool.hatch.build.targets.wheel.force-include]
+"skills" = "src/prefab_ui/skills"
+
 [tool.uv-dynamic-versioning]
 vcs = "git"
 style = "pep440"

--- a/src/prefab_ui/generative.py
+++ b/src/prefab_ui/generative.py
@@ -43,7 +43,10 @@ from prefab_ui.components.base import Component, ContainerComponent, StatefulMix
 RESOURCE_URI = "ui://prefab/generative.html"
 MIME_TYPE = "text/html;profile=mcp-app"
 
-_SKILLS_DIR = Path(__file__).parent.parent.parent / "skills"
+_SKILLS_DIR = Path(__file__).parent / "skills"
+if not _SKILLS_DIR.is_dir():
+    _SKILLS_DIR = Path(__file__).parent.parent.parent / "skills"
+
 
 __all__ = [
     "MIME_TYPE",


### PR DESCRIPTION
Right now, when you build a wheel/sdist, the skills directory is not
included in the resulting build, making generative.py fail (along with
tests run on the build). This commit adds Hatch instructions to
include the static files in the skills directory in builds and updates
the Python code in generative.py to point at the synthetic location in
the package.

This issue surfaced in NixOS/nixpkgs while trying to package the project
and finding that without adding Hatch instructions, builds and tests
would fail: https://github.com/NixOS/nixpkgs/pull/510123.

Signed-off-by: squat <lserven@gmail.com>
