### PR TITLE
fix(renderer): right-align sortable column headers

### DIFF
--- a/renderer/src/components/data-display.tsx
+++ b/renderer/src/components/data-display.tsx
@@ -11,6 +11,7 @@ import { interpolateString } from "../interpolation";
 import {
   globalFilter as dataTableGlobalFilter,
   nextSortAction,
+  sortableHeaderClass,
   toggleRowSelection,
 } from "./data-table-logic";
 import {
@@ -131,7 +132,7 @@ export function PrefabDataTable({
           if (spec.sortable) {
             return (
               <button
-                className="flex items-center gap-1 hover:text-foreground"
+                className={sortableHeaderClass(spec.headerClass)}
                 onClick={() => {
                   const action = nextSortAction(column.getIsSorted());
                   if (action === "clear") {

--- a/renderer/src/components/data-table-logic.test.ts
+++ b/renderer/src/components/data-table-logic.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   globalFilter,
   nextSortAction,
+  sortableHeaderClass,
   toggleRowSelection,
 } from "./data-table-logic";
 
@@ -69,5 +70,64 @@ describe("toggleRowSelection", () => {
     const result = toggleRowSelection("row-1", "row-1");
     expect(result.selectedId).toBeNull();
     expect(result.shouldFireAction).toBe(false);
+  });
+});
+
+describe("sortableHeaderClass", () => {
+  const base = "flex items-center gap-1 hover:text-foreground";
+
+  it("leaves the header unchanged with no alignment class", () => {
+    expect(sortableHeaderClass(undefined)).toBe(base);
+    expect(sortableHeaderClass("")).toBe(base);
+    expect(sortableHeaderClass("font-bold")).toBe(base);
+  });
+
+  it("fills the cell and right-justifies for text-right", () => {
+    expect(sortableHeaderClass("text-right")).toBe(
+      `${base} w-full justify-end`,
+    );
+  });
+
+  it("fills the cell and center-justifies for text-center", () => {
+    expect(sortableHeaderClass("text-center")).toBe(
+      `${base} w-full justify-center`,
+    );
+  });
+
+  it("left-justifies for an explicit text-left", () => {
+    expect(sortableHeaderClass("text-left")).toBe(
+      `${base} w-full justify-start`,
+    );
+  });
+
+  it("finds the alignment token among other classes", () => {
+    expect(sortableHeaderClass("font-bold text-right uppercase")).toBe(
+      `${base} w-full justify-end`,
+    );
+  });
+
+  it("matches whole tokens only — not substrings", () => {
+    // "text-right-ish" is not a real utility; it must not trigger.
+    expect(sortableHeaderClass("text-right-ish")).toBe(base);
+    // "text-rightmost" likewise.
+    expect(sortableHeaderClass("group-text-right")).toBe(base);
+  });
+
+  it("preserves a breakpoint prefix so alignment stays responsive", () => {
+    expect(sortableHeaderClass("sm:text-right")).toBe(
+      `${base} sm:w-full sm:justify-end`,
+    );
+  });
+
+  it("preserves a multi-variant prefix chain", () => {
+    expect(sortableHeaderClass("lg:dark:text-center")).toBe(
+      `${base} lg:dark:w-full lg:dark:justify-center`,
+    );
+  });
+
+  it("handles a bare token plus a prefixed token together", () => {
+    expect(sortableHeaderClass("text-left md:text-right")).toBe(
+      `${base} w-full justify-start md:w-full md:justify-end`,
+    );
   });
 });

--- a/renderer/src/components/data-table-logic.ts
+++ b/renderer/src/components/data-table-logic.ts
@@ -30,6 +30,53 @@ export function nextSortAction(
   return "clear";
 }
 
+/** Maps a text-alignment utility to the matching flex justification. */
+const ALIGN_TO_JUSTIFY: Record<string, string> = {
+  "text-right": "justify-end",
+  "text-center": "justify-center",
+  "text-left": "justify-start",
+};
+
+/**
+ * Class string for a sortable column header's clickable button.
+ *
+ * A sortable header is a `flex` button (label + sort icon) nested
+ * inside the `<th>`. A bare flex button shrinks to its content and
+ * sits at the start of the cell, so `text-right`/`text-center` on the
+ * `<th>` (set by a column's `align`) has nothing to act on — the
+ * header label stays left while the column's values are aligned
+ * elsewhere.
+ *
+ * When the column's `headerClass` carries a text-alignment utility,
+ * the button is made `w-full` and its flex content justified to
+ * match, so the header label tracks the column's `align` setting.
+ *
+ * `headerClass` is free-form, user-supplied Tailwind, so this matches
+ * **exact, whole tokens** and **preserves any variant prefix**:
+ * `sm:text-right` yields `sm:w-full sm:justify-end`, keeping the
+ * alignment responsive instead of forcing it at every breakpoint.
+ * A bare `text-*` token contributes the unprefixed pair.
+ */
+export function sortableHeaderClass(headerClass?: string): string {
+  const base = "flex items-center gap-1 hover:text-foreground";
+  if (!headerClass) return base;
+
+  const extra: string[] = [];
+  for (const token of headerClass.split(/\s+/)) {
+    if (!token) continue;
+    // Split a variant chain (e.g. "sm:dark:") from its final utility.
+    const lastColon = token.lastIndexOf(":");
+    const prefix = lastColon === -1 ? "" : token.slice(0, lastColon + 1);
+    const utility = lastColon === -1 ? token : token.slice(lastColon + 1);
+    const justify = ALIGN_TO_JUSTIFY[utility];
+    if (justify) {
+      extra.push(`${prefix}w-full`, `${prefix}${justify}`);
+    }
+  }
+
+  return extra.length > 0 ? `${base} ${extra.join(" ")}` : base;
+}
+
 /**
  * Compute next row selection state on click.
  * Returns the new selected row ID (null to deselect).


### PR DESCRIPTION
## Summary

Fixes #445 — `DataTableColumn(align="right")` (and `align="center"`) right-aligns a column's **cell values** but leaves the **header label** left-anchored on `sortable=True` columns.

## Root cause

`align` resolves to `text-right`/`text-center`, merged into `headerClass` and applied to the `<th>`. For a non-sortable column the header is plain text, so `text-align` works. For a sortable column the header is a `flex` button (`flex items-center gap-1 …`) sized to its content — it sits at the start of the cell, so `text-align` on the `<th>` has nothing to act on.

## Fix

New pure helper `sortableHeaderClass(headerClass?)` in `data-table-logic.ts`: for each text-align utility in the column's `headerClass`, it appends `w-full` + the matching `justify-*` to the sortable header button so the label tracks the column's `align`.

`headerClass` is free-form, user-supplied Tailwind, so the helper:
- matches **whole class tokens**, not substrings (`text-right-ish` does not trigger);
- **preserves any variant prefix** — `sm:text-right` yields `sm:w-full sm:justify-end`, keeping responsive alignment responsive instead of forcing it at every breakpoint.

No protocol/API change — every existing caller using `align` is fixed automatically.

## Tests

`data-table-logic.test.ts`: 12 cases covering plain alignment, exact-token matching, substring traps, single- and multi-variant prefixes, and mixed tokens. Verified the alignment cases fail without the fix. Full renderer suite: 604 passing. `tsc -b` clean, prettier clean.

## Browser verification

Rendered `PrefabDataTable` in a real Chromium DOM via the renderer dev server:
- `align="right"` column → header button is `w-full justify-end`, `justify-content: flex-end`, button fills the `<th>`; label sits directly over the right-aligned values.
- `sm:text-right` column → button gets `sm:w-full sm:justify-end`; `justify-content` is `normal` at 400px (below `sm`) and `flex-end` at 1200px — responsive behavior preserved.
