### PR TITLE
Add dependency cooldowns

### DIFF
--- a/.github/scripts/check-npm-package-age.mjs
+++ b/.github/scripts/check-npm-package-age.mjs
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+
+import fs from "node:fs/promises";
+
+const args = new Map();
+for (let i = 2; i < process.argv.length; i += 2) {
+  args.set(process.argv[i], process.argv[i + 1]);
+}
+
+const lockfilePath = args.get("--lockfile");
+const baseLockfilePath = args.get("--base-lockfile");
+const daysArg = args.get("--days") ?? "7";
+
+if (!lockfilePath) {
+  console.error("Usage: check-npm-package-age.mjs --lockfile <path> [--days 7]");
+  process.exit(2);
+}
+
+const days = Number(daysArg);
+if (!Number.isFinite(days) || days <= 0) {
+  console.error(`Invalid --days value: ${daysArg}`);
+  process.exit(2);
+}
+
+const cutoff = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+function packageNameFromPath(path) {
+  const marker = "node_modules/";
+  const index = path.lastIndexOf(marker);
+  if (index === -1) {
+    return null;
+  }
+
+  const parts = path.slice(index + marker.length).split("/");
+  if (parts[0]?.startsWith("@")) {
+    return `${parts[0]}/${parts[1]}`;
+  }
+  return parts[0];
+}
+
+async function readRegistryPackages(path) {
+  const lockfile = JSON.parse(await fs.readFile(path, "utf8"));
+  const packages = lockfile.packages ?? {};
+  const registryPackages = new Map();
+
+  for (const [packagePath, details] of Object.entries(packages)) {
+    if (!details?.version || !details?.resolved?.startsWith("https://registry.npmjs.org/")) {
+      continue;
+    }
+
+    const name = packageNameFromPath(packagePath);
+    if (!name) {
+      continue;
+    }
+
+    registryPackages.set(`${name}@${details.version}`, {
+      name,
+      version: details.version,
+    });
+  }
+
+  return registryPackages;
+}
+
+const lockedPackages = await readRegistryPackages(lockfilePath);
+const basePackages = baseLockfilePath
+  ? await readRegistryPackages(baseLockfilePath)
+  : new Map();
+const packagesToCheck = new Map(
+  [...lockedPackages].filter(([key]) => !basePackages.has(key)),
+);
+
+const metadataCache = new Map();
+
+async function fetchPackageMetadata(name) {
+  if (metadataCache.has(name)) {
+    return metadataCache.get(name);
+  }
+
+  const response = await fetch(`https://registry.npmjs.org/${encodeURIComponent(name)}`);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch ${name}: ${response.status} ${response.statusText}`);
+  }
+
+  const metadata = await response.json();
+  metadataCache.set(name, metadata);
+  return metadata;
+}
+
+const tooNew = [];
+const missingTimes = [];
+
+for (const { name, version } of packagesToCheck.values()) {
+  const metadata = await fetchPackageMetadata(name);
+  const publishedAt = metadata.time?.[version];
+
+  if (!publishedAt) {
+    missingTimes.push(`${name}@${version}`);
+    continue;
+  }
+
+  const publishedDate = new Date(publishedAt);
+  if (publishedDate > cutoff) {
+    tooNew.push({
+      package: `${name}@${version}`,
+      publishedAt,
+    });
+  }
+}
+
+if (missingTimes.length > 0 || tooNew.length > 0) {
+  if (tooNew.length > 0) {
+    console.error(`Found ${tooNew.length} npm packages published within the last ${days} days:`);
+    for (const entry of tooNew.slice(0, 25)) {
+      console.error(`- ${entry.package} published at ${entry.publishedAt}`);
+    }
+    if (tooNew.length > 25) {
+      console.error(`... and ${tooNew.length - 25} more`);
+    }
+  }
+
+  if (missingTimes.length > 0) {
+    console.error("Missing npm publish times for:");
+    for (const name of missingTimes.slice(0, 25)) {
+      console.error(`- ${name}`);
+    }
+    if (missingTimes.length > 25) {
+      console.error(`... and ${missingTimes.length - 25} more`);
+    }
+  }
+
+  process.exit(1);
+}
+
+console.log(
+  `All ${packagesToCheck.size} npm registry packages were published before ${cutoff.toISOString()}.`,
+);

--- a/.github/scripts/check-npm-package-age.mjs
+++ b/.github/scripts/check-npm-package-age.mjs
@@ -12,7 +12,9 @@ const baseLockfilePath = args.get("--base-lockfile");
 const daysArg = args.get("--days") ?? "7";
 
 if (!lockfilePath) {
-  console.error("Usage: check-npm-package-age.mjs --lockfile <path> [--days 7]");
+  console.error(
+    "Usage: check-npm-package-age.mjs --lockfile <path> [--days 7]",
+  );
   process.exit(2);
 }
 
@@ -43,7 +45,10 @@ async function readRegistryPackages(path) {
   const registryPackages = new Map();
 
   for (const [packagePath, details] of Object.entries(packages)) {
-    if (!details?.version || !details?.resolved?.startsWith("https://registry.npmjs.org/")) {
+    if (
+      !details?.version ||
+      !details?.resolved?.startsWith("https://registry.npmjs.org/")
+    ) {
       continue;
     }
 
@@ -76,9 +81,13 @@ async function fetchPackageMetadata(name) {
     return metadataCache.get(name);
   }
 
-  const response = await fetch(`https://registry.npmjs.org/${encodeURIComponent(name)}`);
+  const response = await fetch(
+    `https://registry.npmjs.org/${encodeURIComponent(name)}`,
+  );
   if (!response.ok) {
-    throw new Error(`Failed to fetch ${name}: ${response.status} ${response.statusText}`);
+    throw new Error(
+      `Failed to fetch ${name}: ${response.status} ${response.statusText}`,
+    );
   }
 
   const metadata = await response.json();
@@ -109,7 +118,9 @@ for (const { name, version } of packagesToCheck.values()) {
 
 if (missingTimes.length > 0 || tooNew.length > 0) {
   if (tooNew.length > 0) {
-    console.error(`Found ${tooNew.length} npm packages published within the last ${days} days:`);
+    console.error(
+      `Found ${tooNew.length} npm packages published within the last ${days} days:`,
+    );
     for (const entry of tooNew.slice(0, 25)) {
       console.error(`- ${entry.package} published at ${entry.publishedAt}`);
     }
@@ -132,5 +143,7 @@ if (missingTimes.length > 0 || tooNew.length > 0) {
 }
 
 console.log(
-  `All ${packagesToCheck.size} npm registry packages were published before ${cutoff.toISOString()}.`,
+  `All ${
+    packagesToCheck.size
+  } npm registry packages were published before ${cutoff.toISOString()}.`,
 );

--- a/.github/workflows/publish-renderer.yml
+++ b/.github/workflows/publish-renderer.yml
@@ -45,8 +45,11 @@ jobs:
           cd docs-package && npm version "$VERSION" --no-git-tag-version
           cd ../playground-package && npm version "$VERSION" --no-git-tag-version
 
-      - run: npm ci
+      - name: Install renderer dependencies
         working-directory: renderer
+        run: |
+          CUTOFF=$(date -u -d "7 days ago" "+%Y-%m-%dT%H:%M:%SZ")
+          npm ci --before "$CUTOFF"
 
       - run: npm run build:publish
         working-directory: renderer

--- a/.github/workflows/publish-renderer.yml
+++ b/.github/workflows/publish-renderer.yml
@@ -48,8 +48,8 @@ jobs:
       - name: Install renderer dependencies
         working-directory: renderer
         run: |
-          CUTOFF=$(date -u -d "7 days ago" "+%Y-%m-%dT%H:%M:%SZ")
-          npm ci --before "$CUTOFF"
+          node ../.github/scripts/check-npm-package-age.mjs --lockfile package-lock.json --days 7
+          npm ci
 
       - run: npm run build:publish
         working-directory: renderer

--- a/.github/workflows/regenerate-docs.yml
+++ b/.github/workflows/regenerate-docs.yml
@@ -25,7 +25,9 @@ jobs:
           resolution: locked
 
       - name: Install renderer dependencies
-        run: cd renderer && npm ci
+        run: |
+          CUTOFF=$(date -u -d "7 days ago" "+%Y-%m-%dT%H:%M:%SZ")
+          cd renderer && npm ci --before "$CUTOFF"
 
       - name: Build docs
         run: uv run prefab dev build-docs

--- a/.github/workflows/regenerate-docs.yml
+++ b/.github/workflows/regenerate-docs.yml
@@ -26,8 +26,10 @@ jobs:
 
       - name: Install renderer dependencies
         run: |
-          CUTOFF=$(date -u -d "7 days ago" "+%Y-%m-%dT%H:%M:%SZ")
-          cd renderer && npm ci --before "$CUTOFF"
+          git fetch origin "${{ github.base_ref || github.ref_name }}" --depth=1
+          git show "origin/${{ github.base_ref || github.ref_name }}:renderer/package-lock.json" > /tmp/base-package-lock.json
+          node .github/scripts/check-npm-package-age.mjs --lockfile renderer/package-lock.json --base-lockfile /tmp/base-package-lock.json --days 7
+          cd renderer && npm ci
 
       - name: Build docs
         run: uv run prefab dev build-docs

--- a/.github/workflows/run-renderer-tests.yml
+++ b/.github/workflows/run-renderer-tests.yml
@@ -38,7 +38,9 @@ jobs:
 
       - name: Install renderer dependencies
         run: |
-          CUTOFF=$(date -u -d "7 days ago" "+%Y-%m-%dT%H:%M:%SZ")
-          npm ci --before "$CUTOFF"
+          git fetch origin "${{ github.base_ref || github.ref_name }}" --depth=1
+          git show "origin/${{ github.base_ref || github.ref_name }}:renderer/package-lock.json" > /tmp/base-package-lock.json
+          node ../.github/scripts/check-npm-package-age.mjs --lockfile package-lock.json --base-lockfile /tmp/base-package-lock.json --days 7
+          npm ci
 
       - run: npm test

--- a/.github/workflows/run-renderer-tests.yml
+++ b/.github/workflows/run-renderer-tests.yml
@@ -36,5 +36,9 @@ jobs:
           cache: "npm"
           cache-dependency-path: renderer/package-lock.json
 
-      - run: npm ci
+      - name: Install renderer dependencies
+        run: |
+          CUTOFF=$(date -u -d "7 days ago" "+%Y-%m-%dT%H:%M:%SZ")
+          npm ci --before "$CUTOFF"
+
       - run: npm test

--- a/.github/workflows/run-static.yml
+++ b/.github/workflows/run-static.yml
@@ -34,7 +34,9 @@ jobs:
           resolution: locked
 
       - name: Install renderer dependencies
-        run: cd renderer && npm ci
+        run: |
+          CUTOFF=$(date -u -d "7 days ago" "+%Y-%m-%dT%H:%M:%SZ")
+          cd renderer && npm ci --before "$CUTOFF"
 
       - name: Run prek
         uses: j178/prek-action@v1

--- a/.github/workflows/run-static.yml
+++ b/.github/workflows/run-static.yml
@@ -35,8 +35,10 @@ jobs:
 
       - name: Install renderer dependencies
         run: |
-          CUTOFF=$(date -u -d "7 days ago" "+%Y-%m-%dT%H:%M:%SZ")
-          cd renderer && npm ci --before "$CUTOFF"
+          git fetch origin "${{ github.base_ref || github.ref_name }}" --depth=1
+          git show "origin/${{ github.base_ref || github.ref_name }}:renderer/package-lock.json" > /tmp/base-package-lock.json
+          node .github/scripts/check-npm-package-age.mjs --lockfile renderer/package-lock.json --base-lockfile /tmp/base-package-lock.json --days 7
+          cd renderer && npm ci
 
       - name: Run prek
         uses: j178/prek-action@v1

--- a/.github/workflows/run-upgrade-checks.yml
+++ b/.github/workflows/run-upgrade-checks.yml
@@ -38,7 +38,9 @@ jobs:
           resolution: upgrade
 
       - name: Install renderer dependencies
-        run: cd renderer && npm ci
+        run: |
+          CUTOFF=$(date -u -d "7 days ago" "+%Y-%m-%dT%H:%M:%SZ")
+          cd renderer && npm ci --before "$CUTOFF"
 
       - name: Run prek
         uses: j178/prek-action@v1

--- a/.github/workflows/run-upgrade-checks.yml
+++ b/.github/workflows/run-upgrade-checks.yml
@@ -39,8 +39,10 @@ jobs:
 
       - name: Install renderer dependencies
         run: |
-          CUTOFF=$(date -u -d "7 days ago" "+%Y-%m-%dT%H:%M:%SZ")
-          cd renderer && npm ci --before "$CUTOFF"
+          git fetch origin "${{ github.base_ref || github.ref_name }}" --depth=1
+          git show "origin/${{ github.base_ref || github.ref_name }}:renderer/package-lock.json" > /tmp/base-package-lock.json
+          node .github/scripts/check-npm-package-age.mjs --lockfile renderer/package-lock.json --base-lockfile /tmp/base-package-lock.json --days 7
+          cd renderer && npm ci
 
       - name: Run prek
         uses: j178/prek-action@v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,9 @@ style = "pep440"
 bump = true
 fallback-version = "0.0.0"
 
+[tool.uv]
+exclude-newer = "1 week"
+
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"

--- a/renderer/.npmrc
+++ b/renderer/.npmrc
@@ -1,1 +1,0 @@
-min-release-age=7

--- a/renderer/.npmrc
+++ b/renderer/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=7

--- a/uv.lock
+++ b/uv.lock
@@ -11,6 +11,10 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 
+[options]
+exclude-newer = "2026-05-15T22:57:22.16665Z"
+exclude-newer-span = "P1W"
+
 [[package]]
 name = "annotated-doc"
 version = "0.0.4"


### PR DESCRIPTION
Fresh registry uploads are the highest-risk window for dependency confusion and compromised package releases. Prefab already publishes through release automation, but local and CI dependency resolution should also give the ecosystem a little time to detect bad artifacts before they enter our lockfiles and CI installs.

This adds a one-week cooldown to uv resolution for Python dependencies and applies the npm equivalent in renderer CI installs with a rolling `--before` cutoff. Using `--before` keeps the npm side compatible with older npm 11 releases while still enforcing a seven-day registry window in the workflows that install renderer packages.

```toml
[tool.uv]
exclude-newer = "1 week"
```

```ini
npm ci --before "$CUTOFF"
```
