### PR TITLE
Downgrade recent renderer dependencies

### DIFF
--- a/renderer/package-lock.json
+++ b/renderer/package-lock.json
@@ -4236,9 +4236,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.21",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.21.tgz",
-      "integrity": "sha512-uV63apnb0kyPtAUwoWgaGh9HyIFcv8lgmzPZSiTBQAFOFGIzka5EZ1dZocmGnn0XdX0+XTqJ6Tqv7selMuGLRQ==",
+      "version": "4.12.14",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
+      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -6105,9 +6105,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
-      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
       "license": "BSD-3-Clause",
       "peer": true,
       "dependencies": {


### PR DESCRIPTION
The npm release workflow now checks the full renderer lockfile against the 7-day package-age policy. The v0.20.0 release published Python and docs successfully, but npm trusted publishing stopped before build because two recently merged transitive dependency bumps were still inside that window.

This rolls those transitive lockfile resolutions back to versions that satisfy the release gate while keeping the existing package ranges intact. That lets v0.20.1 publish through the normal GitHub Actions trusted publishing path instead of bypassing npm provenance.

```diff
- hono@4.12.21
+ hono@4.12.14

- qs@6.15.2
+ qs@6.14.2
```
