### PR TITLE
Allow LineChart series to be a reactive template

### DIFF
--- a/renderer/src/components/charts.tsx
+++ b/renderer/src/components/charts.tsx
@@ -205,6 +205,7 @@ export function PrefabLineChart({
   className,
 }: LineChartWire & { className?: string }) {
   if (typeof data === "string") return null;
+  if (typeof series === "string" || !Array.isArray(series)) return null;
   const config = buildConfig(series);
   const valueFormatter = getValueFormatter(valueFormat);
 

--- a/renderer/src/schemas/chart.ts
+++ b/renderer/src/schemas/chart.ts
@@ -33,6 +33,7 @@ export const barChartSchema = cartesianBase.extend({
 
 export const lineChartSchema = cartesianBase.extend({
   type: z.literal("LineChart"),
+  series: z.union([z.array(chartSeriesSchema), z.string()]),
   curve: z.enum(["linear", "smooth", "step"]).optional(),
   showDots: z.boolean().optional(),
 });

--- a/src/prefab_ui/components/charts/__init__.py
+++ b/src/prefab_ui/components/charts/__init__.py
@@ -141,7 +141,8 @@ class LineChart(Component):
 
     Args:
         data: Row data or reactive interpolation reference.
-        series: Series to render as lines.
+        series: Series to render as lines, or a sole ``{{ ... }}`` template
+            (e.g. a visibility-filtered list from state).
         x_axis: Data key for x-axis labels.
         height: Chart height in pixels.
         curve: Line interpolation style ("linear", "smooth", or "step").
@@ -170,7 +171,9 @@ class LineChart(Component):
     data: list[dict[str, Any]] | RxStr = Field(
         description="Row data or `{{ interpolation }}` reference"
     )
-    series: list[ChartSeries] = Field(description="Series to render as lines")
+    series: list[ChartSeries] | RxStr = Field(
+        description="Series to render as lines, or `{{ interpolation }}` for a filtered list"
+    )
     x_axis: str | None = Field(
         default=None, alias="xAxis", description="Data key for x-axis labels"
     )


### PR DESCRIPTION
Accept a `{{ ... }}` template (RxStr) for `LineChart.series`, not just a
static list, so series can be visibility-filtered from state at render
time. Updates the Python model, the Zod `series` schema (array | string),
and guards `PrefabLineChart` against an unresolved/non-array series.

Closes #472 