### PR TITLE
Add pievisible pipe

### DIFF
--- a/renderer/src/components/charts.tsx
+++ b/renderer/src/components/charts.tsx
@@ -205,6 +205,7 @@ export function PrefabLineChart({
   className,
 }: LineChartWire & { className?: string }) {
   if (typeof data === "string") return null;
+  if (typeof series === "string" || !Array.isArray(series)) return null;
   const config = buildConfig(series);
   const valueFormatter = getValueFormatter(valueFormat);
 

--- a/renderer/src/expression-pipes.test.ts
+++ b/renderer/src/expression-pipes.test.ts
@@ -43,6 +43,44 @@ describe("selectattr / rejectattr pipes", () => {
   });
 });
 
+describe("pievisible pipe", () => {
+  it("shows visible slices plus Other for hidden rows", () => {
+    const chart_segments = [
+      { label: "US", value: 100, visible: true, group: "primary" },
+      { label: "MX", value: 20, visible: false, group: "secondary" },
+      { label: "IN", value: 10, visible: false, group: "secondary" },
+    ];
+    expect(evaluate("chart_segments | pievisible", { chart_segments })).toEqual([
+      { label: "US", value: 100 },
+      { label: "Other", value: 30 },
+    ]);
+  });
+
+  it("promotes toggled rows and shrinks Other", () => {
+    const chart_segments = [
+      { label: "US", value: 100, visible: true, group: "primary" },
+      { label: "MX", value: 20, visible: true, group: "secondary" },
+      { label: "IN", value: 10, visible: false, group: "secondary" },
+    ];
+    expect(evaluate("chart_segments | pievisible", { chart_segments })).toEqual([
+      { label: "US", value: 100 },
+      { label: "MX", value: 20 },
+      { label: "Other", value: 10 },
+    ]);
+  });
+
+  it("omits Other when every row is visible", () => {
+    const chart_segments = [
+      { label: "US", value: 100, visible: true, group: "primary" },
+      { label: "MX", value: 20, visible: true, group: "secondary" },
+    ];
+    expect(evaluate("chart_segments | pievisible", { chart_segments })).toEqual([
+      { label: "US", value: 100 },
+      { label: "MX", value: 20 },
+    ]);
+  });
+});
+
 describe("pluralize pipe", () => {
   it("returns singular for count of 1", () => {
     expect(evaluate("count | pluralize:'file'", { count: 1 })).toBe("file");

--- a/renderer/src/expression.ts
+++ b/renderer/src/expression.ts
@@ -180,6 +180,33 @@ const pipes: Record<string, PipeFn> = {
         !!(item as Record<string, unknown>)[key],
     );
   },
+  pievisible(value) {
+    if (!Array.isArray(value)) return value;
+    type PieSegment = {
+      label: string;
+      value: number;
+      visible?: boolean;
+      group?: string;
+    };
+    const segments = (value as PieSegment[]).filter(
+      (s) => s.group === "primary" || s.group === "secondary",
+    );
+    const visible = segments.filter((s) => s.visible);
+    const hidden = segments.filter((s) => !s.visible);
+
+    const slices: Array<{ label: string; value: number }> = visible.map(
+      (s) => ({ label: s.label, value: Number(s.value) }),
+    );
+
+    if (hidden.length > 0) {
+      const otherValue = hidden.reduce((sum, s) => sum + Number(s.value), 0);
+      if (otherValue > 0) {
+        slices.push({ label: "Other", value: otherValue });
+      }
+    }
+
+    return slices;
+  },
 
   rejectattr(value, arg) {
     if (!Array.isArray(value) || !arg) return value;

--- a/renderer/src/schemas/chart.ts
+++ b/renderer/src/schemas/chart.ts
@@ -33,6 +33,7 @@ export const barChartSchema = cartesianBase.extend({
 
 export const lineChartSchema = cartesianBase.extend({
   type: z.literal("LineChart"),
+  series: z.union([z.array(chartSeriesSchema), z.string()]),
   curve: z.enum(["linear", "smooth", "step"]).optional(),
   showDots: z.boolean().optional(),
 });

--- a/src/prefab_ui/components/charts/__init__.py
+++ b/src/prefab_ui/components/charts/__init__.py
@@ -141,7 +141,8 @@ class LineChart(Component):
 
     Args:
         data: Row data or reactive interpolation reference.
-        series: Series to render as lines.
+        series: Series to render as lines, or a sole ``{{ ... }}`` template
+            (e.g. a visibility-filtered list from state).
         x_axis: Data key for x-axis labels.
         height: Chart height in pixels.
         curve: Line interpolation style ("linear", "smooth", or "step").
@@ -170,7 +171,9 @@ class LineChart(Component):
     data: list[dict[str, Any]] | RxStr = Field(
         description="Row data or `{{ interpolation }}` reference"
     )
-    series: list[ChartSeries] = Field(description="Series to render as lines")
+    series: list[ChartSeries] | RxStr = Field(
+        description="Series to render as lines, or `{{ interpolation }}` for a filtered list"
+    )
     x_axis: str | None = Field(
         default=None, alias="xAxis", description="Data key for x-axis labels"
     )


### PR DESCRIPTION
For charts with lots of data, Pie charts need a computed "Other" slice that shrinks when users toggle individual segments in Options. selectattr:visible cannot aggregate hidden rows, so add a built-in pievisible expression pipe and rebuild the bundled renderer.
Closes #473 