### PR TITLE
Scroll popover

### DIFF
--- a/renderer/src/app.tsx
+++ b/renderer/src/app.tsx
@@ -15,6 +15,7 @@
 import { useState, useCallback, useRef, useEffect } from "react";
 import { Toaster } from "sonner";
 import type { McpUiHostContext } from "@modelcontextprotocol/ext-apps";
+import { PortalContainerProvider } from "./portal-container";
 import { RenderTree, type ComponentNode } from "./renderer";
 import { useStateStore } from "./state";
 import { bridge } from "./bridge";
@@ -107,6 +108,22 @@ function readInitialData(): {
 
 // Parse baked-in data once before React mounts.
 const INITIAL = readInitialData();
+/** Fixed overlay root so portaled popovers don't inflate iframe scroll height. */
+function McpOverlayPortal({ children }: { children: React.ReactNode }) {
+  const [portal, setPortal] = useState<HTMLElement | undefined>();
+  useEffect(() => {
+    const host = document.createElement("div");
+    host.setAttribute("data-prefab-overlay-portal", "");
+    host.style.cssText =
+      "position:fixed;inset:0;z-index:9998;pointer-events:none;overflow:hidden;";
+    document.body.appendChild(host);
+    setPortal(host);
+    return () => host.remove();
+  }, []);
+  return (
+    <PortalContainerProvider container={portal}>{children}</PortalContainerProvider>
+  );
+}
 
 export function App() {
   const [tree, setTree] = useState<ComponentNode | null>(INITIAL?.view ?? null);
@@ -310,9 +327,9 @@ export function App() {
 
   // Render component tree
   return (
-    <>
+    <McpOverlayPortal>
       <RenderTree tree={tree} defs={defs} state={state} app={appRef.current} />
       <Toaster />
-    </>
+    </McpOverlayPortal>
   );
 }

--- a/renderer/src/components/charts.tsx
+++ b/renderer/src/components/charts.tsx
@@ -205,6 +205,7 @@ export function PrefabLineChart({
   className,
 }: LineChartWire & { className?: string }) {
   if (typeof data === "string") return null;
+  if (typeof series === "string" || !Array.isArray(series)) return null;
   const config = buildConfig(series);
   const valueFormatter = getValueFormatter(valueFormat);
 

--- a/renderer/src/components/compound.tsx
+++ b/renderer/src/components/compound.tsx
@@ -247,15 +247,17 @@ export function PrefabPopover({
       <PopoverTrigger>{trigger}</PopoverTrigger>
       <PopoverContent side={side} className="w-80">
         <OverlayProvider close={() => setOpen(false)}>
-          {title && (
-            <div className="mb-4 space-y-1">
-              <h4 className="font-medium leading-none">{title}</h4>
-              {description && (
-                <p className="text-sm text-muted-foreground">{description}</p>
-              )}
-            </div>
-          )}
-          {content}
+        <div className="flex min-h-0 flex-col gap-2.5">
+            {title && (
+              <div className="space-y-1">
+                <h4 className="font-medium leading-none">{title}</h4>
+                {description && (
+                  <p className="text-sm text-muted-foreground">{description}</p>
+                )}
+              </div>
+            )}
+            <div className="min-h-0 overflow-y-auto">{content}</div>
+          </div>
         </OverlayProvider>
       </PopoverContent>
     </ShadcnPopover>

--- a/renderer/src/schemas/chart.ts
+++ b/renderer/src/schemas/chart.ts
@@ -33,6 +33,7 @@ export const barChartSchema = cartesianBase.extend({
 
 export const lineChartSchema = cartesianBase.extend({
   type: z.literal("LineChart"),
+  series: z.union([z.array(chartSeriesSchema), z.string()]),
   curve: z.enum(["linear", "smooth", "step"]).optional(),
   showDots: z.boolean().optional(),
 });

--- a/renderer/src/style.css
+++ b/renderer/src/style.css
@@ -943,7 +943,7 @@
 
 /* MARK: Popover */
 .pf-popover-content {
-  @apply bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 flex flex-col gap-2.5 rounded-lg p-2.5 text-sm shadow-md ring-1 duration-100;
+  @apply bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 flex max-h-[min(18rem,var(--available-height,18rem))] min-h-0 flex-col gap-2.5 overflow-x-hidden overflow-y-auto rounded-lg p-2.5 text-sm shadow-md ring-1 duration-100;
 }
 
 .pf-popover-content-logical {

--- a/renderer/src/ui/popover.tsx
+++ b/renderer/src/ui/popover.tsx
@@ -31,12 +31,13 @@ function PopoverContent({
         alignOffset={alignOffset}
         side={side}
         sideOffset={sideOffset}
+        positionMethod="fixed"
         className="isolate z-50"
       >
         <PopoverPrimitive.Popup
           data-slot="popover-content"
           className={cn(
-            "pf-popover-content z-50 w-72 origin-(--transform-origin) outline-hidden",
+            "pf-popover-content pointer-events-auto z-50 w-72 max-h-[min(18rem,var(--available-height,18rem))] min-h-0 origin-(--transform-origin) overflow-x-hidden overflow-y-auto outline-hidden",
             className
           )}
           {...props}

--- a/src/prefab_ui/components/charts/__init__.py
+++ b/src/prefab_ui/components/charts/__init__.py
@@ -141,7 +141,8 @@ class LineChart(Component):
 
     Args:
         data: Row data or reactive interpolation reference.
-        series: Series to render as lines.
+        series: Series to render as lines, or a sole ``{{ ... }}`` template
+            (e.g. a visibility-filtered list from state).
         x_axis: Data key for x-axis labels.
         height: Chart height in pixels.
         curve: Line interpolation style ("linear", "smooth", or "step").
@@ -170,7 +171,9 @@ class LineChart(Component):
     data: list[dict[str, Any]] | RxStr = Field(
         description="Row data or `{{ interpolation }}` reference"
     )
-    series: list[ChartSeries] = Field(description="Series to render as lines")
+    series: list[ChartSeries] | RxStr = Field(
+        description="Series to render as lines, or `{{ interpolation }}` for a filtered list"
+    )
     x_axis: str | None = Field(
         default=None, alias="xAxis", description="Data key for x-axis labels"
     )


### PR DESCRIPTION
Prefab MCP Apps often use a `Popover` as a series picker — dozens or hundreds of checkboxes in a narrow iframe. Today, opening that popover does two bad things: portaled content lands in normal document flow and grows the iframe's scroll height, and long lists can't scroll, so items below the fold are unreachable.

This wires the existing `PortalContainerProvider` at the app root into a fixed overlay host (`position:fixed; pointer-events:none`), positions popovers with `positionMethod="fixed"`, and caps popover content at ~18rem with internal scrolling. `PrefabPopover` keeps the title pinned and scrolls only the body.

// app.tsx — portaled overlays no longer affect iframe document height
<McpOverlayPortal>
  <RenderTree ... />
</McpOverlayPortal>
Closes #474 