### PR TITLE
Add axis labels

### DIFF
--- a/renderer/src/components/charts.tsx
+++ b/renderer/src/components/charts.tsx
@@ -47,6 +47,11 @@ import type {
 
 export { PrefabSparkline } from "./sparkline";
 
+const CHART_LEGEND_PROPS = {
+  verticalAlign: "bottom" as const,
+  wrapperStyle: { paddingTop: 20 },
+};
+
 function getValueFormatter(format?: string) {
   if (!format || format === "auto") {
     return undefined;
@@ -84,6 +89,45 @@ function buildConfig(series: SeriesSpec[]): ChartConfig {
   return config;
 }
 
+type AxisTitlePosition = "bottom" | "left";
+
+function axisTitleLabel(
+  text: string | undefined,
+  position: AxisTitlePosition,
+) {
+  if (!text) return {};
+  if (position === "bottom") {
+    return {
+      label: {
+        value: text,
+        position: "bottom" as const,
+        offset: 16,
+      },
+    };
+  }
+  return {
+    label: {
+      value: text,
+      angle: -90,
+      position: "left" as const,
+      offset: 16,
+      style: { textAnchor: "middle" },
+    },
+  };
+}
+
+function chartMargin(
+  xAxisLabel: string | undefined,
+  yAxisLabel: string | undefined,
+) {
+  return {
+    top: 8,
+    right: 8,
+    left: yAxisLabel ? 56 : 8,
+    bottom: xAxisLabel ? 40 : 8,
+  };
+}
+
 function buildPieConfig(
   data: Record<string, unknown>[],
   nameKey: string,
@@ -105,6 +149,8 @@ export function PrefabBarChart({
   data = [],
   series,
   xAxis,
+  xAxisLabel,
+  yAxisLabel,
   height = 300,
   stacked = false,
   horizontal = false,
@@ -120,6 +166,10 @@ export function PrefabBarChart({
   if (typeof data === "string") return null;
   const config = buildConfig(series);
   const valueFormatter = getValueFormatter(valueFormat);
+  const margin = chartMargin(
+    xAxisLabel,
+    showYAxis ? yAxisLabel : undefined,
+  );
 
   return (
     <ChartContainer
@@ -127,7 +177,11 @@ export function PrefabBarChart({
       className={className}
       style={{ height, aspectRatio: "auto" }}
     >
-      <BarChart data={data} layout={horizontal ? "vertical" : "horizontal"}>
+      <BarChart
+        data={data}
+        layout={horizontal ? "vertical" : "horizontal"}
+        margin={margin}
+      >
         {showGrid && (
           <CartesianGrid vertical={horizontal} horizontal={!horizontal} />
         )}
@@ -138,6 +192,7 @@ export function PrefabBarChart({
             tickLine={false}
             axisLine={false}
             tickMargin={8}
+            {...axisTitleLabel(xAxisLabel, "left")}
           />
         )}
         {horizontal && (
@@ -149,6 +204,7 @@ export function PrefabBarChart({
             tickLine={false}
             axisLine={false}
             tickMargin={8}
+            {...axisTitleLabel(xAxisLabel, "bottom")}
           />
         )}
         {!horizontal && showYAxis && (
@@ -157,6 +213,7 @@ export function PrefabBarChart({
             axisLine={false}
             tickMargin={8}
             tickFormatter={valueFormatter}
+            {...axisTitleLabel(yAxisLabel, "left")}
           />
         )}
         {showTooltip && (
@@ -164,7 +221,9 @@ export function PrefabBarChart({
             content={<ChartTooltipContent valueFormatter={valueFormatter} />}
           />
         )}
-        {showLegend && <ChartLegend content={<ChartLegendContent />} />}
+        {showLegend && (
+          <ChartLegend {...CHART_LEGEND_PROPS} content={<ChartLegendContent />} />
+        )}
         {series.map((s) => (
           <Bar
             isAnimationActive={animate}
@@ -193,6 +252,8 @@ export function PrefabLineChart({
   data = [],
   series,
   xAxis,
+  xAxisLabel,
+  yAxisLabel,
   height = 300,
   curve = "linear",
   showDots = false,
@@ -208,6 +269,10 @@ export function PrefabLineChart({
   if (typeof series === "string" || !Array.isArray(series)) return null;
   const config = buildConfig(series);
   const valueFormatter = getValueFormatter(valueFormat);
+  const margin = chartMargin(
+    xAxisLabel,
+    showYAxis ? yAxisLabel : undefined,
+  );
 
   return (
     <ChartContainer
@@ -215,7 +280,7 @@ export function PrefabLineChart({
       className={className}
       style={{ height, aspectRatio: "auto" }}
     >
-      <LineChart data={data}>
+      <LineChart data={data} margin={margin}>
         {showGrid && <CartesianGrid vertical={false} />}
         {xAxis && (
           <XAxis
@@ -223,6 +288,7 @@ export function PrefabLineChart({
             tickLine={false}
             axisLine={false}
             tickMargin={8}
+            {...axisTitleLabel(xAxisLabel, "bottom")}
           />
         )}
         {showYAxis && (
@@ -231,6 +297,7 @@ export function PrefabLineChart({
             axisLine={false}
             tickMargin={8}
             tickFormatter={valueFormatter}
+            {...axisTitleLabel(yAxisLabel, "left")}
           />
         )}
         {showTooltip && (
@@ -238,7 +305,9 @@ export function PrefabLineChart({
             content={<ChartTooltipContent valueFormatter={valueFormatter} />}
           />
         )}
-        {showLegend && <ChartLegend content={<ChartLegendContent />} />}
+        {showLegend && (
+          <ChartLegend {...CHART_LEGEND_PROPS} content={<ChartLegendContent />} />
+        )}
         {series.map((s) => (
           <Line
             isAnimationActive={animate}

--- a/renderer/src/components/charts.tsx
+++ b/renderer/src/components/charts.tsx
@@ -205,6 +205,7 @@ export function PrefabLineChart({
   className,
 }: LineChartWire & { className?: string }) {
   if (typeof data === "string") return null;
+  if (typeof series === "string" || !Array.isArray(series)) return null;
   const config = buildConfig(series);
   const valueFormatter = getValueFormatter(valueFormat);
 

--- a/renderer/src/schemas/chart.ts
+++ b/renderer/src/schemas/chart.ts
@@ -29,6 +29,8 @@ export const barChartSchema = cartesianBase.extend({
   stacked: z.boolean().optional(),
   horizontal: z.boolean().optional(),
   barRadius: z.number().int().optional(),
+  xAxisLabel: z.string().optional(),
+  yAxisLabel: z.string().optional(),
 });
 
 export const lineChartSchema = cartesianBase.extend({
@@ -36,6 +38,8 @@ export const lineChartSchema = cartesianBase.extend({
   series: z.union([z.array(chartSeriesSchema), z.string()]),
   curve: z.enum(["linear", "smooth", "step"]).optional(),
   showDots: z.boolean().optional(),
+  xAxisLabel: z.string().optional(),
+  yAxisLabel: z.string().optional(),
 });
 
 export const areaChartSchema = cartesianBase.extend({

--- a/renderer/src/schemas/chart.ts
+++ b/renderer/src/schemas/chart.ts
@@ -33,6 +33,7 @@ export const barChartSchema = cartesianBase.extend({
 
 export const lineChartSchema = cartesianBase.extend({
   type: z.literal("LineChart"),
+  series: z.union([z.array(chartSeriesSchema), z.string()]),
   curve: z.enum(["linear", "smooth", "step"]).optional(),
   showDots: z.boolean().optional(),
 });

--- a/renderer/src/ui/chart.tsx
+++ b/renderer/src/ui/chart.tsx
@@ -60,7 +60,7 @@ const ChartContainer = React.forwardRef<
         data-chart={chartId}
         ref={ref}
         className={cn(
-          "flex w-full min-w-0 aspect-video justify-center text-xs [&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground [&_.recharts-curve.recharts-tooltip-cursor]:stroke-border [&_.recharts-layer]:outline-none [&_.recharts-radial-bar-background-sector]:fill-muted [&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted [&_.recharts-sector]:outline-none [&_.recharts-surface]:outline-none",
+          "flex w-full min-w-0 aspect-video justify-center text-xs [&_.recharts-cartesian-axis-label_text]:fill-muted-foreground [&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground [&_.recharts-curve.recharts-tooltip-cursor]:stroke-border [&_.recharts-layer]:outline-none [&_.recharts-radial-bar-background-sector]:fill-muted [&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted [&_.recharts-sector]:outline-none [&_.recharts-surface]:outline-none",
           className
         )}
         {...props}
@@ -316,7 +316,7 @@ const ChartLegendContent = React.forwardRef<
         ref={ref}
         className={cn(
           "flex flex-wrap items-center justify-center gap-4",
-          verticalAlign === "top" ? "pb-3" : "pt-3",
+          verticalAlign === "top" ? "pb-3" : "pt-6",
           className
         )}
       >

--- a/src/prefab_ui/components/charts/__init__.py
+++ b/src/prefab_ui/components/charts/__init__.py
@@ -141,7 +141,8 @@ class LineChart(Component):
 
     Args:
         data: Row data or reactive interpolation reference.
-        series: Series to render as lines.
+        series: Series to render as lines, or a sole ``{{ ... }}`` template
+            (e.g. a visibility-filtered list from state).
         x_axis: Data key for x-axis labels.
         height: Chart height in pixels.
         curve: Line interpolation style ("linear", "smooth", or "step").
@@ -170,7 +171,9 @@ class LineChart(Component):
     data: list[dict[str, Any]] | RxStr = Field(
         description="Row data or `{{ interpolation }}` reference"
     )
-    series: list[ChartSeries] = Field(description="Series to render as lines")
+    series: list[ChartSeries] | RxStr = Field(
+        description="Series to render as lines, or `{{ interpolation }}` for a filtered list"
+    )
     x_axis: str | None = Field(
         default=None, alias="xAxis", description="Data key for x-axis labels"
     )

--- a/src/prefab_ui/components/charts/__init__.py
+++ b/src/prefab_ui/components/charts/__init__.py
@@ -67,6 +67,8 @@ class BarChart(Component):
         data: Row data or reactive interpolation reference.
         series: Series to render as bars.
         x_axis: Data key for x-axis labels.
+        x_axis_label: Human-readable title for the category axis.
+        y_axis_label: Human-readable title for the value axis.
         height: Chart height in pixels.
         stacked: Stack bars instead of grouping side-by-side.
         horizontal: Render as horizontal bar chart.
@@ -99,6 +101,16 @@ class BarChart(Component):
     series: list[ChartSeries] = Field(description="Series to render as bars")
     x_axis: str | None = Field(
         default=None, alias="xAxis", description="Data key for x-axis labels"
+    )
+    x_axis_label: RxStr | None = Field(
+        default=None,
+        alias="xAxisLabel",
+        description="Human-readable title for the category axis",
+    )
+    y_axis_label: RxStr | None = Field(
+        default=None,
+        alias="yAxisLabel",
+        description="Human-readable title for the value axis",
     )
     height: int = Field(default=300, description="Chart height in pixels")
     stacked: bool = Field(default=False, description="Stack bars")
@@ -144,6 +156,8 @@ class LineChart(Component):
         series: Series to render as lines, or a sole ``{{ ... }}`` template
             (e.g. a visibility-filtered list from state).
         x_axis: Data key for x-axis labels.
+        x_axis_label: Human-readable title for the category axis.
+        y_axis_label: Human-readable title for the value axis.
         height: Chart height in pixels.
         curve: Line interpolation style ("linear", "smooth", or "step").
         show_dots: Show dots at data points.
@@ -176,6 +190,16 @@ class LineChart(Component):
     )
     x_axis: str | None = Field(
         default=None, alias="xAxis", description="Data key for x-axis labels"
+    )
+    x_axis_label: RxStr | None = Field(
+        default=None,
+        alias="xAxisLabel",
+        description="Human-readable title for the category axis",
+    )
+    y_axis_label: RxStr | None = Field(
+        default=None,
+        alias="yAxisLabel",
+        description="Human-readable title for the value axis",
     )
     height: int = Field(default=300, description="Chart height in pixels")
     curve: Literal["linear", "smooth", "step"] = Field(

--- a/tests/components/test_chart.py
+++ b/tests/components/test_chart.py
@@ -51,7 +51,16 @@ class TestBarChart:
         assert j["valueFormat"] == "currency"
         assert "yAxisFormat" not in j
 
-
+    def test_axis_labels(self):
+        j = BarChart(
+            data=SAMPLE_DATA,
+            series=SERIES,
+            x_axis="month",
+            x_axis_label="Month",
+            y_axis_label="Users",
+        ).to_json()
+        assert j["xAxisLabel"] == "Month"
+        assert j["yAxisLabel"] == "Users"
 class TestLineChart:
     def test_serializes_basic(self):
         j = LineChart(data=SAMPLE_DATA, series=SERIES, x_axis="month").to_json()
@@ -71,7 +80,16 @@ class TestLineChart:
         ).to_json()
         assert j["valueFormat"] == "percent:1"
         assert "yAxisFormat" not in j
-
+    def test_axis_labels(self):
+        j = LineChart(
+            data=SAMPLE_DATA,
+            series=SERIES,
+            x_axis="month",
+            x_axis_label="Month",
+            y_axis_label="Revenue",
+        ).to_json()
+        assert j["xAxisLabel"] == "Month"
+        assert j["yAxisLabel"] == "Revenue"
 
 class TestAreaChart:
     def test_serializes_basic(self):


### PR DESCRIPTION
Charts could show tick values via `x_axis`, but there was no way to give axes human-readable titles. That makes dashboards harder to read when the meaning of the axis isn't obvious from the data alone.

This adds optional `x_axis_label` and `y_axis_label` to BarChart and LineChart. The renderer renders them as Recharts axis labels, bumps margins when a label is present, and styles label text to match existing tick styling. Legend spacing is nudged down so a bottom legend doesn't crowd the x-axis title.