### PR TITLE
ci: bump actions/checkout v6 -> v7

### DIFF
--- a/.github/workflows/marvin-label-triage.yml
+++ b/.github/workflows/marvin-label-triage.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout base repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: ${{ github.repository }}
           ref: ${{ github.event.repository.default_branch }}


### PR DESCRIPTION
Bumps `actions/checkout` v6 -> v7 in `marvin-label-triage.yml`.

This workflow checks out the trusted default branch, so v7's new fork-head refusal under `pull_request_target` does not apply. Straight version bump, behaviorally inert.

PLA-2852