### PR TITLE
Close Deno sandbox subprocess handles

### DIFF
--- a/src/prefab_ui/sandbox/_pyodide.py
+++ b/src/prefab_ui/sandbox/_pyodide.py
@@ -106,14 +106,13 @@ class PyodideSandbox:
         if self._process is not None:
             proc = self._process
             self._process = None
-            if proc.stdin:
-                proc.stdin.close()
-            if proc.stdout:
-                proc.stdout.close()
-            if proc.stderr:
-                proc.stderr.close()
-            proc.terminate()
-            proc.wait()
+            if proc.poll() is None:
+                proc.terminate()
+            try:
+                proc.communicate(timeout=5)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.communicate()
 
     async def run(
         self,

--- a/tests/sandbox/test_pyodide.py
+++ b/tests/sandbox/test_pyodide.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import MagicMock
+
+from prefab_ui.sandbox._pyodide import PyodideSandbox
+
+
+def test_stop_terminates_and_communicates_with_process() -> None:
+    process = MagicMock(spec=subprocess.Popen)
+    process.stdin = MagicMock()
+    process.stdout = MagicMock()
+    process.stderr = MagicMock()
+    process.poll.return_value = None
+    sandbox = PyodideSandbox()
+    sandbox._process = process
+
+    sandbox._stop()
+
+    assert sandbox._process is None
+    process.terminate.assert_called_once_with()
+    process.communicate.assert_called_once_with(timeout=5)
+
+
+def test_stop_kills_process_when_graceful_shutdown_times_out() -> None:
+    process = MagicMock(spec=subprocess.Popen)
+    process.stdin = MagicMock()
+    process.stdout = MagicMock()
+    process.stderr = MagicMock()
+    process.poll.return_value = None
+    process.communicate.side_effect = [subprocess.TimeoutExpired("deno", 5), (b"", b"")]
+    sandbox = PyodideSandbox()
+    sandbox._process = process
+
+    sandbox._stop()
+
+    process.kill.assert_called_once_with()
+    assert process.communicate.call_count == 2


### PR DESCRIPTION
Windows test workers report unraisable warnings for Deno’s stdin, stdout, and stderr handles after sandbox teardown, causing otherwise passing tests to fail later during garbage collection. `PyodideSandbox._stop()` now terminates the process and uses `communicate()` to close and drain all pipes, with a timed kill-and-reap fallback when Deno does not exit promptly.

The regression coverage fixes the shutdown contract around both graceful and timed-out processes.

Closes #507
