### PR TITLE
Fix generated checks for fork PRs

### DIFF
--- a/.github/workflows/regenerate-docs.yml
+++ b/.github/workflows/regenerate-docs.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   check_generated:
@@ -15,8 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.head_ref }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: false
 
       - name: Setup uv
         uses: ./.github/actions/setup-uv
@@ -37,17 +36,14 @@ jobs:
       - name: Build bundled renderer
         run: uv run prefab dev build-renderers
 
-      - name: Commit regenerated files if stale
+      - name: Check regenerated files
         run: |
           STALE_FILES=$(git diff --name-only)
           if [ -n "$STALE_FILES" ]; then
             echo "Stale files detected:"
             echo "$STALE_FILES"
-            git config user.name "github-actions[bot]"
-            git config user.email "github-actions[bot]@users.noreply.github.com"
-            git add -u
-            git commit -m "Regenerate build artifacts"
-            git push
+            echo "::error::Generated files are stale. Run 'prefab dev build-docs' and 'prefab dev build-renderers' locally, then commit the results."
+            exit 1
           else
             echo "All generated files are up to date."
           fi

--- a/src/prefab_ui/renderer/app.html
+++ b/src/prefab_ui/renderer/app.html
@@ -18709,6 +18709,12 @@ class Action(BaseModel):
         """Resolve any Rx values to \`{{ }}\` strings at serialization time."""
         return _coerce_rx(handler(self))  # type: ignore[return-value]  # ty:ignore[invalid-return-type]
 
+    def __or__(self, other: Action) -> _ActionChain:
+        """Chain this action with another action."""
+        if not isinstance(other, Action):
+            raise TypeError("Actions can only be chained with other actions")
+        return _ActionChain([self, other])
+
     on_success: SerializeAsAny[Action] | list[SerializeAsAny[Action]] | None = Field(
         default=None,
         alias="onSuccess",
@@ -18719,6 +18725,15 @@ class Action(BaseModel):
         alias="onError",
         description="Action(s) to run when this action fails",
     )
+
+
+class _ActionChain(list[Action]):
+    """List-like action chain supporting repeated \`\`|\`\` composition."""
+
+    def __or__(self, other: Action) -> _ActionChain:
+        if not isinstance(other, Action):
+            raise TypeError("Actions can only be chained with other actions")
+        return _ActionChain([*self, other])
 `,"prefab_ui/actions/custom.py":`"""Custom JavaScript handler action."""
 
 from __future__ import annotations


### PR DESCRIPTION
The generated-files workflow explicitly checked out the pull request branch name from the base repository. Fork branches do not exist there, so otherwise valid external contributions failed before generation could run.

Using the standard pull-request checkout builds GitHub's merge ref for both local and forked contributions. The workflow is now read-only and reports stale artifacts with exact rebuild commands instead of attempting to mutate contributor branches.
